### PR TITLE
fix: Remove margin auto CSS on dashboard container

### DIFF
--- a/services/app-web/src/pages/Dashboard/Dashboard.module.scss
+++ b/services/app-web/src/pages/Dashboard/Dashboard.module.scss
@@ -14,7 +14,6 @@
     width: 100%;
     max-width: 75rem;
     padding: 0rem 2rem 0rem 2rem;
-    margin: auto;
 }
 
 .alertContainer {


### PR DESCRIPTION
## Summary
Bugfix for spacing on the submission table on the dashboard. This is relevant when the table is empty or has few entries

#### Screenshots
Photo of the bug
![Screen Shot 2021-12-21 at 1 15 17 PM](https://user-images.githubusercontent.com/10750442/147000843-056c5129-73c7-44ba-ba73-520c12af3a39.png)

