### PR TITLE
fix: Required notes should be read for form fields, acceptable file types should be read for file upload

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -56,7 +56,7 @@ export const FileUpload = ({
 }: FileUploadProps): React.ReactElement => {
     const [fileItems, setFileItems] = useState<FileItemT[]>(initialItems || [])
     const fileInputRef = useRef<FileInputRef>(null) // reference to the HTML input which has files
-
+    const inputRequired = inputProps['aria-required'] || inputProps.required
     // update fileItems in parent
     React.useEffect(() => {
         onFileItemsUpdate({ fileItems })
@@ -316,7 +316,7 @@ export const FileUpload = ({
             )}
             <FileInput
                 id={id}
-                name={name}
+                name={`${name}${inputRequired ? ' (required)' : ''}`}
                 className={styles.fileInput}
                 aria-describedby={`${id}-error ${id}-hint`}
                 multiple
@@ -324,6 +324,7 @@ export const FileUpload = ({
                 onDrop={handleOnDrop}
                 accept={inputProps.accept}
                 ref={fileInputRef}
+                aria-required={inputRequired}
             />
             <FileItemsList
                 retryItem={retryFile}

--- a/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.tsx
+++ b/services/app-web/src/components/Form/FieldCheckbox/FieldCheckbox.tsx
@@ -25,12 +25,15 @@ export const FieldCheckbox = ({
     ...inputProps
 }: FieldCheckboxProps): React.ReactElement => {
     const [field] = useField({ name })
+    const isRequired =
+        inputProps['aria-required'] !== false && inputProps.required !== false // consumer must explicitly say this field is not required, otherwise we assume aria-required
     return (
         <Checkbox
             id={id}
             label={label}
             {...field}
             {...inputProps}
+            aria-required={isRequired}
             name={name}
         />
     )

--- a/services/app-web/src/components/Form/FieldRadio/FieldRadio.tsx
+++ b/services/app-web/src/components/Form/FieldRadio/FieldRadio.tsx
@@ -25,7 +25,16 @@ export const FieldRadio = ({
     ...inputProps
 }: FieldRadioProps): React.ReactElement => {
     const [field] = useField({ name })
+    const isRequired =
+        inputProps['aria-required'] !== false && inputProps.required !== false // consumer must explicitly say this field is not required, otherwise we assume aria-required
     return (
-        <Radio id={id} label={label} {...field} {...inputProps} name={name} />
+        <Radio
+            id={id}
+            label={label}
+            {...field}
+            {...inputProps}
+            name={name}
+            aria-required={isRequired}
+        />
     )
 }

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
@@ -36,6 +36,40 @@ describe('Contacts', () => {
         })
     })
 
+    it('displays correct form guidance for contract only submission', async () => {
+        renderWithProviders(
+            <Contacts draftSubmission={mockDraft()} updateDraft={jest.fn()} />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        expect(
+            screen.getByText(/A state contact is required/)
+        ).toBeInTheDocument()
+    })
+
+    it('displays correct form guidance for contract and rates submission', async () => {
+        renderWithProviders(
+            <Contacts
+                draftSubmission={mockContactAndRatesDraft()}
+                updateDraft={jest.fn()}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        expect(
+            screen.getByText(/A state and an actuary contact are required/)
+        ).toBeInTheDocument()
+    })
+
+
     it('checks saved mocked state contacts correctly', async () => {
         const mockUpdateDraftFn = jest.fn()
 

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -138,10 +138,10 @@ const flattenErrors = (
 
     if (errors.stateContacts && Array.isArray(errors.stateContacts)) {
         errors.stateContacts.forEach((contact, index) => {
-            if (!contact) return;
+            if (!contact) return
 
             Object.entries(contact).forEach(([field, value]) => {
-                const errorKey = `stateContacts.${index}.${field}`
+                const errorKey = `${contact}.${field}`
                 flattened[errorKey] = value
             })
         })
@@ -149,10 +149,10 @@ const flattenErrors = (
 
     if (errors.actuaryContacts && Array.isArray(errors.actuaryContacts)) {
         errors.actuaryContacts.forEach((contact, index) => {
-            if (!contact) return;
+            if (!contact) return
 
             Object.entries(contact).forEach(([field, value]) => {
-                const errorKey = `actuaryContacts.${index}.${field}`
+                const errorKey = `${contact}.${field}`
                 flattened[errorKey] = value
             })
         })
@@ -372,7 +372,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`stateContacts.${index}.name`}
+                                                                    htmlFor={`{${stateContact}}.name`}
                                                                 >
                                                                     Name
                                                                 </label>
@@ -380,14 +380,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`stateContacts.${index}.name`}
+                                                                        name={`{${stateContact}}.name`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`stateContacts.${index}.name`}
-                                                                    id={`stateContacts.${index}.name`}
+                                                                    name={`{${stateContact}}.name`}
+                                                                    id={`{${stateContact}}.name`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -414,7 +414,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`stateContacts.${index}.titleRole`}
+                                                                    htmlFor={`{${stateContact}}.titleRole`}
                                                                 >
                                                                     Title/Role
                                                                 </label>
@@ -422,14 +422,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`stateContacts.${index}.titleRole`}
+                                                                        name={`{${stateContact}}.titleRole`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`stateContacts.${index}.titleRole`}
-                                                                    id={`stateContacts.${index}.titleRole`}
+                                                                    name={`{${stateContact}}.titleRole`}
+                                                                    id={`{${stateContact}}.titleRole`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -450,7 +450,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`stateContacts.${index}.email`}
+                                                                    htmlFor={`{${stateContact}}.email`}
                                                                 >
                                                                     Email
                                                                 </label>
@@ -458,14 +458,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`stateContacts.${index}.email`}
+                                                                        name={`{${stateContact}}.email`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`stateContacts.${index}.email`}
-                                                                    id={`stateContacts.${index}.email`}
+                                                                    name={`{${stateContact}}.email`}
+                                                                    id={`{${stateContact}}.email`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -561,7 +561,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`actuaryContacts.${index}.name`}
+                                                                        htmlFor={`${actuaryContact}.name`}
                                                                     >
                                                                         Name
                                                                     </label>
@@ -569,14 +569,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`actuaryContacts.${index}.name`}
+                                                                            name={`${actuaryContact}.name`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`actuaryContacts.${index}.name`}
-                                                                        id={`actuaryContacts.${index}.name`}
+                                                                        name={`${actuaryContact}.name`}
+                                                                        id={`${actuaryContact}.name`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -604,7 +604,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`actuaryContacts.${index}.titleRole`}
+                                                                        htmlFor={`${actuaryContact}.titleRole`}
                                                                     >
                                                                         Title/Role
                                                                     </label>
@@ -612,14 +612,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`actuaryContacts.${index}.titleRole`}
+                                                                            name={`${actuaryContact}.titleRole`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`actuaryContacts.${index}.titleRole`}
-                                                                        id={`actuaryContacts.${index}.titleRole`}
+                                                                        name={`${actuaryContact}.titleRole`}
+                                                                        id={`${actuaryContact}.titleRole`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -640,7 +640,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`actuaryContacts.${index}.email`}
+                                                                        htmlFor={`${actuaryContact}.email`}
                                                                     >
                                                                         Email
                                                                     </label>
@@ -648,14 +648,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`actuaryContacts.${index}.email`}
+                                                                            name={`${actuaryContact}.email`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`actuaryContacts.${index}.email`}
-                                                                        id={`actuaryContacts.${index}.email`}
+                                                                        name={`${actuaryContact}.email`}
+                                                                        id={`${actuaryContact}.email`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -677,7 +677,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        htmlFor={`${actuaryContact}.actuarialFirm`}
                                                                     >
                                                                         Actuarial
                                                                         firm
@@ -686,14 +686,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                            name={`${actuaryContact}.actuarialFirm`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <FieldRadio
                                                                         id={`mercer-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Mercer"
                                                                         value={
                                                                             'MERCER'
@@ -710,7 +710,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`milliman-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Milliman"
                                                                         value={
                                                                             'MILLIMAN'
@@ -727,7 +727,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`optumas-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Optumas"
                                                                         value={
                                                                             'OPTUMAS'
@@ -744,7 +744,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`guidehouse-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Guidehouse"
                                                                         value={
                                                                             'GUIDEHOUSE'
@@ -753,7 +753,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`deloitte-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Deloitte"
                                                                         value={
                                                                             'DELOITTE'
@@ -770,7 +770,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`stateInHouse-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="State in-house"
                                                                         value={
                                                                             'STATE_IN_HOUSE'
@@ -787,7 +787,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`other-${index}`}
-                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        name={`${actuaryContact}.actuarialFirm`}
                                                                         label="Other"
                                                                         value={
                                                                             'OTHER'
@@ -821,7 +821,7 @@ return (
                                                                             )}
                                                                         >
                                                                             <label
-                                                                                htmlFor={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                htmlFor={`${actuaryContact}.actuarialFirmOther`}
                                                                             >
                                                                                 Other
                                                                                 actuarial
@@ -831,14 +831,14 @@ return (
                                                                                 `True`
                                                                             ) && (
                                                                                 <ErrorMessage
-                                                                                    name={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                    name={`${actuaryContact}.actuarialFirmOther`}
                                                                                     component="div"
                                                                                     className="usa-error-message"
                                                                                 />
                                                                             )}
                                                                             <Field
-                                                                                name={`actuaryContacts.${index}.actuarialFirmOther`}
-                                                                                id={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                name={`${actuaryContact}.actuarialFirmOther`}
+                                                                                id={`${actuaryContact}.actuarialFirmOther`}
                                                                                 type="text"
                                                                                 className="usa-input"
                                                                             />

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -138,10 +138,10 @@ const flattenErrors = (
 
     if (errors.stateContacts && Array.isArray(errors.stateContacts)) {
         errors.stateContacts.forEach((contact, index) => {
-            if (!contact) return
+            if (!contact) return;
 
             Object.entries(contact).forEach(([field, value]) => {
-                const errorKey = `${contact}.${field}`
+                const errorKey = `stateContacts.${index}.${field}`
                 flattened[errorKey] = value
             })
         })
@@ -149,10 +149,10 @@ const flattenErrors = (
 
     if (errors.actuaryContacts && Array.isArray(errors.actuaryContacts)) {
         errors.actuaryContacts.forEach((contact, index) => {
-            if (!contact) return
+            if (!contact) return;
 
             Object.entries(contact).forEach(([field, value]) => {
-                const errorKey = `${contact}.${field}`
+                const errorKey = `actuaryContacts.${index}.${field}`
                 flattened[errorKey] = value
             })
         })
@@ -372,7 +372,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`{${stateContact}}.name`}
+                                                                    htmlFor={`stateContacts.${index}.name`}
                                                                 >
                                                                     Name
                                                                 </label>
@@ -380,14 +380,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`{${stateContact}}.name`}
+                                                                        name={`stateContacts.${index}.name`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`{${stateContact}}.name`}
-                                                                    id={`{${stateContact}}.name`}
+                                                                    name={`stateContacts.${index}.name`}
+                                                                    id={`stateContacts.${index}.name`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -414,7 +414,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`{${stateContact}}.titleRole`}
+                                                                    htmlFor={`stateContacts.${index}.titleRole`}
                                                                 >
                                                                     Title/Role
                                                                 </label>
@@ -422,14 +422,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`{${stateContact}}.titleRole`}
+                                                                        name={`stateContacts.${index}.titleRole`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`{${stateContact}}.titleRole`}
-                                                                    id={`{${stateContact}}.titleRole`}
+                                                                    name={`stateContacts.${index}.titleRole`}
+                                                                    id={`stateContacts.${index}.titleRole`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -450,7 +450,7 @@ return (
                                                                 )}
                                                             >
                                                                 <label
-                                                                    htmlFor={`{${stateContact}}.email`}
+                                                                    htmlFor={`stateContacts.${index}.email`}
                                                                 >
                                                                     Email
                                                                 </label>
@@ -458,14 +458,14 @@ return (
                                                                     `True`
                                                                 ) && (
                                                                     <ErrorMessage
-                                                                        name={`{${stateContact}}.email`}
+                                                                        name={`stateContacts.${index}.email`}
                                                                         component="div"
                                                                         className="usa-error-message"
                                                                     />
                                                                 )}
                                                                 <Field
-                                                                    name={`{${stateContact}}.email`}
-                                                                    id={`{${stateContact}}.email`}
+                                                                    name={`stateContacts.${index}.email`}
+                                                                    id={`stateContacts.${index}.email`}
                                                                     aria-required={
                                                                         index ===
                                                                         0
@@ -561,7 +561,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`${actuaryContact}.name`}
+                                                                        htmlFor={`actuaryContacts.${index}.name`}
                                                                     >
                                                                         Name
                                                                     </label>
@@ -569,14 +569,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`${actuaryContact}.name`}
+                                                                            name={`actuaryContacts.${index}.name`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`${actuaryContact}.name`}
-                                                                        id={`${actuaryContact}.name`}
+                                                                        name={`actuaryContacts.${index}.name`}
+                                                                        id={`actuaryContacts.${index}.name`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -604,7 +604,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`${actuaryContact}.titleRole`}
+                                                                        htmlFor={`actuaryContacts.${index}.titleRole`}
                                                                     >
                                                                         Title/Role
                                                                     </label>
@@ -612,14 +612,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`${actuaryContact}.titleRole`}
+                                                                            name={`actuaryContacts.${index}.titleRole`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`${actuaryContact}.titleRole`}
-                                                                        id={`${actuaryContact}.titleRole`}
+                                                                        name={`actuaryContacts.${index}.titleRole`}
+                                                                        id={`actuaryContacts.${index}.titleRole`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -640,7 +640,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`${actuaryContact}.email`}
+                                                                        htmlFor={`actuaryContacts.${index}.email`}
                                                                     >
                                                                         Email
                                                                     </label>
@@ -648,14 +648,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`${actuaryContact}.email`}
+                                                                            name={`actuaryContacts.${index}.email`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`${actuaryContact}.email`}
-                                                                        id={`${actuaryContact}.email`}
+                                                                        name={`actuaryContacts.${index}.email`}
+                                                                        id={`actuaryContacts.${index}.email`}
                                                                         aria-required={
                                                                             index ===
                                                                             0
@@ -677,7 +677,7 @@ return (
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`${actuaryContact}.actuarialFirm`}
+                                                                        htmlFor={`actuaryContacts.${index}.actuarialFirm`}
                                                                     >
                                                                         Actuarial
                                                                         firm
@@ -686,14 +686,14 @@ return (
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`${actuaryContact}.actuarialFirm`}
+                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <FieldRadio
                                                                         id={`mercer-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Mercer"
                                                                         value={
                                                                             'MERCER'
@@ -710,7 +710,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`milliman-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Milliman"
                                                                         value={
                                                                             'MILLIMAN'
@@ -727,7 +727,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`optumas-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Optumas"
                                                                         value={
                                                                             'OPTUMAS'
@@ -744,7 +744,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`guidehouse-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Guidehouse"
                                                                         value={
                                                                             'GUIDEHOUSE'
@@ -753,7 +753,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`deloitte-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Deloitte"
                                                                         value={
                                                                             'DELOITTE'
@@ -770,7 +770,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`stateInHouse-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="State in-house"
                                                                         value={
                                                                             'STATE_IN_HOUSE'
@@ -787,7 +787,7 @@ return (
                                                                     />
                                                                     <FieldRadio
                                                                         id={`other-${index}`}
-                                                                        name={`${actuaryContact}.actuarialFirm`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
                                                                         label="Other"
                                                                         value={
                                                                             'OTHER'
@@ -821,7 +821,7 @@ return (
                                                                             )}
                                                                         >
                                                                             <label
-                                                                                htmlFor={`${actuaryContact}.actuarialFirmOther`}
+                                                                                htmlFor={`actuaryContacts.${index}.actuarialFirmOther`}
                                                                             >
                                                                                 Other
                                                                                 actuarial
@@ -831,14 +831,14 @@ return (
                                                                                 `True`
                                                                             ) && (
                                                                                 <ErrorMessage
-                                                                                    name={`${actuaryContact}.actuarialFirmOther`}
+                                                                                    name={`actuaryContacts.${index}.actuarialFirmOther`}
                                                                                     component="div"
                                                                                     className="usa-error-message"
                                                                                 />
                                                                             )}
                                                                             <Field
-                                                                                name={`${actuaryContact}.actuarialFirmOther`}
-                                                                                id={`${actuaryContact}.actuarialFirmOther`}
+                                                                                name={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                id={`actuaryContacts.${index}.actuarialFirmOther`}
                                                                                 type="text"
                                                                                 className="usa-input"
                                                                             />

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -191,182 +191,377 @@ export const Contacts = ({
 
     const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
     const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] = React.useState(false)
-
-    /*
+const includeActuaryContacts =
+    draftSubmission.submissionType !== 'CONTRACT_ONLY'
+/*
      Set focus to contact name field when adding new contacts.
      Clears ref and focusNewContact component state immediately after. The reset allows additional contacts to be added and preserves expected focus behavior.
     */
-    React.useEffect(() => {
-        if (focusNewContact) {
-            newStateContactNameRef.current &&
-                newStateContactNameRef.current.focus()
-            setFocusNewContact(false)
-            newStateContactNameRef.current = null
-        }
-        if (focusNewActuaryContact) {
-            newActuaryContactNameRef.current &&
-                newActuaryContactNameRef.current.focus()
-            setFocusNewActuaryContact(false)
-            newActuaryContactNameRef.current = null
-        }
-    }, [focusNewContact, focusNewActuaryContact])
-
-    useEffect(() => {
-        // Focus the error summary heading only if we are displaying
-        // validation errors and the heading element exists
-        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
-            errorSummaryHeadingRef.current.focus()
-        }
-        setFocusErrorSummaryHeading(false);
-    }, [focusErrorSummaryHeading])
-
-    // TODO: refactor this into reusable component that is more understandable
-    const showFieldErrors = (error?: FormError): boolean | undefined =>
-        shouldValidate && Boolean(error)
-
-    const stateContacts = stripTypename(draftSubmission.stateContacts)
-    const actuaryContacts = stripTypename(draftSubmission.actuaryContacts)
-
-    const emptyStateContact = {
-        name: '',
-        titleRole: '',
-        email: '',
+React.useEffect(() => {
+    if (focusNewContact) {
+        newStateContactNameRef.current && newStateContactNameRef.current.focus()
+        setFocusNewContact(false)
+        newStateContactNameRef.current = null
     }
-
-    const emptyActuaryContact = {
-        name: '',
-        titleRole: '',
-        email: '',
-        actuarialFirm: null,
-        actuarialFirmOther: '',
+    if (focusNewActuaryContact) {
+        newActuaryContactNameRef.current &&
+            newActuaryContactNameRef.current.focus()
+        setFocusNewActuaryContact(false)
+        newActuaryContactNameRef.current = null
     }
+}, [focusNewContact, focusNewActuaryContact])
 
-    if (stateContacts.length === 0) {
-        stateContacts.push(emptyStateContact)
+useEffect(() => {
+    // Focus the error summary heading only if we are displaying
+    // validation errors and the heading element exists
+    if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
+        errorSummaryHeadingRef.current.focus()
     }
+    setFocusErrorSummaryHeading(false)
+}, [focusErrorSummaryHeading])
 
-    if (
-        actuaryContacts.length === 0 &&
-        draftSubmission.submissionType !== 'CONTRACT_ONLY'
-    ) {
-        actuaryContacts.push(emptyActuaryContact)
+// TODO: refactor this into reusable component that is more understandable
+const showFieldErrors = (error?: FormError): boolean | undefined =>
+    shouldValidate && Boolean(error)
+
+const stateContacts = stripTypename(draftSubmission.stateContacts)
+const actuaryContacts = stripTypename(draftSubmission.actuaryContacts)
+
+const emptyStateContact = {
+    name: '',
+    titleRole: '',
+    email: '',
+}
+
+const emptyActuaryContact = {
+    name: '',
+    titleRole: '',
+    email: '',
+    actuarialFirm: null,
+    actuarialFirmOther: '',
+}
+
+if (stateContacts.length === 0) {
+    stateContacts.push(emptyStateContact)
+}
+
+if (actuaryContacts.length === 0 && includeActuaryContacts) {
+    actuaryContacts.push(emptyActuaryContact)
+}
+
+const contactsInitialValues: ContactsFormValues = {
+    stateContacts: stateContacts,
+    actuaryContacts: actuaryContacts,
+    actuaryCommunicationPreference:
+        draftSubmission?.actuaryCommunicationPreference ?? undefined,
+}
+
+// Handler for Contacts legends so that contacts show up as
+// State contacts 1 instead of State contacts 0 for first contact
+// and show (required) for only the first contact
+// Also handles the difference between State Contacts and Actuary Contacts
+const handleContactLegend = (index: number, contactText: string) => {
+    const count = index + 1
+    const required = index ? '' : ' (required)'
+
+    if (contactText === 'State') {
+        return `State contacts ${count} ${required}`
+    } else if (contactText === 'Actuary') {
+        if (!index) return `Certifying actuary ${required}`
+        else return `Additional actuary contact ${index}`
     }
+}
 
-    const contactsInitialValues: ContactsFormValues = {
-        stateContacts: stateContacts,
-        actuaryContacts: actuaryContacts,
-        actuaryCommunicationPreference:
-            draftSubmission?.actuaryCommunicationPreference ?? undefined,
-    }
+const handleFormSubmit = async (
+    values: ContactsFormValues,
+    formikHelpers: FormikHelpers<ContactsFormValues>
+) => {
+    const updatedDraft = updatesFromSubmission(draftSubmission)
+    updatedDraft.stateContacts = values.stateContacts
+    updatedDraft.actuaryContacts = values.actuaryContacts
+    updatedDraft.actuaryCommunicationPreference =
+        values.actuaryCommunicationPreference
 
-    // Handler for Contacts legends so that contacts show up as
-    // State contacts 1 instead of State contacts 0 for first contact
-    // and show (required) for only the first contact
-    // Also handles the difference between State Contacts and Actuary Contacts
-    const handleContactLegend = (index: number, contactText: string) => {
-        const count = index + 1
-        const required = index ? '' : ' (required)'
-
-        if (contactText === 'State') {
-            return `State contacts ${count} ${required}`
-        } else if (contactText === 'Actuary') {
-            if (!index) return `Certifying actuary ${required}`
-            else return `Additional actuary contact ${index}`
-        }
-    }
-
-    const handleFormSubmit = async (
-        values: ContactsFormValues,
-        formikHelpers: FormikHelpers<ContactsFormValues>
-    ) => {
-        const updatedDraft = updatesFromSubmission(draftSubmission)
-        updatedDraft.stateContacts = values.stateContacts
-        updatedDraft.actuaryContacts = values.actuaryContacts
-        updatedDraft.actuaryCommunicationPreference =
-            values.actuaryCommunicationPreference
-
-        try {
-            const updatedSubmission = await updateDraft({
-                submissionID: draftSubmission.id,
-                draftSubmissionUpdates: updatedDraft,
-            })
-            if (updatedSubmission) {
-                if (redirectToDashboard.current) {
-                    history.push(`/dashboard`)
-                } else {
-                    history.push(`/submissions/${draftSubmission.id}/documents`)
-                }
+    try {
+        const updatedSubmission = await updateDraft({
+            submissionID: draftSubmission.id,
+            draftSubmissionUpdates: updatedDraft,
+        })
+        if (updatedSubmission) {
+            if (redirectToDashboard.current) {
+                history.push(`/dashboard`)
+            } else {
+                history.push(`/submissions/${draftSubmission.id}/documents`)
             }
-        } catch (serverError) {
-            formikHelpers.setSubmitting(false)
-            redirectToDashboard.current = false
         }
+    } catch (serverError) {
+        formikHelpers.setSubmitting(false)
+        redirectToDashboard.current = false
     }
+}
 
-    const contactSchema = yupValidation(draftSubmission.submissionType)
+const contactSchema = yupValidation(draftSubmission.submissionType)
 
-    return (
-        <>
-            <Formik
-                initialValues={contactsInitialValues}
-                onSubmit={handleFormSubmit}
-                validationSchema={contactSchema}
-            >
-                {({ values, errors, dirty, handleSubmit, isSubmitting }) => (
-                    <>
-                        <UswdsForm
-                            className={styles.formContainer}
-                            id="ContactsForm"
-                            aria-label="Contacts Form"
-                            onSubmit={handleSubmit}
-                        >
+return (
+    <>
+        <Formik
+            initialValues={contactsInitialValues}
+            onSubmit={handleFormSubmit}
+            validationSchema={contactSchema}
+        >
+            {({ values, errors, dirty, handleSubmit, isSubmitting }) => (
+                <>
+                    <UswdsForm
+                        className={styles.formContainer}
+                        id="ContactsForm"
+                        aria-label="Contacts Form"
+                        aria-describedby="form-guidance"
+                        onSubmit={handleSubmit}
+                    >
+                        <fieldset className="usa-fieldset">
+                            <h3>State contacts</h3>
+                            {formAlert && formAlert}
+                            <p>
+                                Enter contact information for the state
+                                personnel you'd like to receive all CMS
+                                communication about this submission.
+                            </p>
+                            <legend className="srOnly">State contacts</legend>
+                            <span id="form-guidance">
+                                {includeActuaryContacts
+                                    ? 'A state and an actuary contact are required'
+                                    : 'A state contact is required'}
+                            </span>
+
+                            {shouldValidate && (
+                                <ErrorSummary
+                                    errors={flattenErrors(errors)}
+                                    headingRef={errorSummaryHeadingRef}
+                                />
+                            )}
+
+                            <FieldArray name="stateContacts">
+                                {({ remove, push }) => (
+                                    <div
+                                        className={styles.stateContacts}
+                                        data-testid="state-contacts"
+                                    >
+                                        {values.stateContacts.length > 0 &&
+                                            values.stateContacts.map(
+                                                (stateContact, index) => (
+                                                    <div
+                                                        className={
+                                                            styles.stateContact
+                                                        }
+                                                        key={index}
+                                                    >
+                                                        <Fieldset
+                                                            legend={handleContactLegend(
+                                                                index,
+                                                                'State'
+                                                            )}
+                                                        >
+                                                            <FormGroup
+                                                                error={showFieldErrors(
+                                                                    stateContactErrorHandling(
+                                                                        errors
+                                                                            ?.stateContacts?.[
+                                                                            index
+                                                                        ]
+                                                                    )?.name
+                                                                )}
+                                                            >
+                                                                <label
+                                                                    htmlFor={`stateContacts.${index}.name`}
+                                                                >
+                                                                    Name
+                                                                </label>
+                                                                {showFieldErrors(
+                                                                    `True`
+                                                                ) && (
+                                                                    <ErrorMessage
+                                                                        name={`stateContacts.${index}.name`}
+                                                                        component="div"
+                                                                        className="usa-error-message"
+                                                                    />
+                                                                )}
+                                                                <Field
+                                                                    name={`stateContacts.${index}.name`}
+                                                                    id={`stateContacts.${index}.name`}
+                                                                    aria-required={
+                                                                        index ===
+                                                                        0
+                                                                    }
+                                                                    type="text"
+                                                                    className="usa-input"
+                                                                    innerRef={(
+                                                                        el: HTMLElement
+                                                                    ) =>
+                                                                        (newStateContactNameRef.current =
+                                                                            el)
+                                                                    }
+                                                                />
+                                                            </FormGroup>
+
+                                                            <FormGroup
+                                                                error={showFieldErrors(
+                                                                    stateContactErrorHandling(
+                                                                        errors
+                                                                            ?.stateContacts?.[
+                                                                            index
+                                                                        ]
+                                                                    )?.titleRole
+                                                                )}
+                                                            >
+                                                                <label
+                                                                    htmlFor={`stateContacts.${index}.titleRole`}
+                                                                >
+                                                                    Title/Role
+                                                                </label>
+                                                                {showFieldErrors(
+                                                                    `True`
+                                                                ) && (
+                                                                    <ErrorMessage
+                                                                        name={`stateContacts.${index}.titleRole`}
+                                                                        component="div"
+                                                                        className="usa-error-message"
+                                                                    />
+                                                                )}
+                                                                <Field
+                                                                    name={`stateContacts.${index}.titleRole`}
+                                                                    id={`stateContacts.${index}.titleRole`}
+                                                                    aria-required={
+                                                                        index ===
+                                                                        0
+                                                                    }
+                                                                    type="text"
+                                                                    className="usa-input"
+                                                                />
+                                                            </FormGroup>
+
+                                                            <FormGroup
+                                                                error={showFieldErrors(
+                                                                    stateContactErrorHandling(
+                                                                        errors
+                                                                            ?.stateContacts?.[
+                                                                            index
+                                                                        ]
+                                                                    )?.email
+                                                                )}
+                                                            >
+                                                                <label
+                                                                    htmlFor={`stateContacts.${index}.email`}
+                                                                >
+                                                                    Email
+                                                                </label>
+                                                                {showFieldErrors(
+                                                                    `True`
+                                                                ) && (
+                                                                    <ErrorMessage
+                                                                        name={`stateContacts.${index}.email`}
+                                                                        component="div"
+                                                                        className="usa-error-message"
+                                                                    />
+                                                                )}
+                                                                <Field
+                                                                    name={`stateContacts.${index}.email`}
+                                                                    id={`stateContacts.${index}.email`}
+                                                                    aria-required={
+                                                                        index ===
+                                                                        0
+                                                                    }
+                                                                    type="text"
+                                                                    className="usa-input"
+                                                                />
+                                                            </FormGroup>
+
+                                                            {index > 0 && (
+                                                                <Button
+                                                                    type="button"
+                                                                    unstyled
+                                                                    className={
+                                                                        styles.removeContactBtn
+                                                                    }
+                                                                    onClick={() => {
+                                                                        remove(
+                                                                            index
+                                                                        )
+                                                                        setNewStateContactButtonFocus()
+                                                                    }}
+                                                                >
+                                                                    Remove
+                                                                    contact
+                                                                </Button>
+                                                            )}
+                                                        </Fieldset>
+                                                    </div>
+                                                )
+                                            )}
+
+                                        <button
+                                            type="button"
+                                            className={`usa-button usa-button--outline ${styles.addContactBtn}`}
+                                            onClick={() => {
+                                                push(emptyStateContact)
+                                                setFocusNewContact(true)
+                                            }}
+                                            ref={newStateContactButtonRef}
+                                        >
+                                            Add state contact
+                                        </button>
+                                    </div>
+                                )}
+                            </FieldArray>
+                        </fieldset>
+
+                        {includeActuaryContacts && (
                             <fieldset className="usa-fieldset">
-                                <h3>State contacts</h3>
+                                <h3>Actuary contacts</h3>
                                 {formAlert && formAlert}
                                 <p>
-                                    Enter contact information for the state
-                                    personnel you'd like to receive all CMS
-                                    communication about this submission.
+                                    Provide contact information for the
+                                    actuaries who worked directly on this
+                                    submission.
                                 </p>
                                 <legend className="srOnly">
-                                    State contacts
+                                    Actuary contacts
                                 </legend>
+                                {formAlert && formAlert}
 
-                                { shouldValidate && <ErrorSummary errors={flattenErrors(errors)} headingRef={errorSummaryHeadingRef} /> }
-
-                                <FieldArray name="stateContacts">
+                                <FieldArray name="actuaryContacts">
                                     {({ remove, push }) => (
                                         <div
-                                            className={styles.stateContacts}
+                                            className={styles.actuaryContacts}
                                             data-testid="state-contacts"
                                         >
-                                            {values.stateContacts.length > 0 &&
-                                                values.stateContacts.map(
-                                                    (stateContact, index) => (
+                                            {values.actuaryContacts.length >
+                                                0 &&
+                                                values.actuaryContacts.map(
+                                                    (actuaryContact, index) => (
                                                         <div
                                                             className={
-                                                                styles.stateContact
+                                                                styles.actuaryContact
                                                             }
                                                             key={index}
                                                         >
                                                             <Fieldset
                                                                 legend={handleContactLegend(
                                                                     index,
-                                                                    'State'
+                                                                    'Actuary'
                                                                 )}
                                                             >
                                                                 <FormGroup
                                                                     error={showFieldErrors(
-                                                                        stateContactErrorHandling(
+                                                                        actuaryContactErrorHandling(
                                                                             errors
-                                                                                ?.stateContacts?.[
+                                                                                ?.actuaryContacts?.[
                                                                                 index
                                                                             ]
                                                                         )?.name
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`stateContacts.${index}.name`}
+                                                                        htmlFor={`actuaryContacts.${index}.name`}
                                                                     >
                                                                         Name
                                                                     </label>
@@ -374,20 +569,24 @@ export const Contacts = ({
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`stateContacts.${index}.name`}
+                                                                            name={`actuaryContacts.${index}.name`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`stateContacts.${index}.name`}
-                                                                        id={`stateContacts.${index}.name`}
+                                                                        name={`actuaryContacts.${index}.name`}
+                                                                        id={`actuaryContacts.${index}.name`}
+                                                                        aria-required={
+                                                                            index ===
+                                                                            0
+                                                                        }
                                                                         type="text"
                                                                         className="usa-input"
                                                                         innerRef={(
                                                                             el: HTMLElement
                                                                         ) =>
-                                                                            (newStateContactNameRef.current =
+                                                                            (newActuaryContactNameRef.current =
                                                                                 el)
                                                                         }
                                                                     />
@@ -395,9 +594,9 @@ export const Contacts = ({
 
                                                                 <FormGroup
                                                                     error={showFieldErrors(
-                                                                        stateContactErrorHandling(
+                                                                        actuaryContactErrorHandling(
                                                                             errors
-                                                                                ?.stateContacts?.[
+                                                                                ?.actuaryContacts?.[
                                                                                 index
                                                                             ]
                                                                         )
@@ -405,7 +604,7 @@ export const Contacts = ({
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`stateContacts.${index}.titleRole`}
+                                                                        htmlFor={`actuaryContacts.${index}.titleRole`}
                                                                     >
                                                                         Title/Role
                                                                     </label>
@@ -413,14 +612,18 @@ export const Contacts = ({
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`stateContacts.${index}.titleRole`}
+                                                                            name={`actuaryContacts.${index}.titleRole`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`stateContacts.${index}.titleRole`}
-                                                                        id={`stateContacts.${index}.titleRole`}
+                                                                        name={`actuaryContacts.${index}.titleRole`}
+                                                                        id={`actuaryContacts.${index}.titleRole`}
+                                                                        aria-required={
+                                                                            index ===
+                                                                            0
+                                                                        }
                                                                         type="text"
                                                                         className="usa-input"
                                                                     />
@@ -428,16 +631,16 @@ export const Contacts = ({
 
                                                                 <FormGroup
                                                                     error={showFieldErrors(
-                                                                        stateContactErrorHandling(
+                                                                        actuaryContactErrorHandling(
                                                                             errors
-                                                                                ?.stateContacts?.[
+                                                                                ?.actuaryContacts?.[
                                                                                 index
                                                                             ]
                                                                         )?.email
                                                                     )}
                                                                 >
                                                                     <label
-                                                                        htmlFor={`stateContacts.${index}.email`}
+                                                                        htmlFor={`actuaryContacts.${index}.email`}
                                                                     >
                                                                         Email
                                                                     </label>
@@ -445,17 +648,202 @@ export const Contacts = ({
                                                                         `True`
                                                                     ) && (
                                                                         <ErrorMessage
-                                                                            name={`stateContacts.${index}.email`}
+                                                                            name={`actuaryContacts.${index}.email`}
                                                                             component="div"
                                                                             className="usa-error-message"
                                                                         />
                                                                     )}
                                                                     <Field
-                                                                        name={`stateContacts.${index}.email`}
-                                                                        id={`stateContacts.${index}.email`}
+                                                                        name={`actuaryContacts.${index}.email`}
+                                                                        id={`actuaryContacts.${index}.email`}
+                                                                        aria-required={
+                                                                            index ===
+                                                                            0
+                                                                        }
                                                                         type="text"
                                                                         className="usa-input"
                                                                     />
+                                                                </FormGroup>
+
+                                                                <FormGroup
+                                                                    error={showFieldErrors(
+                                                                        actuaryContactErrorHandling(
+                                                                            errors
+                                                                                ?.actuaryContacts?.[
+                                                                                index
+                                                                            ]
+                                                                        )
+                                                                            ?.actuarialFirm
+                                                                    )}
+                                                                >
+                                                                    <label
+                                                                        htmlFor={`actuaryContacts.${index}.actuarialFirm`}
+                                                                    >
+                                                                        Actuarial
+                                                                        firm
+                                                                    </label>
+                                                                    {showFieldErrors(
+                                                                        `True`
+                                                                    ) && (
+                                                                        <ErrorMessage
+                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                            component="div"
+                                                                            className="usa-error-message"
+                                                                        />
+                                                                    )}
+                                                                    <FieldRadio
+                                                                        id={`mercer-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Mercer"
+                                                                        value={
+                                                                            'MERCER'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'MERCER'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`milliman-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Milliman"
+                                                                        value={
+                                                                            'MILLIMAN'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'MILLIMAN'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`optumas-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Optumas"
+                                                                        value={
+                                                                            'OPTUMAS'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'OPTUMAS'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`guidehouse-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Guidehouse"
+                                                                        value={
+                                                                            'GUIDEHOUSE'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`deloitte-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Deloitte"
+                                                                        value={
+                                                                            'DELOITTE'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'DELOITTE'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`stateInHouse-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="State in-house"
+                                                                        value={
+                                                                            'STATE_IN_HOUSE'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'STATE_IN_HOUSE'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+                                                                    <FieldRadio
+                                                                        id={`other-${index}`}
+                                                                        name={`actuaryContacts.${index}.actuarialFirm`}
+                                                                        label="Other"
+                                                                        value={
+                                                                            'OTHER'
+                                                                        }
+                                                                        checked={
+                                                                            values
+                                                                                .actuaryContacts[
+                                                                                index
+                                                                            ]
+                                                                                .actuarialFirm ===
+                                                                            'OTHER'
+                                                                        }
+                                                                        aria-required
+                                                                    />
+
+                                                                    {values
+                                                                        .actuaryContacts[
+                                                                        index
+                                                                    ]
+                                                                        .actuarialFirm ===
+                                                                        'OTHER' && (
+                                                                        <FormGroup
+                                                                            error={showFieldErrors(
+                                                                                actuaryContactErrorHandling(
+                                                                                    errors
+                                                                                        ?.actuaryContacts?.[
+                                                                                        index
+                                                                                    ]
+                                                                                )
+                                                                                    ?.actuarialFirmOther
+                                                                            )}
+                                                                        >
+                                                                            <label
+                                                                                htmlFor={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                            >
+                                                                                Other
+                                                                                actuarial
+                                                                                firm
+                                                                            </label>
+                                                                            {showFieldErrors(
+                                                                                `True`
+                                                                            ) && (
+                                                                                <ErrorMessage
+                                                                                    name={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                    component="div"
+                                                                                    className="usa-error-message"
+                                                                                />
+                                                                            )}
+                                                                            <Field
+                                                                                name={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                id={`actuaryContacts.${index}.actuarialFirmOther`}
+                                                                                type="text"
+                                                                                className="usa-input"
+                                                                            />
+                                                                        </FormGroup>
+                                                                    )}
                                                                 </FormGroup>
 
                                                                 {index > 0 && (
@@ -469,7 +857,7 @@ export const Contacts = ({
                                                                             remove(
                                                                                 index
                                                                             )
-                                                                            setNewStateContactButtonFocus()
+                                                                            setNewActuaryContactButtonFocus()
                                                                         }}
                                                                     >
                                                                         Remove
@@ -485,488 +873,116 @@ export const Contacts = ({
                                                 type="button"
                                                 className={`usa-button usa-button--outline ${styles.addContactBtn}`}
                                                 onClick={() => {
-                                                    push(emptyStateContact)
-                                                    setFocusNewContact(true)
+                                                    push(emptyActuaryContact)
+                                                    setFocusNewActuaryContact(
+                                                        true
+                                                    )
                                                 }}
-                                                ref={newStateContactButtonRef}
+                                                ref={newActuaryContactButtonRef}
                                             >
-                                                Add state contact
+                                                Add actuary contact
                                             </button>
                                         </div>
                                     )}
                                 </FieldArray>
-                            </fieldset>
 
-                            {draftSubmission.submissionType !==
-                                'CONTRACT_ONLY' && (
-                                <fieldset className="usa-fieldset">
-                                    <h3>Actuary contacts</h3>
-                                    {formAlert && formAlert}
-                                    <p>
-                                        Provide contact information for the
-                                        actuaries who worked directly on this
-                                        submission.
-                                    </p>
-                                    <legend className="srOnly">
-                                        Actuary contacts
-                                    </legend>
-                                    {formAlert && formAlert}
-
-                                    <FieldArray name="actuaryContacts">
-                                        {({ remove, push }) => (
-                                            <div
-                                                className={
-                                                    styles.actuaryContacts
-                                                }
-                                                data-testid="state-contacts"
-                                            >
-                                                {values.actuaryContacts.length >
-                                                    0 &&
-                                                    values.actuaryContacts.map(
-                                                        (
-                                                            actuaryContact,
-                                                            index
-                                                        ) => (
-                                                            <div
-                                                                className={
-                                                                    styles.actuaryContact
-                                                                }
-                                                                key={index}
-                                                            >
-                                                                <Fieldset
-                                                                    legend={handleContactLegend(
-                                                                        index,
-                                                                        'Actuary'
-                                                                    )}
-                                                                >
-                                                                    <FormGroup
-                                                                        error={showFieldErrors(
-                                                                            actuaryContactErrorHandling(
-                                                                                errors
-                                                                                    ?.actuaryContacts?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.name
-                                                                        )}
-                                                                    >
-                                                                        <label
-                                                                            htmlFor={`actuaryContacts.${index}.name`}
-                                                                        >
-                                                                            Name
-                                                                        </label>
-                                                                        {showFieldErrors(
-                                                                            `True`
-                                                                        ) && (
-                                                                            <ErrorMessage
-                                                                                name={`actuaryContacts.${index}.name`}
-                                                                                component="div"
-                                                                                className="usa-error-message"
-                                                                            />
-                                                                        )}
-                                                                        <Field
-                                                                            name={`actuaryContacts.${index}.name`}
-                                                                            id={`actuaryContacts.${index}.name`}
-                                                                            type="text"
-                                                                            className="usa-input"
-                                                                            innerRef={(
-                                                                                el: HTMLElement
-                                                                            ) =>
-                                                                                (newActuaryContactNameRef.current =
-                                                                                    el)
-                                                                            }
-                                                                        />
-                                                                    </FormGroup>
-
-                                                                    <FormGroup
-                                                                        error={showFieldErrors(
-                                                                            actuaryContactErrorHandling(
-                                                                                errors
-                                                                                    ?.actuaryContacts?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.titleRole
-                                                                        )}
-                                                                    >
-                                                                        <label
-                                                                            htmlFor={`actuaryContacts.${index}.titleRole`}
-                                                                        >
-                                                                            Title/Role
-                                                                        </label>
-                                                                        {showFieldErrors(
-                                                                            `True`
-                                                                        ) && (
-                                                                            <ErrorMessage
-                                                                                name={`actuaryContacts.${index}.titleRole`}
-                                                                                component="div"
-                                                                                className="usa-error-message"
-                                                                            />
-                                                                        )}
-                                                                        <Field
-                                                                            name={`actuaryContacts.${index}.titleRole`}
-                                                                            id={`actuaryContacts.${index}.titleRole`}
-                                                                            type="text"
-                                                                            className="usa-input"
-                                                                        />
-                                                                    </FormGroup>
-
-                                                                    <FormGroup
-                                                                        error={showFieldErrors(
-                                                                            actuaryContactErrorHandling(
-                                                                                errors
-                                                                                    ?.actuaryContacts?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.email
-                                                                        )}
-                                                                    >
-                                                                        <label
-                                                                            htmlFor={`actuaryContacts.${index}.email`}
-                                                                        >
-                                                                            Email
-                                                                        </label>
-                                                                        {showFieldErrors(
-                                                                            `True`
-                                                                        ) && (
-                                                                            <ErrorMessage
-                                                                                name={`actuaryContacts.${index}.email`}
-                                                                                component="div"
-                                                                                className="usa-error-message"
-                                                                            />
-                                                                        )}
-                                                                        <Field
-                                                                            name={`actuaryContacts.${index}.email`}
-                                                                            id={`actuaryContacts.${index}.email`}
-                                                                            type="text"
-                                                                            className="usa-input"
-                                                                        />
-                                                                    </FormGroup>
-
-                                                                    <FormGroup
-                                                                        error={showFieldErrors(
-                                                                            actuaryContactErrorHandling(
-                                                                                errors
-                                                                                    ?.actuaryContacts?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.actuarialFirm
-                                                                        )}
-                                                                    >
-                                                                        <label
-                                                                            htmlFor={`actuaryContacts.${index}.actuarialFirm`}
-                                                                        >
-                                                                            Actuarial
-                                                                            firm
-                                                                        </label>
-                                                                        {showFieldErrors(
-                                                                            `True`
-                                                                        ) && (
-                                                                            <ErrorMessage
-                                                                                name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                                component="div"
-                                                                                className="usa-error-message"
-                                                                            />
-                                                                        )}
-                                                                        <FieldRadio
-                                                                            id={`mercer-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Mercer"
-                                                                            value={
-                                                                                'MERCER'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'MERCER'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`milliman-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Milliman"
-                                                                            value={
-                                                                                'MILLIMAN'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'MILLIMAN'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`optumas-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Optumas"
-                                                                            value={
-                                                                                'OPTUMAS'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'OPTUMAS'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`guidehouse-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Guidehouse"
-                                                                            value={
-                                                                                'GUIDEHOUSE'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`deloitte-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Deloitte"
-                                                                            value={
-                                                                                'DELOITTE'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'DELOITTE'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`stateInHouse-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="State in-house"
-                                                                            value={
-                                                                                'STATE_IN_HOUSE'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'STATE_IN_HOUSE'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-                                                                        <FieldRadio
-                                                                            id={`other-${index}`}
-                                                                            name={`actuaryContacts.${index}.actuarialFirm`}
-                                                                            label="Other"
-                                                                            value={
-                                                                                'OTHER'
-                                                                            }
-                                                                            checked={
-                                                                                values
-                                                                                    .actuaryContacts[
-                                                                                    index
-                                                                                ]
-                                                                                    .actuarialFirm ===
-                                                                                'OTHER'
-                                                                            }
-                                                                            aria-required
-                                                                        />
-
-                                                                        {values
-                                                                            .actuaryContacts[
-                                                                            index
-                                                                        ]
-                                                                            .actuarialFirm ===
-                                                                            'OTHER' && (
-                                                                            <FormGroup
-                                                                                error={showFieldErrors(
-                                                                                    actuaryContactErrorHandling(
-                                                                                        errors
-                                                                                            ?.actuaryContacts?.[
-                                                                                            index
-                                                                                        ]
-                                                                                    )
-                                                                                        ?.actuarialFirmOther
-                                                                                )}
-                                                                            >
-                                                                                <label
-                                                                                    htmlFor={`actuaryContacts.${index}.actuarialFirmOther`}
-                                                                                >
-                                                                                    Other
-                                                                                    actuarial
-                                                                                    firm
-                                                                                </label>
-                                                                                {showFieldErrors(
-                                                                                    `True`
-                                                                                ) && (
-                                                                                    <ErrorMessage
-                                                                                        name={`actuaryContacts.${index}.actuarialFirmOther`}
-                                                                                        component="div"
-                                                                                        className="usa-error-message"
-                                                                                    />
-                                                                                )}
-                                                                                <Field
-                                                                                    name={`actuaryContacts.${index}.actuarialFirmOther`}
-                                                                                    id={`actuaryContacts.${index}.actuarialFirmOther`}
-                                                                                    type="text"
-                                                                                    className="usa-input"
-                                                                                />
-                                                                            </FormGroup>
-                                                                        )}
-                                                                    </FormGroup>
-
-                                                                    {index >
-                                                                        0 && (
-                                                                        <Button
-                                                                            type="button"
-                                                                            unstyled
-                                                                            className={
-                                                                                styles.removeContactBtn
-                                                                            }
-                                                                            onClick={() => {
-                                                                                remove(
-                                                                                    index
-                                                                                )
-                                                                                setNewActuaryContactButtonFocus()
-                                                                            }}
-                                                                        >
-                                                                            Remove
-                                                                            contact
-                                                                        </Button>
-                                                                    )}
-                                                                </Fieldset>
-                                                            </div>
-                                                        )
-                                                    )}
-
-                                                <button
-                                                    type="button"
-                                                    className={`usa-button usa-button--outline ${styles.addContactBtn}`}
-                                                    onClick={() => {
-                                                        push(
-                                                            emptyActuaryContact
-                                                        )
-                                                        setFocusNewActuaryContact(
-                                                            true
-                                                        )
-                                                    }}
-                                                    ref={
-                                                        newActuaryContactButtonRef
-                                                    }
-                                                >
-                                                    Add actuary contact
-                                                </button>
-                                            </div>
-                                        )}
-                                    </FieldArray>
-
-                                    <legend className="srOnly">
-                                        Actuarial communication preference
-                                    </legend>
-                                    <FormGroup
-                                        error={showFieldErrors(
-                                            errors.actuaryCommunicationPreference
-                                        )}
+                                <legend className="srOnly">
+                                    Actuarial communication preference
+                                </legend>
+                                <FormGroup
+                                    error={showFieldErrors(
+                                        errors.actuaryCommunicationPreference
+                                    )}
+                                >
+                                    <Fieldset
+                                        className={styles.radioGroup}
+                                        legend="Communication preference between CMS Office of the Actuary (OACT) and the state’s actuary"
                                     >
-                                        <Fieldset
-                                            className={styles.radioGroup}
-                                            legend="Communication preference between CMS Office of the Actuary (OACT) and the state’s actuary"
-                                        >
-                                            {showFieldErrors(`True`) && (
-                                                <ErrorMessage
-                                                    name={`actuaryCommunicationPreference`}
-                                                    component="div"
-                                                    className="usa-error-message"
-                                                />
-                                            )}
-                                            <FieldRadio
-                                                id="OACTtoActuary"
-                                                name="actuaryCommunicationPreference"
-                                                label={`OACT can communicate directly with the state’s actuary but should copy the state on all written communication and all appointments for verbal discussions.`}
-                                                value={'OACT_TO_ACTUARY'}
-                                                checked={
-                                                    values.actuaryCommunicationPreference ===
-                                                    'OACT_TO_ACTUARY'
-                                                }
-                                                aria-required
+                                        {showFieldErrors(`True`) && (
+                                            <ErrorMessage
+                                                name={`actuaryCommunicationPreference`}
+                                                component="div"
+                                                className="usa-error-message"
                                             />
-                                            <FieldRadio
-                                                id="OACTtoState"
-                                                name="actuaryCommunicationPreference"
-                                                label={`OACT can communicate directly with the state, and the state will relay all written communication to their actuary and set up time for any potential verbal discussions.`}
-                                                value={'OACT_TO_STATE'}
-                                                checked={
-                                                    values.actuaryCommunicationPreference ===
-                                                    'OACT_TO_STATE'
-                                                }
-                                                aria-required
-                                            />
-                                        </Fieldset>
-                                    </FormGroup>
-                                </fieldset>
-                            )}
-                            <div className={styles.pageActions}>
-                                <Button
-                                    type="button"
-                                    unstyled
-                                    onClick={() => {
-                                        if (!dirty) {
-                                            history.push(`/dashboard`)
-                                        } else {
-                                            setShouldValidate(true)
-                                            setFocusErrorSummaryHeading(true)
+                                        )}
+                                        <FieldRadio
+                                            id="OACTtoActuary"
+                                            name="actuaryCommunicationPreference"
+                                            label={`OACT can communicate directly with the state’s actuary but should copy the state on all written communication and all appointments for verbal discussions.`}
+                                            value={'OACT_TO_ACTUARY'}
+                                            checked={
+                                                values.actuaryCommunicationPreference ===
+                                                'OACT_TO_ACTUARY'
+                                            }
+                                            aria-required
+                                        />
+                                        <FieldRadio
+                                            id="OACTtoState"
+                                            name="actuaryCommunicationPreference"
+                                            label={`OACT can communicate directly with the state, and the state will relay all written communication to their actuary and set up time for any potential verbal discussions.`}
+                                            value={'OACT_TO_STATE'}
+                                            checked={
+                                                values.actuaryCommunicationPreference ===
+                                                'OACT_TO_STATE'
+                                            }
+                                            aria-required
+                                        />
+                                    </Fieldset>
+                                </FormGroup>
+                            </fieldset>
+                        )}
+                        <div className={styles.pageActions}>
+                            <Button
+                                type="button"
+                                unstyled
+                                onClick={() => {
+                                    if (!dirty) {
+                                        history.push(`/dashboard`)
+                                    } else {
+                                        setShouldValidate(true)
+                                        setFocusErrorSummaryHeading(true)
 
-                                            redirectToDashboard.current = true
-                                            handleSubmit()
-                                        }
+                                        redirectToDashboard.current = true
+                                        handleSubmit()
+                                    }
+                                }}
+                            >
+                                Save as draft
+                            </Button>
+                            <ButtonGroup
+                                type="default"
+                                className={styles.buttonGroup}
+                            >
+                                <Link
+                                    asCustom={NavLink}
+                                    className="usa-button usa-button--outline"
+                                    variant="unstyled"
+                                    to={
+                                        draftSubmission.submissionType ===
+                                        'CONTRACT_ONLY'
+                                            ? 'contract-details'
+                                            : 'rate-details'
+                                    }
+                                >
+                                    Back
+                                </Link>
+                                <Button
+                                    type="submit"
+                                    disabled={isSubmitting}
+                                    onClick={() => {
+                                        redirectToDashboard.current = false
+                                        setShouldValidate(true)
+                                        setFocusErrorSummaryHeading(true)
                                     }}
                                 >
-                                    Save as draft
+                                    Continue
                                 </Button>
-                                <ButtonGroup
-                                    type="default"
-                                    className={styles.buttonGroup}
-                                >
-                                    <Link
-                                        asCustom={NavLink}
-                                        className="usa-button usa-button--outline"
-                                        variant="unstyled"
-                                        to={
-                                            draftSubmission.submissionType ===
-                                            'CONTRACT_ONLY'
-                                                ? 'contract-details'
-                                                : 'rate-details'
-                                        }
-                                    >
-                                        Back
-                                    </Link>
-                                    <Button
-                                        type="submit"
-                                        disabled={isSubmitting}
-                                        onClick={() => {
-                                            redirectToDashboard.current = false
-                                            setShouldValidate(true)
-                                            setFocusErrorSummaryHeading(true)
-                                        }}
-                                    >
-                                        Continue
-                                    </Button>
-                                </ButtonGroup>
-                            </div>
-                        </UswdsForm>
-                    </>
-                )}
-            </Formik>
-        </>
-    )
+                            </ButtonGroup>
+                        </div>
+                    </UswdsForm>
+                </>
+            )}
+        </Formik>
+    </>
+)
 }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -25,6 +25,23 @@ describe('ContractDetails', () => {
     }
     afterEach(() => jest.clearAllMocks())
 
+
+    it('displays correct form guidance', async () => {
+        renderWithProviders(
+            <ContractDetails
+                draftSubmission={mockDraft()}
+                updateDraft={jest.fn()}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        expect(screen.getByText(/All fields are required/)).toBeInTheDocument()
+    })
+
     it('progressively discloses options for capitation rates', async () => {
         // mount an empty form
 
@@ -35,7 +52,7 @@ describe('ContractDetails', () => {
         renderWithProviders(
             <ContractDetails
                 draftSubmission={emptyDraft}
-                updateDraft={async (_) => undefined}
+                updateDraft={jest.fn()}
             />,
             {
                 apolloProvider: {

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -371,6 +371,7 @@ export const ContractDetails = ({
                         className={styles.formContainer}
                         id="ContractDetailsForm"
                         aria-label="Contract Details Form"
+                        aria-describedby='form-guidance'
                         onSubmit={(e) => {
                             setShouldValidate(true)
                             setFocusErrorSummaryHeading(true)
@@ -380,7 +381,7 @@ export const ContractDetails = ({
                         <fieldset className="usa-fieldset">
                             <legend className="srOnly">Contract Details</legend>
                             {formAlert && formAlert}
-                            <span>All fields are required</span>
+                            <span id="form-guidance">All fields are required</span>
 
                             {shouldValidate && (
                                 <ErrorSummary
@@ -401,6 +402,7 @@ export const ContractDetails = ({
                                     id="documents"
                                     name="documents"
                                     label="Upload contract"
+                                    aria-required
                                     error={documentsError}
                                     hint={
                                         <>
@@ -433,6 +435,7 @@ export const ContractDetails = ({
                                 error={showFieldErrors(errors.contractType)}
                             >
                                 <Fieldset
+                                    aria-required
                                     className={styles.radioGroup}
                                     legend="Contract action type"
                                 >
@@ -445,19 +448,19 @@ export const ContractDetails = ({
                                         id="baseContract"
                                         name="contractType"
                                         label="Base contract"
+                                        aria-required
                                         value={'BASE'}
                                         checked={values.contractType === 'BASE'}
-                                        aria-required
                                     />
                                     <FieldRadio
                                         id="amendmentContract"
                                         name="contractType"
                                         label="Amendment to base contract"
+                                        aria-required
                                         value={'AMENDMENT'}
                                         checked={
                                             values.contractType === 'AMENDMENT'
                                         }
-                                        aria-required
                                     />
                                 </Fieldset>
                             </FormGroup>
@@ -475,6 +478,7 @@ export const ContractDetails = ({
                                         }
                                     >
                                         <Fieldset
+                                            aria-required
                                             legend={
                                                 isContractAmendmentSelected(
                                                     values
@@ -503,9 +507,10 @@ export const ContractDetails = ({
                                                 startDateHint="mm/dd/yyyy"
                                                 startDateLabel="Start date"
                                                 startDatePickerProps={{
-                                                    disabled: false,
                                                     id: 'contractDateStart',
                                                     name: 'contractDateStart',
+                                                    'aria-required': true,
+                                                    disabled: false,
                                                     defaultValue:
                                                         values.contractDateStart,
                                                     maxDate:
@@ -526,6 +531,7 @@ export const ContractDetails = ({
                                                     disabled: false,
                                                     id: 'contractDateEnd',
                                                     name: 'contractDateEnd',
+                                                    'aria-required': true,
                                                     defaultValue:
                                                         values.contractDateEnd,
                                                     minDate:
@@ -548,7 +554,10 @@ export const ContractDetails = ({
                                             errors.managedCareEntities
                                         )}
                                     >
-                                        <Fieldset legend="Managed Care entities">
+                                        <Fieldset
+                                            aria-required
+                                            legend="Managed Care entities"
+                                        >
                                             <Link
                                                 variant="external"
                                                 href={
@@ -622,7 +631,10 @@ export const ContractDetails = ({
                                             errors.federalAuthorities
                                         )}
                                     >
-                                        <Fieldset legend="Federal authority your program operates under">
+                                        <Fieldset
+                                            aria-required
+                                            legend="Federal authority your program operates under"
+                                        >
                                             <Link
                                                 variant="external"
                                                 href={
@@ -720,7 +732,10 @@ export const ContractDetails = ({
                                                     errors.itemsAmended
                                                 )}
                                             >
-                                                <Fieldset legend="Items being amended">
+                                                <Fieldset
+                                                    aria-required
+                                                    legend="Items being amended"
+                                                >
                                                     <Link
                                                         variant="external"
                                                         asCustom={
@@ -784,7 +799,10 @@ export const ContractDetails = ({
                                                                         : styles.nestedOptions
                                                                 }
                                                             >
-                                                                <Fieldset legend="Select reason for capitation rate change">
+                                                                <Fieldset
+                                                                    aria-required
+                                                                    legend="Select reason for capitation rate change"
+                                                                >
                                                                     {showFieldErrors(
                                                                         errors.capitationRates
                                                                     ) && (
@@ -992,11 +1010,12 @@ export const ContractDetails = ({
                                                         >
                                                             <FieldTextInput
                                                                 id="other-items-amended"
+                                                                name="otherItemAmended"
                                                                 label="Other item description"
+                                                                aria-required
                                                                 showError={showFieldErrors(
                                                                     errors.otherItemAmended
                                                                 )}
-                                                                name="otherItemAmended"
                                                                 type="text"
                                                             />
                                                         </div>
@@ -1011,7 +1030,10 @@ export const ContractDetails = ({
                                                             errors.relatedToCovid19
                                                         )}
                                                     >
-                                                        <Fieldset legend="Is this contract action related to the COVID-19 public health emergency?">
+                                                        <Fieldset
+                                                            aria-required
+                                                            legend="Is this contract action related to the COVID-19 public health emergency?"
+                                                        >
                                                             {showFieldErrors(
                                                                 errors.relatedToCovid19
                                                             ) && (
@@ -1050,7 +1072,10 @@ export const ContractDetails = ({
                                                                 errors.relatedToVaccination
                                                             )}
                                                         >
-                                                            <Fieldset legend="Is this related to coverage and reimbursement for vaccine administration?">
+                                                            <Fieldset
+                                                                aria-required
+                                                                legend="Is this related to coverage and reimbursement for vaccine administration?"
+                                                            >
                                                                 {showFieldErrors(
                                                                     errors.relatedToVaccination
                                                                 ) && (

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -382,10 +382,19 @@ export const ContractDetails = ({
                             {formAlert && formAlert}
                             <span>All fields are required</span>
 
-                            { shouldValidate && <ErrorSummary
-                                errors={documentsError ? {documents: documentsError, ...errors} : errors}
-                                headingRef={errorSummaryHeadingRef}
-                            /> }
+                            {shouldValidate && (
+                                <ErrorSummary
+                                    errors={
+                                        documentsError
+                                            ? {
+                                                  documents: documentsError,
+                                                  ...errors,
+                                              }
+                                            : errors
+                                    }
+                                    headingRef={errorSummaryHeadingRef}
+                                />
+                            )}
 
                             <FormGroup error={showDocumentErrors}>
                                 <FileUpload
@@ -406,6 +415,10 @@ export const ContractDetails = ({
                                                 Document definitions and
                                                 requirements
                                             </Link>
+                                            <span className="srOnly">
+                                                This input only accepts PDF,
+                                                CSV, DOC, DOCX, XLS, XLSX files.
+                                            </span>
                                         </>
                                     }
                                     accept="application/pdf,text/csv,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -266,6 +266,10 @@ export const Documents = ({
                                         supporting documents
                                     </strong>
                                 </p>
+                                <span className="srOnly">
+                                    This input only accepts PDF, CSV, DOC, DOCX,
+                                    XLS, XLSX files.
+                                </span>
                             </>
                         }
                         accept="application/pdf,text/csv,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -51,6 +51,22 @@ describe('RateDetails', () => {
         ).not.toBeDisabled()
     })
 
+
+    it('displays correct form guidance', async () => {
+        renderWithProviders(
+            <RateDetails
+                draftSubmission={emptyRateDetailsDraft}
+                updateDraft={jest.fn()}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        expect(screen.getByText(/All fields are required/)).toBeInTheDocument()
+    })
+
     it('loads with empty rate type and document upload fields visible', async () => {
         const mockUpdateDraftFn = jest.fn()
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -324,10 +324,19 @@ export const RateDetails = ({
                                 {formAlert && formAlert}
                                 <span>All fields are required</span>
 
-                                { shouldValidate && <ErrorSummary
-                                errors={documentsError ? {documents: documentsError, ...errors} : errors}
-                                headingRef={errorSummaryHeadingRef}
-                            /> }
+                                {shouldValidate && (
+                                    <ErrorSummary
+                                        errors={
+                                            documentsError
+                                                ? {
+                                                      documents: documentsError,
+                                                      ...errors,
+                                                  }
+                                                : errors
+                                        }
+                                        headingRef={errorSummaryHeadingRef}
+                                    />
+                                )}
 
                                 <FormGroup error={showDocumentErrors}>
                                     <FileUpload
@@ -336,17 +345,24 @@ export const RateDetails = ({
                                         label="Upload rate certification"
                                         error={documentsError}
                                         hint={
-                                            <Link
-                                                aria-label="Document definitions and requirements (opens in new window)"
-                                                href={
-                                                    'https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf'
-                                                }
-                                                variant="external"
-                                                target="_blank"
-                                            >
-                                                Document definitions and
-                                                requirements
-                                            </Link>
+                                            <>
+                                                <Link
+                                                    aria-label="Document definitions and requirements (opens in new window)"
+                                                    href={
+                                                        'https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf'
+                                                    }
+                                                    variant="external"
+                                                    target="_blank"
+                                                >
+                                                    Document definitions and
+                                                    requirements
+                                                </Link>
+                                                <span className="srOnly">
+                                                    This input only accepts PDF,
+                                                    CSV, DOC, DOCX, XLS, XLSX
+                                                    files.
+                                                </span>
+                                            </>
                                         }
                                         accept="application/pdf,text/csv,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
                                         initialItems={

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -457,6 +457,7 @@ export const RateDetails = ({
                                                         disabled: false,
                                                         id: 'rateDateStart',
                                                         name: 'rateDateStart',
+                                                        'aria-required': true,
                                                         defaultValue:
                                                             values.rateDateStart,
                                                         onChange: (val) =>
@@ -473,6 +474,7 @@ export const RateDetails = ({
                                                         disabled: false,
                                                         id: 'rateDateEnd',
                                                         name: 'rateDateEnd',
+                                                        'aria-required': true,
                                                         defaultValue:
                                                             values.rateDateEnd,
                                                         onChange: (val) =>
@@ -523,6 +525,8 @@ export const RateDetails = ({
                                                                 disabled: false,
                                                                 id: 'effectiveDateStart',
                                                                 name: 'effectiveDateStart',
+                                                                'aria-required':
+                                                                    true,
                                                                 defaultValue:
                                                                     values.effectiveDateStart,
                                                                 onChange: (
@@ -541,6 +545,8 @@ export const RateDetails = ({
                                                                 disabled: false,
                                                                 id: 'effectiveDateEnd',
                                                                 name: 'effectiveDateEnd',
+                                                                'aria-required':
+                                                                    true,
                                                                 defaultValue:
                                                                     values.effectiveDateEnd,
                                                                 onChange: (

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -313,6 +313,7 @@ export const RateDetails = ({
                             className={styles.formContainer}
                             id="RateDetailsForm"
                             aria-label="Rate Details Form"
+                            aria-describedby="form-guidance"
                             onSubmit={(e) => {
                                 setShouldValidate(true)
                                 setFocusErrorSummaryHeading(true)
@@ -322,7 +323,9 @@ export const RateDetails = ({
                             <fieldset className="usa-fieldset">
                                 <legend className="srOnly">Rate Details</legend>
                                 {formAlert && formAlert}
-                                <span>All fields are required</span>
+                                <span id="form-guidance">
+                                    All fields are required
+                                </span>
 
                                 {shouldValidate && (
                                     <ErrorSummary
@@ -343,6 +346,7 @@ export const RateDetails = ({
                                         id="rateDocuments"
                                         name="rateDocuments"
                                         label="Upload rate certification"
+                                        aria-required
                                         error={documentsError}
                                         hint={
                                             <>
@@ -380,6 +384,7 @@ export const RateDetails = ({
                                     <Fieldset
                                         className={styles.radioGroup}
                                         legend="Rate certification type"
+                                        aria-required
                                     >
                                         {showFieldErrors(errors.rateType) && (
                                             <ErrorMessage>
@@ -392,7 +397,6 @@ export const RateDetails = ({
                                             label="New rate certification"
                                             value={'NEW'}
                                             checked={values.rateType === 'NEW'}
-                                            aria-required
                                         />
                                         <FieldRadio
                                             id="amendmentRate"
@@ -402,7 +406,6 @@ export const RateDetails = ({
                                             checked={
                                                 values.rateType === 'AMENDMENT'
                                             }
-                                            aria-required
                                         />
                                     </Fieldset>
                                 </FormGroup>
@@ -420,6 +423,7 @@ export const RateDetails = ({
                                             }
                                         >
                                             <Fieldset
+                                                aria-required
                                                 legend={
                                                     isRateTypeAmendment(values)
                                                         ? 'Rating period of original rate certification'
@@ -488,7 +492,10 @@ export const RateDetails = ({
                                         {isRateTypeAmendment(values) && (
                                             <>
                                                 <FormGroup>
-                                                    <Fieldset legend="Effective dates of rate amendment">
+                                                    <Fieldset
+                                                        aria-required
+                                                        legend="Effective dates of rate amendment"
+                                                    >
                                                         {showFieldErrors(
                                                             errors.effectiveDateStart ||
                                                                 errors.effectiveDateEnd

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -18,18 +18,15 @@ describe('SubmissionType', () => {
         submissionType: '',
     }
 
-        it('displays correct form guidance', async () => {
-            renderWithProviders(<SubmissionType />, {
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
-            })
-
-            expect(
-                screen.getByText(/All fields are required/)
-            ).toBeInTheDocument()
+    it('displays correct form guidance', async () => {
+        renderWithProviders(<SubmissionType />, {
+            apolloProvider: {
+                mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+            },
         })
 
+        expect(screen.getByText(/All fields are required/)).toBeInTheDocument()
+    })
 
     it('displays submission type form when expected', async () => {
         renderWithProviders(<SubmissionType />, {
@@ -127,7 +124,7 @@ describe('SubmissionType', () => {
 
         await waitFor(() =>
             expect(
-                screen.getByRole('combobox', { name: 'programs' })
+                screen.getByRole('combobox', { name: 'programs (required)' })
             ).toBeInTheDocument()
         )
     })

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -18,6 +18,19 @@ describe('SubmissionType', () => {
         submissionType: '',
     }
 
+        it('displays correct form guidance', async () => {
+            renderWithProviders(<SubmissionType />, {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            })
+
+            expect(
+                screen.getByText(/All fields are required/)
+            ).toBeInTheDocument()
+        })
+
+
     it('displays submission type form when expected', async () => {
         renderWithProviders(<SubmissionType />, {
             apolloProvider: {

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -251,6 +251,7 @@ export const SubmissionType = ({
                                 ? 'New Submission Form'
                                 : 'Submission Type Form'
                         }
+                        aria-describedby="form-guidance"
                         onSubmit={handleSubmit}
                     >
                         <fieldset className="usa-fieldset">
@@ -261,9 +262,16 @@ export const SubmissionType = ({
                                         Something went wrong
                                     </Alert>
                                 ))}
-                            <span>All fields are required</span>
+                            <span id="form-guidance">
+                                All fields are required
+                            </span>
 
-                            { shouldValidate && <ErrorSummary errors={errors} headingRef={errorSummaryHeadingRef} /> }
+                            {shouldValidate && (
+                                <ErrorSummary
+                                    errors={errors}
+                                    headingRef={errorSummaryHeadingRef}
+                                />
+                            )}
 
                             <FormGroup
                                 error={showFieldErrors(errors.programIDs)}
@@ -291,7 +299,7 @@ export const SubmissionType = ({
                                             classNamePrefix="program-select"
                                             id="programIDs"
                                             name="programIDs"
-                                            aria-label="programs"
+                                            aria-label="programs (required)"
                                             options={programOptions}
                                             isMulti
                                             ariaLiveMessages={{
@@ -314,6 +322,7 @@ export const SubmissionType = ({
                             >
                                 <Fieldset
                                     className={styles.radioGroup}
+                                    aria-required
                                     legend="Choose submission type"
                                 >
                                     {showFieldErrors(errors.submissionType) && (
@@ -322,7 +331,6 @@ export const SubmissionType = ({
                                         </ErrorMessage>
                                     )}
                                     <FieldRadio
-                                        aria-required
                                         checked={
                                             values.submissionType ===
                                             'CONTRACT_ONLY'
@@ -337,7 +345,6 @@ export const SubmissionType = ({
                                         value={'CONTRACT_ONLY'}
                                     />
                                     <FieldRadio
-                                        aria-required
                                         checked={
                                             values.submissionType ===
                                             'CONTRACT_AND_RATES'
@@ -357,6 +364,7 @@ export const SubmissionType = ({
                                 label="Submission description"
                                 id="submissionDescription"
                                 name="submissionDescription"
+                                aria-required
                                 showError={showFieldErrors(
                                     errors.submissionDescription
                                 )}
@@ -385,9 +393,10 @@ export const SubmissionType = ({
                         <PageActions
                             pageVariant="FIRST"
                             backOnClick={() => history.push('/dashboard')}
-                            continueOnClick={() =>{ 
-                                setShouldValidate(true)   
-                                setFocusErrorSummaryHeading(true)}}
+                            continueOnClick={() => {
+                                setShouldValidate(true)
+                                setFocusErrorSummaryHeading(true)
+                            }}
                             saveAsDraftOnClick={() => setShouldValidate(true)}
                             continueDisabled={isSubmitting}
                         />

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -28,7 +28,7 @@ Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
 
 Cypress.Commands.add('fillOutContractActionOnly', () => {
     // Must be on '/submissions/new'
-    cy.findByRole('combobox', { name: 'programs' }).click({
+    cy.findByRole('combobox', { name: 'programs (required)' }).click({
         force: true,
     })
     cy.findByText('PMAP').click()
@@ -40,7 +40,7 @@ Cypress.Commands.add('fillOutContractActionOnly', () => {
 
 Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
     // Must be on '/submissions/new'
-    cy.findByRole('combobox', { name: 'programs' }).click({
+    cy.findByRole('combobox', { name: 'programs (required)' }).click({
         force: true,
     })
     cy.findByText('PMAP').click()


### PR DESCRIPTION
## Summary
- Required notes should be read in relation to form fields
- State user knows accepted file formats on doc upload

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-13570
https://qmacbis.atlassian.net/browse/OY2-13574

#### Test cases covered
- displays correct form guidance - on SubmissionType, ContractDetails, RateDetails pages
- displays correct form guidance for contract only submission and displays correct form guidance for contract and rates submission - on Contacts page

## QA guidance
- Make sure required fields are announced as required by screenreader (voiceover and JAWS)
