### PR TITLE
OY2-13565 make step header h2

### DIFF
--- a/services/app-web/package.json
+++ b/services/app-web/package.json
@@ -64,7 +64,7 @@
     },
     "dependencies": {
         "@apollo/client": "^3.4.15",
-        "@trussworks/react-uswds": "^2.2.0",
+        "@trussworks/react-uswds": "^2.6.0",
         "@types/classnames": "^2.2.11",
         "@types/jest": "^27.0.1",
         "@types/react": "^17.0.5",

--- a/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.test.tsx
+++ b/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.test.tsx
@@ -11,7 +11,7 @@ describe('DynamicStepIndicator', () => {
                 currentFormPage={STATE_SUBMISSION_FORM_ROUTES[2]}
             />
         )
-
+        expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
         const steps = screen.getAllByRole('listitem')
 
         expect(steps.length).toBe(STATE_SUBMISSION_FORM_ROUTES.length)

--- a/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.tsx
+++ b/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.tsx
@@ -36,7 +36,7 @@ export const DynamicStepIndicator = ({
         })
 
     return (
-        <StepIndicator>
+        <StepIndicator headingLevel="h2">
             {formPagesWithStatus.map((formPage) => {
                 return (
                     <StepIndicatorStep

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
@@ -12,7 +12,7 @@ describe('contacts', () => {
 
             // Navigate to contract details page by clicking back for contract only submission
             cy.findByRole('button', { name: /Back/ }).click()
-            cy.findByRole('heading', { level: 4, name: /Contract details/ })
+            cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
@@ -24,7 +24,7 @@ describe('contacts', () => {
 
             // Navigate to rate details page by clicking back for contract and rates submission
             cy.findByRole('button', { name: /Back/ }).click()
-            cy.findByRole('heading', { level: 4, name: /Rate details/ })
+            cy.findByRole('heading', { level: 2, name: /Rate details/ })
 
             // Navigate to contacts page
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
@@ -11,7 +11,7 @@ describe('contract details', () => {
 
             // Navigate to type page by clicking back
             cy.findByRole('button', { name: /Back/ }).click()
-            cy.findByRole('heading', { level: 4, name: /Submission type/ })
+            cy.findByRole('heading', { level: 2, name: /Submission type/ })
 
             // Navigate to contract details page
             cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
@@ -27,7 +27,7 @@ describe('contract details', () => {
 
             // Navigate to contacts page by clicking continue for contract only submission
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Contacts/ })
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
@@ -39,7 +39,7 @@ describe('contract details', () => {
 
             // Navigate to contacts page by clicking continue for contract and rates submission
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Rate details/ })
+            cy.findByRole('heading', { level: 2, name: /Rate details/ })
         })
     })
 
@@ -51,6 +51,6 @@ describe('contract details', () => {
 
         // Navigate to contacts page by clicking continue for contract only submission
         cy.navigateForm('Continue')
-        cy.findByRole('heading', { level: 4, name: /Contacts/ })
+        cy.findByRole('heading', { level: 2, name: /Contacts/ })
     })
 })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
@@ -37,7 +37,7 @@ describe('documents', () => {
                 .findAllByRole('listitem')
                 .should('have.length', 3)
             cy.navigateForm('Back')
-            cy.findByRole('heading', { level: 4, name: /Contacts/ })
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
             // reload page, see two documents,  duplicate was discarded on Back
             cy.visit(`/submissions/${draftSubmissionID}/documents`)
@@ -99,7 +99,7 @@ describe('documents', () => {
             cy.verifyDocumentsHaveNoErrors()
 
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Review and submit/ })
+            cy.findByRole('heading', { level: 2, name: /Review and submit/ })
         })
     })
 })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -16,6 +16,6 @@ describe('new submission', () => {
 
         // Navigate to contract details page by clicking continue for contract only submission
         cy.navigateForm('Continue')
-        cy.findByRole('heading', { level: 4, name: /Contract details/ })
+        cy.findByRole('heading', { level: 2, name: /Contract details/ })
     })
 })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -12,7 +12,7 @@ describe('rate details', () => {
 
             // Navigate to contract details page by clicking back
             cy.findByRole('button', { name: /Back/ }).click()
-            cy.findByRole('heading', { level: 4, name: /Contract details/ })
+            cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to rate details page
             cy.visit(`/submissions/${draftSubmissionId}/rate-details`)
@@ -28,7 +28,7 @@ describe('rate details', () => {
 
             // Navigate to contacts page by clicking continue
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Contacts/ })
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
         })
     })
 
