### PR TITLE
Announce selected file count (#10541)

### DIFF
--- a/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
+++ b/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
@@ -120,16 +120,27 @@ export const FileItem = ({
         retryItem(item)
     }
 
+    let statusValue = "";
+    if (isLoading) {
+        statusValue = "uploading";
+    } else if (isScanning) {
+        statusValue = "scanning for viruses"
+    } else if (hasDuplicateNameError || hasScanningError || hasUploadError || hasUnexpectedError) {
+        statusValue = "error"
+    }
+
     return (
         <>
             <div className={styles.fileItemText}>
-                <img
-                    id={item.id}
-                    data-testid="file-input-preview-image"
-                    src={SPACER_GIF}
-                    alt=""
-                    className={imageClasses}
-                />
+                <div role="progressbar" aria-valuetext={statusValue} aria-label={`Status of file ${name}`}>
+                    <img
+                        id={item.id}
+                        data-testid="file-input-preview-image"
+                        src={SPACER_GIF}
+                        alt=""
+                        className={imageClasses}
+                    />
+                </div>
                 <span
                     style={{
                         display: 'flex',

--- a/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
+++ b/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
@@ -12,13 +12,19 @@ exports[`FileItemList component renders correctly 1`] = `
     <div
       className="fileItemText"
     >
-      <img
-        alt=""
-        className="usa-file-input__preview-image is-loading usa-file-input__preview-image--pdf"
-        data-testid="file-input-preview-image"
-        id="testFile"
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      />
+      <div
+        aria-label="Status of file testFile.pdf"
+        aria-valuetext="uploading"
+        role="progressbar"
+      >
+        <img
+          alt=""
+          className="usa-file-input__preview-image is-loading usa-file-input__preview-image--pdf"
+          data-testid="file-input-preview-image"
+          id="testFile"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
+      </div>
       <span
         style={
           Object {
@@ -58,13 +64,19 @@ exports[`FileItemList component renders correctly 1`] = `
     <div
       className="fileItemText"
     >
-      <img
-        alt=""
-        className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
-        data-testid="file-input-preview-image"
-        id="testFile2"
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      />
+      <div
+        aria-label="Status of file testFile2.pdf"
+        aria-valuetext="error"
+        role="progressbar"
+      >
+        <img
+          alt=""
+          className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
+          data-testid="file-input-preview-image"
+          id="testFile2"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
+      </div>
       <span
         style={
           Object {
@@ -117,13 +129,19 @@ exports[`FileItemList component renders correctly 1`] = `
     <div
       className="fileItemText"
     >
-      <img
-        alt=""
-        className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
-        data-testid="file-input-preview-image"
-        id="testFile3"
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      />
+      <div
+        aria-label="Status of file testFile3.pdf"
+        aria-valuetext="error"
+        role="progressbar"
+      >
+        <img
+          alt=""
+          className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
+          data-testid="file-input-preview-image"
+          id="testFile3"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
+      </div>
       <span
         style={
           Object {
@@ -171,13 +189,19 @@ exports[`FileItemList component renders correctly 1`] = `
     <div
       className="fileItemText"
     >
-      <img
-        alt=""
-        className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
-        data-testid="file-input-preview-image"
-        id="testFile4"
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      />
+      <div
+        aria-label="Status of file testFile4.pdf"
+        aria-valuetext=""
+        role="progressbar"
+      >
+        <img
+          alt=""
+          className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
+          data-testid="file-input-preview-image"
+          id="testFile4"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
+      </div>
       <span
         style={
           Object {
@@ -212,13 +236,19 @@ exports[`FileItemList component renders correctly 1`] = `
     <div
       className="fileItemText"
     >
-      <img
-        alt=""
-        className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
-        data-testid="file-input-preview-image"
-        id="testFile44"
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-      />
+      <div
+        aria-label="Status of file testFile4.pdf"
+        aria-valuetext="error"
+        role="progressbar"
+      >
+        <img
+          alt=""
+          className="usa-file-input__preview-image usa-file-input__preview-image--pdf"
+          data-testid="file-input-preview-image"
+          id="testFile44"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+        />
+      </div>
       <span
         style={
           Object {

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -310,7 +310,7 @@ export const FileUpload = ({
         addFilesAndUpdateList(files)
     }
 
-    const summary = `${fileItems.length} file${fileItems.length !== 1 ? 's' : ''} selected`
+    const summary = `${fileItems.length} file${fileItems.length !== 1 ? 's' : ''} added`
 
     return (
         <FormGroup className="margin-top-0">

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -56,6 +56,8 @@ export const FileUpload = ({
 }: FileUploadProps): React.ReactElement => {
     const [fileItems, setFileItems] = useState<FileItemT[]>(initialItems || [])
     const fileInputRef = useRef<FileInputRef>(null) // reference to the HTML input which has files
+    const summaryRef = useRef<HTMLHeadingElement>(null) // reference to the heading that we will focus
+
     const inputRequired = inputProps['aria-required'] || inputProps.required
     // update fileItems in parent
     React.useEffect(() => {
@@ -145,6 +147,10 @@ export const FileUpload = ({
         setFileItems((prevItems) => {
             return refreshItems(prevItems, deletedItem)
         })
+
+        if (summaryRef.current) {
+            summaryRef.current.focus();
+        }
     }
     // Upload to S3 and update file items in component state with the async loading status
     // This includes moving from pending/loading UI to display success or errors
@@ -282,6 +288,12 @@ export const FileUpload = ({
         if (fileInputRef.current?.input) {
             fileInputRef.current.input.value = ''
         }
+
+        setTimeout(function(){
+            if (summaryRef.current) {
+                summaryRef.current.focus();
+            }
+        }, 200)
     }
 
     const handleOnDrop = (e: React.DragEvent): void => {
@@ -298,10 +310,12 @@ export const FileUpload = ({
         addFilesAndUpdateList(files)
     }
 
+    const summary = `${fileItems.length} file${fileItems.length !== 1 ? 's' : ''} selected`
+
     return (
         <FormGroup className="margin-top-0">
             <Label className={isLabelVisible ? '' : 'srOnly'} htmlFor={id}>
-                {label}
+                Select a file
             </Label>
 
             {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
@@ -314,6 +328,9 @@ export const FileUpload = ({
                     {hint}
                 </span>
             )}
+
+            <h5 tabIndex={-1} ref={summaryRef} className="text-normal font-body-sm margin-0">{summary}</h5>
+
             <FileInput
                 id={id}
                 name={`${name}${inputRequired ? ' (required)' : ''}`}

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -315,7 +315,7 @@ export const FileUpload = ({
     return (
         <FormGroup className="margin-top-0">
             <Label className={isLabelVisible ? '' : 'srOnly'} htmlFor={id}>
-                Select a file
+                {label}
             </Label>
 
             {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}


### PR DESCRIPTION
## Summary

 This PR adds some text to the file upload component that describes how many files have been selected. This text updates automatically, and whenever a new file is added or one is removed, it is auto-focused. This will cause it to be announced by JAWS.

This PR also includes some additional markup to add ARIA roles to the progress display used during file uploads. That work will likely continue.

For more details, see commit messages 😄 

#### Related issues

This PR supersedes #716, which took a different approach to addressing this issue. 

#### Screenshots

https://user-images.githubusercontent.com/3331/148585769-5d6a1bcb-cbe0-492e-acb8-909091ca6fdb.mov

#### Test cases covered

## QA guidance

As you make changes to the file list, the number of file should always be announced.
