### PR TITLE
Add config to debug tests in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug all app-web tests",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+            "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+            "cwd": "${workspaceRoot}/services/app-web",
+            "protocol": "inspector",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+          },
+          {
+            "name": "Debug current file tests",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+            "args": [
+              "test",
+              "${fileBasenameNoExtension}",
+              "--runInBand",
+              "--no-cache",
+              "--watchAll"
+            ],
+            "cwd": "${workspaceRoot}/services/app-web",
+            "protocol": "inspector",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+          }
+    ]
+}


### PR DESCRIPTION
## Summary

On past projects, we've shared a vscode config for doing things like running tests in the vscode debugger.  If folks would prefer to keep their config individually and locally, we can just close this.

@jim did the heavy lifting to get the debugger working on this project (for tests in /app-web).