@@ -47,7 +47,7 @@ describe('rate details', () => {
 
             // Navigate to contacts page by clicking continue
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Contacts/ })
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
         })
     })
 })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -12,7 +12,7 @@ describe('review and submit', () => {
 
             // Navigate to documents page by clicking back
             cy.findByRole('button', { name: /Back/ }).click()
-            cy.findByRole('heading', { level: 4, name: /Supporting documents/ })
+            cy.findByRole('heading', { level: 2, name: /Supporting documents/ })
 
             // Navigate to review and submit page
             cy.visit(`/submissions/${draftSubmissionId}/review-and-submit`)

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -19,7 +19,7 @@ describe('submission type', () => {
 
             // Navigate to contract details page by clicking continue for contract only submission
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Contract details/ })
+            cy.findByRole('heading', { level: 2, name: /Contract details/ })
         })
     })
 
@@ -38,7 +38,7 @@ describe('submission type', () => {
 
             // Navigate to contract details page by clicking continue for contract and rates submission
             cy.navigateForm('Continue')
-            cy.findByRole('heading', { level: 4, name: /Contract details/ })
+            cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to type page
             cy.visit(`/submissions/${draftSubmissionId}/type`)

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -9,7 +9,7 @@ Cypress.Commands.add('startNewContractOnlySubmission', () => {
     cy.fillOutContractActionOnly()
 
     cy.navigateForm('Continue')
-    cy.findByRole('heading', { level: 4, name: /Contract details/ })
+    cy.findByRole('heading', { level: 2, name: /Contract details/ })
 })
 
 Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
@@ -23,7 +23,7 @@ Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
     cy.fillOutContractActionAndRateCertification()
 
     cy.navigateForm('Continue')
-    cy.findByRole('heading', { level: 4, name: /Contract details/ })
+    cy.findByRole('heading', { level: 2, name: /Contract details/ })
 })
 
 Cypress.Commands.add('fillOutContractActionOnly', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,10 +7134,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@trussworks/react-uswds@^2.2.0":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@trussworks/react-uswds/-/react-uswds-2.4.1.tgz#62604c86940492564465286c8214ae22a4bb5e2b"
-  integrity sha512-jjzBV3nVH3ee0UhWJmQr8+5k/bOTQREUWMi0U75dhF6z+kalw20c9yWBA4DlsE6ePu5d55y3ye2Rz7F+4dO+dA==
+"@trussworks/react-uswds@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@trussworks/react-uswds/-/react-uswds-2.6.0.tgz#833bc5ba8b0ec96e161ff3bc0d9c4d8634dbddd1"
+  integrity sha512-5/6UuBvA2jU4rK2KjDigQma8+SB9B8AXXMJcqBkal2dTuKmUNYDFoVdR6txpdRTzFMoLFiCCsc2PhPDJmZQ9bg==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"


### PR DESCRIPTION
## Summary

Closes [13565](https://qmacbis.atlassian.net/browse/OY2-13565)

Small change to use react-uswds's new capability to specify the header level in a step indicator to make sure that our headers progress sequentially.

#### Test cases covered

Added one line to a unit test to check that the passed-in level is what's in the DOM.

## QA guidance

Should look and work exactly the same, but the DOM should have an h2 in the header, and screen readers should not be confused by the app headers.
