### PR TITLE
Clean up email tests and make red text bold

### DIFF
--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -39,11 +39,7 @@ const newPackageCMSEmailTemplate = (
 
             View submission: ${submissionURL}`,
         bodyHTML: `
-<<<<<<< HEAD
             <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
-=======
-            <span style="color:#FF0000">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
->>>>>>> origin/main
             <br /><br />
             ${submissionName(submission)} was received from ${
             submission.stateCode
@@ -92,11 +88,7 @@ const newPackageStateEmailTemplate = (
             3. Questions: You may receive questions via email from CMS as they conduct their review.
             4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
         bodyHTML: `
-<<<<<<< HEAD
             <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
-=======
-            <span style="color:#FF0000">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
->>>>>>> origin/main
             <br /><br />
              ${submissionName(submission)} was successfully submitted.
             <br /><br />

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -39,7 +39,11 @@ const newPackageCMSEmailTemplate = (
 
             View submission: ${submissionURL}`,
         bodyHTML: `
+<<<<<<< HEAD
+            <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+=======
             <span style="color:#FF0000">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+>>>>>>> origin/main
             <br /><br />
             ${submissionName(submission)} was received from ${
             submission.stateCode
@@ -88,7 +92,11 @@ const newPackageStateEmailTemplate = (
             3. Questions: You may receive questions via email from CMS as they conduct their review.
             4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
         bodyHTML: `
+<<<<<<< HEAD
+            <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+=======
             <span style="color:#FF0000">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+>>>>>>> origin/main
             <br /><br />
              ${submissionName(submission)} was successfully submitted.
             <br /><br />

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -39,7 +39,7 @@ const newPackageCMSEmailTemplate = (
 
             View submission: ${submissionURL}`,
         bodyHTML: `
-            <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+            <span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
             <br /><br />
             ${submissionName(submission)} was received from ${
             submission.stateCode
@@ -88,7 +88,7 @@ const newPackageStateEmailTemplate = (
             3. Questions: You may receive questions via email from CMS as they conduct their review.
             4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
         bodyHTML: `
-            <span style="color:#FF0000",font-weight:"bold">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+            <span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
             <br /><br />
              ${submissionName(submission)} was successfully submitted.
             <br /><br />

--- a/services/app-api/resolvers/submitDraftSubmission.test.ts
+++ b/services/app-api/resolvers/submitDraftSubmission.test.ts
@@ -257,21 +257,51 @@ describe('submitDraftSubmission', () => {
             ?.submission as StateSubmission
         expect(mockEmailer.sendEmail).toHaveBeenCalledTimes(2)
 
-        // Need more resilient way to test email text
-        // expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
-        //     expect.objectContaining({
-        //         bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-        //         ${sub.name} was received from FL.
+<<<<<<< HEAD
+        // email subject line is correct for CMS email
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `TEST New Managed Care Submission: ${sub.name}`
+                ),
+            })
+        )
+        //email body text includes warning about unofficial submission
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `This is NOT an official submission`
+                ),
+            })
+        )
 
-        //     Submission type: Contract action and rate certification
-        //     Submission description: An updated submission
-
-        //     View submission: http://localhost/submissions/${sub.id}`,
-        //     })
-        // )
+        // email body text includes submission type
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    'Submission type: Contract action and rate certification'
+                ),
+            })
+        )
+        // email body text includes submission description
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    'Submission description: An updated submission'
+                ),
+            })
+        )
+        // email body text includes link to submission
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `http://localhost/submissions/${sub.id}`
+                ),
+            })
+        )
     })
 
