### PR TITLE
Fix s3 event trigger for AV scan

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -124,9 +124,7 @@ resources:
                 - ETag
         NotificationConfiguration:
           LambdaConfigurations:
-            - Event: s3:CompleteMultipartUpload
-              Function: !GetAtt AvScanLambdaFunction.Arn
-            - Event: s3:ObjectCreated:Put
+            - Event: s3:ObjectCreated:*
               Function: !GetAtt AvScanLambdaFunction.Arn
       DependsOn: LambdaInvokePermission
     DocumentsUploadsBucketPolicy:


### PR DESCRIPTION
## Summary

There was a typo in the s3 event type for the AV scanning fix that landed earlier. This collapses the rule into a single wildcard -- all objects created in the uploads bucket will trigger an AV scan. The list of event notification types can be found in the [AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html).
