### PR TITLE
Change date rage separator to 'to'

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -103,7 +103,7 @@ export const ContractDetailsSummarySection = ({
                             label="Contract effective dates"
                             data={`${dayjs(submission.contractDateStart).format(
                                 'MM/DD/YYYY'
-                            )} - ${dayjs(submission.contractDateEnd).format(
+                            )} to ${dayjs(submission.contractDateEnd).format(
                                 'MM/DD/YYYY'
                             )}`}
                         />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -39,29 +39,11 @@ export const RateDetailsSummarySection = ({
                                     ? 'Rating period of original rate certification'
                                     : 'Rating period'
                             }
-                            data={
-                                <>
-                                    <time
-                                        dateTime={dayjs(
-                                            submission.rateDateStart
-                                        ).format('YYYY-MM-DD')}
-                                    >
-                                        {dayjs(submission.rateDateStart).format(
-                                            'MM/DD/YYYY'
-                                        )}
-                                    </time>{' '}
-                                    to{' '}
-                                    <time
-                                        dateTime={dayjs(
-                                            submission.rateDateEnd
-                                        ).format('YYYY-MM-DD')}
-                                    >
-                                        {dayjs(submission.rateDateEnd).format(
-                                            'MM/DD/YYYY'
-                                        )}
-                                    </time>
-                                </>
-                            }
+                            data={`${dayjs(submission.rateDateStart).format(
+                                'MM/DD/YYYY'
+                            )} to ${dayjs(submission.rateDateEnd).format(
+                                'MM/DD/YYYY'
+                            )}`}
                         />
                     }
                 />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -39,11 +39,29 @@ export const RateDetailsSummarySection = ({
                                     ? 'Rating period of original rate certification'
                                     : 'Rating period'
                             }
-                            data={`${dayjs(submission.rateDateStart).format(
-                                'MM/DD/YYYY'
-                            )} to ${dayjs(submission.rateDateEnd).format(
-                                'MM/DD/YYYY'
-                            )}`}
+                            data={
+                                <>
+                                    <time
+                                        dateTime={dayjs(
+                                            submission.rateDateStart
+                                        ).format('YYYY-MM-DD')}
+                                    >
+                                        {dayjs(submission.rateDateStart).format(
+                                            'MM/DD/YYYY'
+                                        )}
+                                    </time>{' '}
+                                    to{' '}
+                                    <time
+                                        dateTime={dayjs(
+                                            submission.rateDateEnd
+                                        ).format('YYYY-MM-DD')}
+                                    >
+                                        {dayjs(submission.rateDateEnd).format(
+                                            'MM/DD/YYYY'
+                                        )}
+                                    </time>
+                                </>
+                            }
                         />
                     }
                 />

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -41,7 +41,7 @@ export const RateDetailsSummarySection = ({
                             }
                             data={`${dayjs(submission.rateDateStart).format(
                                 'MM/DD/YYYY'
-                            )} - ${dayjs(submission.rateDateEnd).format(
+                            )} to ${dayjs(submission.rateDateEnd).format(
                                 'MM/DD/YYYY'
                             )}`}
                         />
@@ -69,7 +69,7 @@ export const RateDetailsSummarySection = ({
                                 data={`${dayjs(
                                     submission.rateAmendmentInfo
                                         .effectiveDateStart
-                                ).format('MM/DD/YYYY')} - ${dayjs(
+                                ).format('MM/DD/YYYY')} to ${dayjs(
                                     submission.rateAmendmentInfo
                                         .effectiveDateEnd
                                 ).format('MM/DD/YYYY')}`}

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -50,6 +50,9 @@ describe('dashboard', () => {
         cy.location().then((loc) => {
             expect(loc.search).to.match(/.*justSubmitted=*/)
             const submissionName = loc.search.split('=').pop()
+            if (submissionName === undefined) {
+                throw new Error('No submission name found' + loc.search)
+            }
             cy.findByText(`${submissionName} was sent to CMS`).should('exist')
             cy.findByText(submissionName).should('exist').click()
             cy.url({ timeout: 10_000 }).should('contain', submissionId)
@@ -61,7 +64,7 @@ describe('dashboard', () => {
             cy.findByText('Last updated').should('exist')
             cy.findByText('Rate details').should('exist')
             cy.findByText('New rate certification').should('exist')
-            cy.findByText('02/29/2024 - 02/28/2025').should('exist')
+            cy.findByText('02/29/2024 to 02/28/2025').should('exist')
             // Link back to dashboard, submission visible in default program
             cy.findByText('Back to state dashboard').should('exist').click()
             cy.findByText('Dashboard').should('exist')
@@ -91,13 +94,13 @@ describe('dashboard', () => {
                 .parents('tr')
                 .findByTestId('submission-date')
                 .should('be.empty')
-                cy.get('table')
+            cy.get('table')
                 .contains('span', 'Submitted')
                 .eq(0)
                 .parents('tr')
                 .findByTestId('submission-date')
                 .should('not.be.empty')
-                /* the submission ID should contain 'MCR-', which is the prefix for all submissions
+            /* the submission ID should contain 'MCR-', which is the prefix for all submissions
                 as well as the names of the programs (we only check for one program name here) */
             cy.get('table')
                 .contains('span', 'Draft')
@@ -116,7 +119,8 @@ describe('dashboard', () => {
                         .then((submissionId) => {
                             expect(submissionId).to.contain(text.toUpperCase())
                             expect(submissionId).to.contain('MCR-')
+                        })
+                })
         })
     })
 })
-})})


### PR DESCRIPTION
## Summary

Our date ranges on the summary pages get read strangely by Voiceover. This is a change to address that. 

We display date ranges (like contract effectiveness dates) on pages like this:

12/03/2021 - 08/14/2022

Voiceover has a real bug with this where it reads the 08 as “two thousand eight” for some reason. JAWS did not. But both of them read them very literally. “twelve slash zero three slash twenty twenty one dash…”

[This guidance](https://www.gov.uk/guidance/content-design/writing-for-gov-uk#date-ranges) from gov.uk specifies using “to” instead of a dash, and that was enough to get VO to behave. It also suggests writing out months explicitly. So then I tried this:

Dec 3 2021 to Aug 14 2022

and VO read it like a person would. “December third two thousand twenty one to…”
I’m definitely going to advocate we use “to” as separator, and am curious how our users would like slashless dates, they certainly seem nicer to listen to

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-11681

#### Screenshots
<img width="213" alt="Screen Shot 2021-12-17 at 5 16 29 PM" src="https://user-images.githubusercontent.com/55759/146624085-b0b150c9-12ed-4663-9532-24f2e03cee45.png">