-    it('send email to user and state contacts if submission is valid', async () => {
+    it('send email to user if submission is valid', async () => {
         const mockEmailer = testEmailer()
         const server = await constructTestPostgresServer({
             emailer: mockEmailer,
@@ -293,6 +323,113 @@ describe('submitDraftSubmission', () => {
 
         const sub = submitResult?.data?.submitDraftSubmission
             ?.submission as StateSubmission
+
+        // email subject line is correct for state email
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `TEST ${sub.name} was sent to CMS`
+                ),
+            })
+        )
+
+        // email body text includes warning about unofficial submission
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `This is NOT an official submission`
+                ),
+            })
+        )
+
+        // email body text includes submission name
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `${sub.name} was successfully submitted.`
+                ),
+            })
+        )
+        // email body text includes items of what's next list
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining('What comes next:'),
+            })
+        )
+        // email body text includes link to submission
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `http://localhost/submissions/${sub.id}`
+                ),
+            })
+        )
+=======
+        // Need more resilient way to test email text
+        // expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+        //     expect.objectContaining({
+        //         bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
+        //         ${sub.name} was received from FL.
+
+        //     Submission type: Contract action and rate certification
+        //     Submission description: An updated submission
+
+        //     View submission: http://localhost/submissions/${sub.id}`,
+        //     })
+        // )
+>>>>>>> origin/main
+    })
+
+    it('send email to all state contacts if submission is valid', async () => {
+        const mockEmailer = testEmailer()
+        const server = await constructTestPostgresServer({
+            emailer: mockEmailer,
+        })
+        const draft = await createAndUpdateTestDraftSubmission(server, {})
+        const draftID = draft.id
+
+        await new Promise((resolve) => setTimeout(resolve, 2000)) // TODO: why is this here in other tests??
+        const submitResult = await server.executeOperation({
+            query: SUBMIT_DRAFT_SUBMISSION,
+            variables: {
+                input: {
+                    submissionID: draftID,
+                },
+            },
+        })
+
+        expect(submitResult.errors).toBeUndefined()
+
+        const sub = submitResult?.data?.submitDraftSubmission
+            ?.submission as StateSubmission
+<<<<<<< HEAD
+
+        // email subject line is correct for state email
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subject: expect.stringContaining(
+                    `TEST ${sub.name} was sent to CMS`
+                ),
+            })
+        )
+
+        // email body text includes warning about unofficial submission
+        expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                bodyText: expect.stringContaining(
+                    `This is NOT an official submission`
+                ),
+            })
+        )
+
+        sub.stateContacts.forEach((contact) => {
+            expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    toAddresses: expect.arrayContaining([contact.email]),
+                })
+            )
+        })
+=======
         expect(mockEmailer.sendEmail).toHaveBeenCalledTimes(2)
         // Need more resilient way to test email text
         // expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
@@ -310,7 +447,9 @@ describe('submitDraftSubmission', () => {
         //     4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
         //     })
         // )
+>>>>>>> origin/main
     })
+
 
     it('does not send any emails if submission fails', async () => {
         const mockEmailer = testEmailer()

--- a/services/app-api/resolvers/submitDraftSubmission.test.ts
+++ b/services/app-api/resolvers/submitDraftSubmission.test.ts
@@ -257,7 +257,6 @@ describe('submitDraftSubmission', () => {
             ?.submission as StateSubmission
         expect(mockEmailer.sendEmail).toHaveBeenCalledTimes(2)
 
-<<<<<<< HEAD
         // email subject line is correct for CMS email
         expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -364,20 +363,6 @@ describe('submitDraftSubmission', () => {
                 ),
             })
         )
-=======
-        // Need more resilient way to test email text
-        // expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
-        //     expect.objectContaining({
-        //         bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-        //         ${sub.name} was received from FL.
-
-        //     Submission type: Contract action and rate certification
-        //     Submission description: An updated submission
-
-        //     View submission: http://localhost/submissions/${sub.id}`,
-        //     })
-        // )
->>>>>>> origin/main
     })
 
     it('send email to all state contacts if submission is valid', async () => {
@@ -402,7 +387,6 @@ describe('submitDraftSubmission', () => {
 
         const sub = submitResult?.data?.submitDraftSubmission
             ?.submission as StateSubmission
-<<<<<<< HEAD
 
         // email subject line is correct for state email
         expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
@@ -429,25 +413,6 @@ describe('submitDraftSubmission', () => {
                 })
             )
         })
-=======
-        expect(mockEmailer.sendEmail).toHaveBeenCalledTimes(2)
-        // Need more resilient way to test email text
-        // expect(mockEmailer.sendEmail).toHaveBeenCalledWith(
-        //     expect.objectContaining({
-        //         bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-        //     ${sub.name} was successfully submitted.
-        //     View submission: http://localhost/submissions/${sub.id}
-
-        //     If you need to make any changes, please contact CMS.
-
-        //     What comes next:
-        //     1. Check for completeness: CMS will review all documentation submitted to ensure all required materials were received.
-        //     2. CMS review: Your submission will be reviewed by CMS for adherence to federal regulations. If a rate certification is included, it will be reviewed for policy adherence and actuarial soundness.
-        //     3. Questions: You may receive questions via email from CMS as they conduct their review.
-        //     4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
-        //     })
-        // )
->>>>>>> origin/main
     })
 
 


### PR DESCRIPTION
## Summary
- make it BOLD
- get tests back in there without all fighting all the whitespace. Test smaller chunks of text.

#### Related issues
follow up from #741 

#### Test cases covered

Added a new set of tests to make sure all state contacts are included in to addresses for state email.  Otherwise just added more assertions to existing tests to hopefully make it less breakable but still have a test that will fail if the wrong email template is prepared.

