### PR TITLE
Conditionally keep Aurora online

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -58,7 +58,6 @@ custom:
       - main
   pauseAurora:
     other: true
-    dev: true
     val: false
     prod: false
 

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -19,17 +19,17 @@ provider:
       statements:
         - Effect: 'Allow'
           Action:
-            - secretsmanager:DescribeSecret
-            - secretsmanager:GetSecretValue
-            - secretsmanager:PutSecretValue
-            - secretsmanager:UpdateSecretVersionStage
+            - secretsmanager:DescribeSecret # pragma: allowlist secret
+            - secretsmanager:GetSecretValue # pragma: allowlist secret
+            - secretsmanager:PutSecretValue # pragma: allowlist secret
+            - secretsmanager:UpdateSecretVersionStage # pragma: allowlist secret
           Resource: '*'
           Condition:
             StringEquals:
-              'secretsmanager:resource/AllowRotationLambdaArn': '${self:custom.rotatorArn}'
+              'secretsmanager:resource/AllowRotationLambdaArn': '${self:custom.rotatorArn}' # pragma: allowlist secret
         - Effect: Allow
           Action:
-            - secretsmanager:GetRandomPassword
+            - secretsmanager:GetRandomPassword # pragma: allowlist secret
           Resource: '*'
         - Effect: Allow
           Action:
@@ -56,6 +56,11 @@ custom:
       - val
       - prod
       - main
+  pauseAurora:
+    other: true
+    dev: true
+    val: false
+    prod: false
 
 package:
   individually: true
@@ -108,6 +113,8 @@ resources:
         MasterUserPassword: !Sub '{{resolve:secretsmanager:${PostgresSecret}::password}}'
         DBSubnetGroupName: !Ref PostgresSubnetGroup
         VpcSecurityGroupIds: ['${self:custom.sgId}']
+        ScalingConfiguration:
+          AutoPause: ${self:custom.pauseAurora.${opt:stage}, self:custom.pauseAurora.other}
 
     PostgresSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup


### PR DESCRIPTION
## Summary

Because Aurora turns itself off if there is no traffic to it, we have long cold-start times for our application in val and prod. This creates a bad user experience as a fresh user to the application when the database is off has to wait 30 seconds or more before the application can handle requests.

We've decided to keep a minimal configuration online in val and prod so there are no more cold start times.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-14082

