### PR TITLE
Fix upload "scan" failures

### DIFF
--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -144,7 +144,7 @@ const waitFor = (delay = 1000) =>
 const retryWithBackoff = async (
     fn: () => Promise<void | S3Error>,
     retryCount = 0,
-    maxRetries = 3,
+    maxRetries = 6,
     err: null | S3Error = null
 ): Promise<void | S3Error> => {
     if (retryCount > maxRetries) {

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -120,6 +120,8 @@ resources:
                 - DELETE
                 - HEAD
               MaxAge: 3000
+              ExposedHeaders:
+                - ETag
         NotificationConfiguration:
           LambdaConfigurations:
             - Event: s3:ObjectCreated:Put

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -124,6 +124,8 @@ resources:
                 - ETag
         NotificationConfiguration:
           LambdaConfigurations:
+            - Event: s3:CompleteMultipartUpload
+              Function: !GetAtt AvScanLambdaFunction.Arn
             - Event: s3:ObjectCreated:Put
               Function: !GetAtt AvScanLambdaFunction.Arn
       DependsOn: LambdaInvokePermission


### PR DESCRIPTION
## Summary

[Ticket 13893](https://qmacbis.atlassian.net/browse/OY2-13893)

During a walkthrough, we saw multiple file upload scan failures and decided to investigate.

In pairing on this with @mojotalantikite and @haworku, we discovered two issues:
1. Large files were being uploaded in parts, and multipart upload *requires a different trigger* in the lambda
2. Scans of larger files were taking longer than our three polling retries allowed.

#### Screenshots

![image](https://user-images.githubusercontent.com/8964335/147002535-8a7c8942-ad3e-4c31-afa5-bdd829632c88.png)


#### Test cases covered

No tests; just some config changes.

## QA guidance

Upload large files, and several files at the same time.  Should work.
