### PR TITLE
Readme edits: add more detail about how to verify ctkey setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ which serverless # should return something like /managed-care-review/scripts/ser
 which sls # should return something like /managed-care-review/scripts/sls`
 ```
 
-These should both point to paths inside the codebase (not to paths in usr/local/bin).
+These should both point to paths inside the codebase (not to paths in /usr/local/bin).
 
 
 Then verify things are working by running any serverless command , e.g. `cd services/app-api && serverless info --stage main`. This command should print information and not return any Serverless Error around "AWS Credentials".

--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ To verify things are working, run:
 ctkey --version
 ```
 
+To verify serverless (and AWS access) is set up properly with ctkey, run:
+
+ ```shell
+which serverless # should return something like /managed-care-review/scripts/serverless`
+which sls # should return something like /managed-care-review/scripts/sls`
+```
+
+These should both point to paths inside the codebase (not to paths in usr/local/bin).
+You can also verify things are working by running any serverless command , e.g. `cd services/app-api && serverless info --stage main`.
+
 Mac users: If you get an OS X error about the file not being trusted, go to
 System Preferences > Security > General and click to allow ctkey.
 

--- a/README.md
+++ b/README.md
@@ -218,16 +218,6 @@ To verify things are working, run:
 ctkey --version
 ```
 
-To verify serverless (and AWS access) is set up properly with ctkey, run:
-
- ```shell
-which serverless # should return something like /managed-care-review/scripts/serverless`
-which sls # should return something like /managed-care-review/scripts/sls`
-```
-
-These should both point to paths inside the codebase (not to paths in usr/local/bin).
-You can also verify things are working by running any serverless command , e.g. `cd services/app-api && serverless info --stage main`.
-
 Mac users: If you get an OS X error about the file not being trusted, go to
 System Preferences > Security > General and click to allow ctkey.
 
@@ -253,6 +243,20 @@ Cloudtamer credentials are updated.
 Currently, `ctkey-wrapper` requires the user to be running the openconnect-tinyproxy
 container [here](https://github.com/trussworks/openconnect-tinyproxy) to connect
 to Cloudtamer.
+
+### Verify serverless setup
+
+To verify serverless (and AWS access) is set up properly with ctkey, run:
+
+ ```shell
+which serverless # should return something like /managed-care-review/scripts/serverless`
+which sls # should return something like /managed-care-review/scripts/sls`
+```
+
+These should both point to paths inside the codebase (not to paths in usr/local/bin).
+
+
+Then verify things are working by running any serverless command , e.g. `cd services/app-api && serverless info --stage main`. This command should print information and not return any Serverless Error around "AWS Credentials".
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
Adding some notes on how to verify ctkey setup with serverless.  The `which serverless` expected result is tied to work in #590.