### PR TITLE
Fixing wrapping tag layout on dashboard

### DIFF
--- a/services/app-web/src/pages/Dashboard/Dashboard.module.scss
+++ b/services/app-web/src/pages/Dashboard/Dashboard.module.scss
@@ -61,7 +61,6 @@
 
 .programTag {
     background: $cms-color-primary;
-    display: inline-block;
 }
 
 .submittedTag {

--- a/services/app-web/src/pages/Dashboard/Dashboard.module.scss
+++ b/services/app-web/src/pages/Dashboard/Dashboard.module.scss
@@ -61,6 +61,7 @@
 
 .programTag {
     background: $cms-color-primary;
+    display: inline-block;
 }
 
 .submittedTag {


### PR DESCRIPTION
Tags on the dashboard are wrapping strangely with longer program names. 

I've added `display: inline-block` to the tag layout to allow for the tags to wrap to new lines when they are longer.