### PR TITLE
Add documents definitions and requirements table

### DIFF
--- a/services/app-web/src/pages/Help/Help.module.scss
+++ b/services/app-web/src/pages/Help/Help.module.scss
@@ -3,4 +3,10 @@
 
 .helpSection {
     margin: units(4) 0;
+
+    table {
+        th, td {
+            vertical-align: top;
+        }
+    }
 }

--- a/services/app-web/src/pages/Help/Help.module.scss
+++ b/services/app-web/src/pages/Help/Help.module.scss
@@ -3,8 +3,4 @@
 
 .helpSection {
     margin: units(4) 0;
-
-    table {
-        max-width: 88ex;
-    }
 }

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -223,7 +223,7 @@ export const Help = (): React.ReactElement => {
                             <td>All appendices and attachments to the contract document. <br/><br/>Please note: Adding a new appendix during the course of a contract period requires an executed "amendment to base contract" submission.</td>
                             <td>For all "base contract" and "amendment to base contract" submissions.</td>
                             <td>
-                                <a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank">11.8.2019 CMCS Informational Bulletin</a>
+                                <a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank" rel="noreferrer">11.8.2019 CMCS Informational Bulletin</a>
                             </td>
                             <td>Contract</td>
                         </tr>
@@ -259,7 +259,7 @@ export const Help = (): React.ReactElement => {
                             <td>Redlined contract changes/Contract change document</td>
                             <td>States who have significant changes between one contract verison and the next will sometimes submit redlined or contract change documents to CMS in order to clearly outline the changes between each version.</td>
                             <td>Optional</td>
-                            <td><a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank">11.8.2019 CMCS Informational Bulletin</a></td>
+                            <td><a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank" rel="noreferrer">11.8.2019 CMCS Informational Bulletin</a></td>
                             <td>Contract - supporting</td>
                         </tr>
                         <tr>
@@ -279,15 +279,15 @@ export const Help = (): React.ReactElement => {
                         <tr>
                             <td>Rate development index</td>
                             <td>The rate certification must include an index that identifies the page number or the section number for each item described within this guidance. In cases where not all sections of this guidance are relevant for a particular rate certification (i.e., a rate amendment that adds a new benefit for part of the year), inapplicable sections of the guidance must be included and marked as “Not Applicable” in the index.</td>
-                            <td>For all "contract action and rate certification" submissions. All rate certifications must be accompanied by an index and this index should also follow the structure of the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Rate Development Guide</a> from CMS.</td>
-                            <td>§ 438.7(a), § 438.7(d) <br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Section 1. Item 1.B.v. of the Medicaid Managed Care Rate Development Guide</a></td>
+                            <td>For all "contract action and rate certification" submissions. All rate certifications must be accompanied by an index and this index should also follow the structure of the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank" rel="noreferrer">Rate Development Guide</a> from CMS.</td>
+                            <td>§ 438.7(a), § 438.7(d) <br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank" rel="noreferrer">Section 1. Item 1.B.v. of the Medicaid Managed Care Rate Development Guide</a></td>
                             <td>Rate - supporting</td>
                         </tr>
                         <tr>
                             <td>Accelerated rate review -- rate development summary</td>
-                            <td>In order to receive an accelerated rate review, states must submit a Rate Development Summary that includes all elements listed in the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Rate Development Guide</a> from CMS.</td>
+                            <td>In order to receive an accelerated rate review, states must submit a Rate Development Summary that includes all elements listed in the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank" rel="noreferrer">Rate Development Guide</a> from CMS.</td>
                             <td>For all "contract action and rate certification" submissions where states elect to use the accelerated rate review process.</td>
-                            <td>§ 438.7(d)<br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Appendix A of the Medicaid Managed Care Rate Development Guide</a></td>
+                            <td>§ 438.7(d)<br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank" rel="noreferrer">Appendix A of the Medicaid Managed Care Rate Development Guide</a></td>
                             <td>Rate-supporting</td>
                         </tr>
                         <tr>

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -189,10 +189,10 @@ export const Help = (): React.ReactElement => {
                 </Table>
             </section>
             <section className={styles.helpSection}>
-                <h3 id="documents-definitions-and-requirements">
+                <h3 id="document-definitions-requirements">
                     Documents definitions and requirements
                 </h3>
-                <h4 id="key-docyments">Key documents</h4>
+                <h4 id="key-documents">Key documents</h4>
                 <Table bordered fixed fullWidth>
                     <thead>
                         <tr>

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -207,21 +207,21 @@ export const Help = (): React.ReactElement => {
                         <tr>
                             <td>Base contract</td>
                             <td>The final language agreed to by all parties.</td>
-                            <td>For all "base contract" "contract action" submissions</td>
+                            <td>For all "base contract" "contract action" submissions.</td>
                             <td>Medicaid: § 438.3(a)<br/><br/>CHIP: § 457.1201</td>
                             <td>Contract</td>
                         </tr>
                         <tr>
                             <td>Contract amendment</td>
                             <td>The final language agreed to by all parties for a change to the base contract</td>
-                            <td>For all "amendment to base contract" submissions</td>
+                            <td>For all "amendment to base contract" submissions.</td>
                             <td>Medicaid: § 438.3(a)<br/><br/>CHIP: § 457.1201</td>
                             <td>Contract</td>
                         </tr>
                         <tr>
                             <td>Contract appendix</td>
-                            <td>All appendices and attachments to the contract document. <br/><br/>Please note: Adding a new appendix during the course of a contract period requires an executed "amendment to base contract" submission</td>
-                            <td>For all "base contract" and "amendment to base contract" submissions</td>
+                            <td>All appendices and attachments to the contract document. <br/><br/>Please note: Adding a new appendix during the course of a contract period requires an executed "amendment to base contract" submission.</td>
+                            <td>For all "base contract" and "amendment to base contract" submissions.</td>
                             <td>
                                 <a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank">11.8.2019 CMCS Informational Bulletin</a>
                             </td>
@@ -229,10 +229,94 @@ export const Help = (): React.ReactElement => {
                         </tr>
                         <tr>
                             <td>Rate certification</td>
-                            <td>The actuary’s certification of the rates or rate ranges, along with the report from the actuary describing the development of the rates or rate ranges</td>
-                            <td>For all "contract action and rate certification" submissions</td>
+                            <td>The actuary’s certification of the rates or rate ranges, along with the report from the actuary describing the development of the rates or rate ranges.</td>
+                            <td>For all "contract action and rate certification" submissions.</td>
                             <td>Medicaid: § 438.7</td>
                             <td>Rate certification</td>
+                        </tr>
+                    </tbody>
+                </Table>
+                <h4 id="supporting-documents">Supporting documents</h4>
+                <Table bordered fixed fullWidth>
+                    <thead>
+                        <tr>
+                            <th>Document type</th>
+                            <th>Definition</th>
+                            <th>Required</th>
+                            <th>Regulatory reference</th>
+                            <th>MC-Review category</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Signature pages</td>
+                            <td>Contract pages that are signed and dated by all parties. <br/><br/>These can be part of the base contract/contract amendment document, or can be attached separately.</td>
+                            <td>For all submissions</td>
+                            <td>Medicaid: § 438.3(a) <br/><br/>CHIP:§ 457.1201</td>
+                            <td>Contract - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Redlined contract changes/Contract change document</td>
+                            <td>States who have significant changes between one contract verison and the next will sometimes submit redlined or contract change documents to CMS in order to clearly outline the changes between each version.</td>
+                            <td>Optional</td>
+                            <td><a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank">11.8.2019 CMCS Informational Bulletin</a></td>
+                            <td>Contract - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Readiness review results</td>
+                            <td>The state's assessment of the ability and capacity of the managed care plan to satisfactorily perform operations/administration, service delivery, and financial management functions per 42 CFR 438.66(d)(4)(i) - (iii)</td>
+                            <td>For all "contract action" submissions where a state implements in Medicaid 1) a new managed care program, 2) a new managed care plan not previously contracted with the state, or 3) the provision of covered benefits to new eligibility groups.</td>
+                            <td>Medicaid: § 438.66(d)(2)(iii)</td>
+                            <td>Contract - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>MH/SUD Parity Analysis</td>
+                            <td>Mental Health Parity and Addiction Equity Act of 2008 (MHPAEA) is a federal law that generally prevents group health plans and health insurance issuers that provide mental health or substance use disorder (MH/SUD) benefits from imposing less favorable benefit limitations on those benefits than on medical/surgical benefits. This analysis supports the parity of those benefits.</td>
+                            <td>For all "contract action" submissions where a state provides any services to MCO enrollees using a delivery system other than the MCO and 1) a change in benefits provided by the MCO, PIHP, PAHP or FFS is occurring or 2) the State is contracting with a new MCO(s).</td>
+                            <td>Medicaid: § 438.3(n)(2), § 438.920 <br/><br/>CHIP: § 457.496(f), § 457.1201(l) </td>
+                            <td>Contract - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Rate development index</td>
+                            <td>The rate certification must include an index that identifies the page number or the section number for each item described within this guidance. In cases where not all sections of this guidance are relevant for a particular rate certification (i.e., a rate amendment that adds a new benefit for part of the year), inapplicable sections of the guidance must be included and marked as “Not Applicable” in the index.</td>
+                            <td>For all "contract action and rate certification" submissions. All rate certifications must be accompanied by an index and this index should also follow the structure of the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Rate Development Guide</a> from CMS.</td>
+                            <td>§ 438.7(a), § 438.7(d) <br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Section 1. Item 1.B.v. of the Medicaid Managed Care Rate Development Guide</a></td>
+                            <td>Rate - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Accelerated rate review -- rate development summary</td>
+                            <td>In order to receive an accelerated rate review, states must submit a Rate Development Summary that includes all elements listed in the most recent <a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Rate Development Guide</a> from CMS.</td>
+                            <td>For all "contract action and rate certification" submissions where states elect to use the accelerated rate review process.</td>
+                            <td>§ 438.7(d)<br /><br /><a href="https://www.medicaid.gov/medicaid/managed-care/downloads/2021-2022-medicaid-rate-guide-11102021.pdf" target="_blank">Appendix A of the Medicaid Managed Care Rate Development Guide</a></td>
+                            <td>Rate-supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Rate appendix/exhibit</td>
+                            <td>Supplementary material related to a rate certification.<br /><br />Appendices can be included within the rate certification itself or submitted as separate documents.</td>
+                            <td>For all "contract action and rate certification" submissions. All documents attached to a rate certification must be submitted. </td>
+                            <td>§ 438.7(a)</td>
+                            <td>Rate-supporting</td>
+                        </tr>
+                        <tr>
+                            <td>MLR report</td>
+                            <td>The Affordable Care Act requires health insurance issuers to submit data on the proportion of premium revenues spent on clinical services and quality improvement, also known as the Medical Loss Ratio (MLR).</td>
+                            <td>For all "contract action and rate certification" submissions where states implement capitation rates for the state’s annual rating period.</td>
+                            <td>Medicaid: § 438.74(a) <br /><br />CHIP: § 457.1203(e) </td>
+                            <td>Rate - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Other contract documentation</td>
+                            <td>A document that relates to the contract action, but is not described by the other available document types.</td>
+                            <td>Optional</td>
+                            <td>Medicaid: § 438.3(a) <br /><br />CHIP: § 457.1201</td>
+                            <td>Contract - supporting</td>
+                        </tr>
+                        <tr>
+                            <td>Other Rate Documentation</td>
+                            <td>A document that relates to the rate certification, but is not described by the other available document types.</td>
+                            <td>Optional</td>
+                            <td>§ 438.7(a)</td>
+                            <td>Rate -supporting</td>
                         </tr>
                     </tbody>
                 </Table>

--- a/services/app-web/src/pages/Help/Help.tsx
+++ b/services/app-web/src/pages/Help/Help.tsx
@@ -188,6 +188,55 @@ export const Help = (): React.ReactElement => {
                     </tbody>
                 </Table>
             </section>
+            <section className={styles.helpSection}>
+                <h3 id="documents-definitions-and-requirements">
+                    Documents definitions and requirements
+                </h3>
+                <h4 id="key-docyments">Key documents</h4>
+                <Table bordered fixed fullWidth>
+                    <thead>
+                        <tr>
+                            <th>Document type</th>
+                            <th>Definition</th>
+                            <th>Required</th>
+                            <th>Regulatory reference</th>
+                            <th>MC-Review category</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Base contract</td>
+                            <td>The final language agreed to by all parties.</td>
+                            <td>For all "base contract" "contract action" submissions</td>
+                            <td>Medicaid: § 438.3(a)<br/><br/>CHIP: § 457.1201</td>
+                            <td>Contract</td>
+                        </tr>
+                        <tr>
+                            <td>Contract amendment</td>
+                            <td>The final language agreed to by all parties for a change to the base contract</td>
+                            <td>For all "amendment to base contract" submissions</td>
+                            <td>Medicaid: § 438.3(a)<br/><br/>CHIP: § 457.1201</td>
+                            <td>Contract</td>
+                        </tr>
+                        <tr>
+                            <td>Contract appendix</td>
+                            <td>All appendices and attachments to the contract document. <br/><br/>Please note: Adding a new appendix during the course of a contract period requires an executed "amendment to base contract" submission</td>
+                            <td>For all "base contract" and "amendment to base contract" submissions</td>
+                            <td>
+                                <a href="https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf" target="_blank">11.8.2019 CMCS Informational Bulletin</a>
+                            </td>
+                            <td>Contract</td>
+                        </tr>
+                        <tr>
+                            <td>Rate certification</td>
+                            <td>The actuary’s certification of the rates or rate ranges, along with the report from the actuary describing the development of the rates or rate ranges</td>
+                            <td>For all "contract action and rate certification" submissions</td>
+                            <td>Medicaid: § 438.7</td>
+                            <td>Rate certification</td>
+                        </tr>
+                    </tbody>
+                </Table>
+            </section>
         </GridContainer>
     )
 }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -408,7 +408,7 @@ export const ContractDetails = ({
                                             <Link
                                                 aria-label="Document definitions and requirements (opens in new window)"
                                                 href={
-                                                    '/help#document-definitions-requirements'
+                                                    '/help#key-documents'
                                                 }
                                                 variant="external"
                                                 target="_blank"

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
@@ -84,7 +84,7 @@ describe('Documents', () => {
             }
         )
 
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         expect(input).toBeInTheDocument()
         expect(input).toHaveAttribute(
             'accept',
@@ -135,27 +135,6 @@ describe('Documents', () => {
         })
     })
 
-    it('show correct hint text', () => {
-        const mockUpdateDraftFn = jest.fn()
-        renderWithProviders(
-            <Documents
-                draftSubmission={{
-                    ...mockDraft(),
-                    submissionType: 'CONTRACT_ONLY',
-                }}
-                updateDraft={mockUpdateDraftFn}
-            />,
-            {
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
-            }
-        )
-        expect(screen.queryByTestId('documents-hint')).toHaveTextContent(
-            'Upload and categorize any additional supporting documents'
-        )
-    })
-
     it('error is shown in input when invalid file types dropped', async () => {
         const mockUpdateDraftFn = jest.fn()
         renderWithProviders(
@@ -204,7 +183,7 @@ describe('Documents', () => {
                 },
             }
         )
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         userEvent.upload(input, [TEST_DOC_FILE])
         userEvent.upload(input, [TEST_PDF_FILE])
         userEvent.upload(input, [TEST_DOC_FILE])
@@ -231,7 +210,7 @@ describe('Documents', () => {
                 },
             }
         )
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
 
         userEvent.upload(input, [TEST_XLS_FILE])
 
@@ -284,7 +263,7 @@ describe('Documents', () => {
                 },
             }
         )
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         userEvent.upload(input, [TEST_DOC_FILE])
         userEvent.upload(input, [TEST_PDF_FILE])
         userEvent.upload(input, [TEST_DOC_FILE])
@@ -322,7 +301,7 @@ describe('Documents', () => {
             const continueButton = screen.getByRole('button', {
                 name: 'Continue',
             })
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
 
             userEvent.upload(input, [TEST_DOC_FILE])
 
@@ -351,7 +330,7 @@ describe('Documents', () => {
             const continueButton = screen.getByRole('button', {
                 name: 'Continue',
             })
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
             const targetEl = screen.getByTestId('file-input-droptarget')
 
             userEvent.upload(input, [TEST_DOC_FILE])
@@ -381,7 +360,7 @@ describe('Documents', () => {
                     },
                 }
             )
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
             const saveAsDraftButton = screen.getByRole('button', {
                 name: 'Save as draft',
             })
@@ -452,7 +431,7 @@ describe('Documents', () => {
                 name: 'Continue',
             })
 
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
             const targetEl = screen.getByTestId('file-input-droptarget')
 
             userEvent.upload(input, [TEST_DOC_FILE])
@@ -541,7 +520,7 @@ describe('Documents', () => {
             const saveAsDraftButton = screen.getByRole('button', {
                 name: 'Save as draft',
             })
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
 
             userEvent.upload(input, [TEST_DOC_FILE])
 
@@ -570,7 +549,7 @@ describe('Documents', () => {
             const saveAsDraftButton = screen.getByRole('button', {
                 name: 'Save as draft',
             })
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
             const targetEl = screen.getByTestId('file-input-droptarget')
 
             userEvent.upload(input, [TEST_DOC_FILE])
@@ -625,7 +604,7 @@ describe('Documents', () => {
                     },
                 }
             )
-            const input = screen.getByLabelText('Upload supporting documents')
+            const input = screen.getByLabelText('Upload any additional supporting documents')
             const saveAsDraftButton = screen.getByRole('button', {
                 name: 'Save as draft',
             })
@@ -669,7 +648,7 @@ describe('Back button', () => {
         const backButton = screen.getByRole('button', {
             name: 'Back',
         })
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
 
         userEvent.upload(input, [TEST_DOC_FILE])
 
@@ -698,7 +677,7 @@ describe('Back button', () => {
         const backButton = screen.getByRole('button', {
             name: 'Back',
         })
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         const targetEl = screen.getByTestId('file-input-droptarget')
 
         userEvent.upload(input, [TEST_DOC_FILE])
@@ -754,7 +733,7 @@ describe('Back button', () => {
                 },
             }
         )
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         const backButton = screen.getByRole('button', {
             name: 'Back',
         })

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
@@ -63,7 +63,7 @@ describe('Documents', () => {
             }
         )
 
-        const input = screen.getByLabelText('Upload supporting documents')
+        const input = screen.getByLabelText('Upload any additionalsupporting documents')
         expect(input).toBeInTheDocument()
         userEvent.upload(input, [TEST_DOC_FILE])
 

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
@@ -63,7 +63,7 @@ describe('Documents', () => {
             }
         )
 
-        const input = screen.getByLabelText('Upload any additionalsupporting documents')
+        const input = screen.getByLabelText('Upload any additional supporting documents')
         expect(input).toBeInTheDocument()
         userEvent.upload(input, [TEST_DOC_FILE])
 

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -234,7 +234,7 @@ export const Documents = ({
                     <FileUpload
                         id="documents"
                         name="documents"
-                        label="Upload and categorize any additional
+                        label="Upload any additional
                         supporting documents"
                         hint={
                             <>

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -234,8 +234,7 @@ export const Documents = ({
                     <FileUpload
                         id="documents"
                         name="documents"
-                        label="Upload any additional
-                        supporting documents"
+                        label="Upload any additional supporting documents"
                         hint={
                             <>
                                 <Link

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -234,30 +234,20 @@ export const Documents = ({
                     <FileUpload
                         id="documents"
                         name="documents"
-                        label="Upload supporting documents"
-                        isLabelVisible={false}
+                        label="Upload and categorize any additional
+                        supporting documents"
                         hint={
                             <>
                                 <Link
                                     aria-label="Document definitions and requirements (opens in new window)"
                                     href={
-                                        'https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf'
+                                        '/help#supporting-documents'
                                     }
                                     variant="external"
                                     target="_blank"
                                 >
                                     Document definitions and requirements
                                 </Link>
-
-                                <p
-                                    data-testid="documents-hint"
-                                    className="text-base-darker"
-                                >
-                                    <strong>
-                                        Upload and categorize any additional
-                                        supporting documents
-                                    </strong>
-                                </p>
                                 <span className="srOnly">
                                     This input only accepts PDF, CSV, DOC, DOCX,
                                     XLS, XLSX files.

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -351,7 +351,7 @@ export const RateDetails = ({
                                                 <Link
                                                     aria-label="Document definitions and requirements (opens in new window)"
                                                     href={
-                                                        'https://www.medicaid.gov/federal-policy-guidance/downloads/cib110819.pdf'
+                                                        '/help#key-documents'
                                                     }
                                                     variant="external"
                                                     target="_blank"

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
@@ -184,7 +184,7 @@ describe('StateSubmissionForm', () => {
 
             await waitFor(() => {
                 expect(
-                    screen.getByText('Upload supporting documents')
+                    screen.getByText('Upload any additional supporting documents')
                 ).toBeInTheDocument()
                 expect(screen.getByTestId('file-input')).toBeInTheDocument()
             })


### PR DESCRIPTION
Adding the documents definitions and requirements table to the help page along with links on contract details, rate details, and supporting documents pages.
