### PR TITLE
Prepend npx to serverless local command

### DIFF
--- a/dev_tool/src/local/api.ts
+++ b/dev_tool/src/local/api.ts
@@ -22,6 +22,7 @@ export async function runAPILocally(runner: LabeledProcessRunner) {
     runner.runCommandAndOutput(
         'api',
         [
+            'npx',
             'serverless',
             '--stage',
             'local',


### PR DESCRIPTION
## Summary

Now that ctkey is working for `serverless` commands, when running `./dev local` the command that is being run uses the ctkey wrapped command. This doesn't work when we don't want to actually connect to AWS. 

This fix runs `npx serverless ...` so that the command being run by `./dev local` uses the regular serverless environment and skips ct-key.
