### PR TITLE
Add documentCategories to api

### DIFF
--- a/services/app-api/resolvers/fetchStateSubmission.test.ts
+++ b/services/app-api/resolvers/fetchStateSubmission.test.ts
@@ -37,6 +37,7 @@ describe('fetchStateSubmission', () => {
             {
                 name: 'contractDocument.pdf',
                 s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT'],
             },
         ])
         const today = new Date()

--- a/services/app-api/resolvers/updateDraftSubmission.test.ts
+++ b/services/app-api/resolvers/updateDraftSubmission.test.ts
@@ -315,15 +315,23 @@ describe('updateDraftSubmission', () => {
                 {
                     name: 'myfile.pdf',
                     s3URL: 'fakeS3URL',
+                    documentCategories: ['CONTRACT_RELATED'],
                 },
             ],
             contractDocuments: [
                 {
                     name: 'contractDocument.pdf',
                     s3URL: 'fakeS3URL001',
+                    documentCategories: ['CONTRACT'],
                 },
             ],
-            rateDocuments: [],
+            rateDocuments: [
+                {
+                    name: 'rateDocument.pdf',
+                    s3URL: 'fakeS3URL001',
+                    documentCategories: ['RATES'],
+                },
+            ],
             contractType: 'BASE',
             contractDateStart: startDate,
             contractDateEnd: endDate,
@@ -367,6 +375,7 @@ describe('updateDraftSubmission', () => {
             {
                 name: 'myfile.pdf',
                 s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED'],
             },
         ])
 
@@ -374,6 +383,15 @@ describe('updateDraftSubmission', () => {
             {
                 name: 'contractDocument.pdf',
                 s3URL: 'fakeS3URL001',
+                documentCategories: ['CONTRACT'],
+            },
+        ])
+
+        expect(resultDraft1.rateDocuments).toEqual([
+            {
+                name: 'rateDocument.pdf',
+                s3URL: 'fakeS3URL001',
+                documentCategories: ['RATES'],
             },
         ])
 
@@ -384,12 +402,14 @@ describe('updateDraftSubmission', () => {
             submissionDescription: 'An updated submission',
             documents: [
                 {
-                    name: 'myfile2.pdf',
+                    name: 'addendum.pdf',
                     s3URL: 'fakeS3URL',
+                    documentCategories: ['CONTRACT_RELATED', 'RATES_RELATED'],
                 },
                 {
                     name: 'myfile3.pdf',
                     s3URL: 'fakeS3URL',
+                    documentCategories: ['CONTRACT_RELATED'],
                 },
             ],
             contractType: 'BASE',
@@ -397,15 +417,28 @@ describe('updateDraftSubmission', () => {
                 {
                     name: 'contractDocument2.pdf',
                     s3URL: 'fakeS3URL002',
+                    documentCategories: ['CONTRACT'],
                 },
                 {
                     name: 'contractDocument3.pdf',
                     s3URL: 'fakeS3URL003',
+                    documentCategories: ['CONTRACT'],
                 },
             ],
             contractDateStart: resultDraft1.contractDateStart,
             contractDateEnd: resultDraft1.contractDateEnd,
-            rateDocuments: [],
+            rateDocuments: [
+                {
+                    name: 'rateDocumentUpdated.pdf',
+                    s3URL: 'fakeS3URL003',
+                    documentCategories: ['RATES'],
+                },
+                {
+                    name: 'rateDocumentUpdated2.pdf',
+                    s3URL: 'fakeS3URL003',
+                    documentCategories: ['RATES'],
+                },
+            ],
             managedCareEntities: [],
             federalAuthorities: [],
             stateContacts: [
@@ -446,7 +479,17 @@ describe('updateDraftSubmission', () => {
 
         expect(updateResult2.errors).toBeUndefined()
         expect(resultDraft2.documents.length).toEqual(2)
-        expect(resultDraft2.documents[0].name).toEqual('myfile2.pdf')
+        expect(resultDraft2.documents[0].name).toEqual('addendum.pdf')
+
+        expect(resultDraft2.contractDocuments.length).toEqual(2)
+        expect(resultDraft2.contractDocuments[0].name).toEqual(
+            'contractDocument2.pdf'
+        )
+
+        expect(resultDraft2.rateDocuments.length).toEqual(2)
+        expect(resultDraft2.rateDocuments[0].name).toEqual(
+            'rateDocumentUpdated.pdf'
+        )
     })
 
     it('updates a submission to have state contacts', async () => {
@@ -803,12 +846,14 @@ describe('updateDraftSubmission', () => {
                 {
                     name: 'myfile.pdf',
                     s3URL: 'fakeS3URL',
+                    documentCategories: ['RATES_RELATED'],
                 },
             ],
             contractDocuments: [
                 {
                     name: 'myContractDocument.pdf',
                     s3URL: 'fakeS3URL001',
+                    documentCategories: ['CONTRACT'],
                 },
             ],
             stateContacts: [
@@ -851,6 +896,7 @@ describe('updateDraftSubmission', () => {
             {
                 name: 'myfile.pdf',
                 s3URL: 'fakeS3URL',
+                documentCategories:[ 'RATES_RELATED'],
             },
         ])
 

--- a/services/app-api/testHelpers/gqlHelpers.ts
+++ b/services/app-api/testHelpers/gqlHelpers.ts
@@ -153,6 +153,7 @@ const createAndUpdateTestDraftSubmission = async (
             {
                 name: 'contractDocument.pdf',
                 s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT' as const],
             },
         ],
         managedCareEntities: ['MCO'],
@@ -165,6 +166,7 @@ const createAndUpdateTestDraftSubmission = async (
             {
                 name: 'rateDocument.pdf',
                 s3URL: 'fakeS3URL',
+                documentCategories: ['RATES' as const],
             },
         ],
         ...partialDraftSubmissionUpdates,

--- a/services/app-graphql/src/mutations/createDraftSubmission.graphql
+++ b/services/app-graphql/src/mutations/createDraftSubmission.graphql
@@ -29,11 +29,13 @@ mutation createDraftSubmission($input: CreateDraftSubmissionInput!) {
             documents {
                 name
                 s3URL
+                documentCategories
             }
             contractType
             contractDocuments {
                 name
                 s3URL
+                documentCategories
             }
             contractDateStart
             contractDateEnd
@@ -53,6 +55,7 @@ mutation createDraftSubmission($input: CreateDraftSubmissionInput!) {
             rateDocuments {
                 name
                 s3URL
+                documentCategories
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/mutations/submitDraftSubmission.graphql
+++ b/services/app-graphql/src/mutations/submitDraftSubmission.graphql
@@ -30,11 +30,13 @@ mutation submitDraftSubmission($input: SubmitDraftSubmissionInput!) {
             documents {
                 name
                 s3URL
+                documentCategories
             }
             contractType
             contractDocuments {
                 name
                 s3URL
+                documentCategories
             }
             contractDateStart
             contractDateEnd
@@ -54,6 +56,7 @@ mutation submitDraftSubmission($input: SubmitDraftSubmissionInput!) {
             rateDocuments {
                 name
                 s3URL
+                documentCategories
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/mutations/updateDraftSubmission.graphql
+++ b/services/app-graphql/src/mutations/updateDraftSubmission.graphql
@@ -29,11 +29,13 @@ mutation updateDraftSubmission($input: UpdateDraftSubmissionInput!) {
             documents {
                 name
                 s3URL
+                documentCategories
             }
             contractType
             contractDocuments {
                 name
                 s3URL
+                documentCategories
             }
             contractDateStart
             contractDateEnd
@@ -53,6 +55,7 @@ mutation updateDraftSubmission($input: UpdateDraftSubmissionInput!) {
             rateDocuments {
                 name
                 s3URL
+                documentCategories
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/queries/fetchDraftSubmission.graphql
+++ b/services/app-graphql/src/queries/fetchDraftSubmission.graphql
@@ -29,11 +29,13 @@ query fetchDraftSubmission($input: FetchDraftSubmissionInput!) {
             documents {
                 name
                 s3URL
+                documentCategories
             }
             contractType
             contractDocuments {
                 name
                 s3URL
+                documentCategories
             }
             contractDateStart
             contractDateEnd
@@ -53,6 +55,7 @@ query fetchDraftSubmission($input: FetchDraftSubmissionInput!) {
             rateDocuments {
                 name
                 s3URL
+                documentCategories
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/queries/fetchStateSubmission.graphql
+++ b/services/app-graphql/src/queries/fetchStateSubmission.graphql
@@ -30,11 +30,13 @@ query fetchStateSubmission($input: FetchStateSubmissionInput!) {
             documents {
                 name
                 s3URL
+                documentCategories
             }
             contractType
             contractDocuments {
                 name
                 s3URL
+                documentCategories
             }
             contractDateStart
             contractDateEnd
@@ -54,6 +56,7 @@ query fetchStateSubmission($input: FetchStateSubmissionInput!) {
             rateDocuments {
                 name
                 s3URL
+                documentCategories
             }
             rateDateStart
             rateDateEnd

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -150,14 +150,23 @@ enum ActuaryCommunicationType {
     OACT_TO_STATE
 }
 
+enum DocumentCategory {
+    CONTRACT
+    RATES
+    CONTRACT_RELATED
+    RATES_RELATED
+}
+
 type Document {
     name: String!
     s3URL: String!
+    documentCategories: [DocumentCategory!]!
 }
 
 input DocumentInput {
     name: String!
     s3URL: String!
+    documentCategories: [DocumentCategory!]!
 }
 
 type CapitationRatesAmendedInfo {

--- a/services/app-proto/src/state_submission.proto
+++ b/services/app-proto/src/state_submission.proto
@@ -190,9 +190,19 @@ enum ActuarialFirmType {
 
     
 /// Generic sub types
+enum DocumentCategory {
+  DOCUMENT_CATEGORY_UNSPECIFIED = 0;
+  DOCUMENT_CATEGORY_CONTRACT = 1;
+  DOCUMENT_CATEGORY_RATES = 2;
+  DOCUMENT_CATEGORY_CONTRACT_RELATED = 3;
+  DOCUMENT_CATEGORY_RATES_RELATED = 4;
+}
+
+
 message Document {
   optional string name = 1;
   optional string s3_url = 2;
+  repeated DocumentCategory document_categories = 3;
 }
 
 enum StateCode {

--- a/services/app-web/src/common-code/domain-models/DraftSubmissionType.d.ts
+++ b/services/app-web/src/common-code/domain-models/DraftSubmissionType.d.ts
@@ -3,9 +3,17 @@
 // GQL SCHEMA MATCHED TYPES
 type SubmissionType = 'CONTRACT_ONLY' | 'CONTRACT_AND_RATES'
 export type CapitationRatesAmendedReason = 'ANNUAL' | 'MIDYEAR' | 'OTHER'
+
+type DocumentCategoryType =
+    | 'CONTRACT'
+    | 'RATES'
+    | 'CONTRACT_RELATED'
+    | 'RATES_RELATED'
+
 type SubmissionDocument = {
     name: string
     s3URL: string
+    documentCategories: DocumentCategoryType[]
 }
 
 type ContractAmendmentInfo = {
@@ -109,6 +117,7 @@ export type DraftSubmissionType = {
 }
 
 export type {
+    DocumentCategoryType,
     SubmissionType,
     SubmissionDocument,
     RateType,

--- a/services/app-web/src/common-code/domain-models/index.ts
+++ b/services/app-web/src/common-code/domain-models/index.ts
@@ -12,6 +12,7 @@ export type {
 } from './cognitoUserType'
 
 export type {
+    DocumentCategoryType,
     DraftSubmissionType,
     SubmissionType,
     SubmissionDocument,

--- a/services/app-web/src/common-code/proto/stateSubmission/draftSubmissionSchema.ts
+++ b/services/app-web/src/common-code/proto/stateSubmission/draftSubmissionSchema.ts
@@ -20,6 +20,16 @@ export const capitationRatesAmendedReasonSchema = z.union([
 const submissionDocumentSchema = z.object({
     name: z.string(),
     s3URL: z.string(),
+    documentCategories: z.array(
+        z
+            .union([
+                z.literal('CONTRACT'),
+                z.literal('RATES'),
+                z.literal('CONTRACT_RELATED'),
+                z.literal('RATES_RELATED'),
+            ])
+            .optional()
+    ),
 })
 
 const contractAmendmentInfoSchema = z.object({

--- a/services/app-web/src/common-code/proto/stateSubmission/stateSubmissionEncoding.test.ts
+++ b/services/app-web/src/common-code/proto/stateSubmission/stateSubmissionEncoding.test.ts
@@ -131,17 +131,25 @@ const nowWithDocuments: DraftSubmissionType = {
     documents: [
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT_RELATED'],
         },
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc2',
+            name: 'rates and contract addendum doc',
+            documentCategories: ['CONTRACT_RELATED', 'RATES_RELATED'],
         },
     ],
     contractType: 'BASE',
     contractDateStart: new Date(Date.UTC(2021, 4, 22)),
     contractDateEnd: new Date(Date.UTC(2022, 4, 21)),
-    contractDocuments: [],
+    contractDocuments: [
+        {
+            s3URL: 'www.example.com/foo.png',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT'],
+        },
+    ],
     rateDocuments: [],
     managedCareEntities: [],
     federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
@@ -187,11 +195,13 @@ const fullRateAmendment: DraftSubmissionType = {
     documents: [
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT_RELATED'],
         },
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc2',
+            name: 'rates and contract addendum doc',
+            documentCategories: ['CONTRACT_RELATED', 'RATES_RELATED'],
         },
     ],
     contractType: 'BASE',
@@ -252,18 +262,32 @@ const fullContractInfo: DraftSubmissionType = {
     documents: [
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT_RELATED'],
         },
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc2',
+            name: 'rates and contract addendum doc',
+            documentCategories: ['CONTRACT_RELATED', 'RATES_RELATED'],
         },
     ],
     contractType: 'AMENDMENT',
     contractDateStart: new Date(Date.UTC(2021, 4, 22)),
     contractDateEnd: new Date(Date.UTC(2022, 4, 21)),
-    contractDocuments: [],
-    rateDocuments: [],
+    contractDocuments: [
+        {
+            s3URL: 'www.example.com/foo.png',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT'],
+        },
+    ],
+    rateDocuments: [
+        {
+            s3URL: 'www.example.com/foo.png',
+            name: 'Rates certification',
+            documentCategories: ['RATES'],
+        },
+    ],
     contractAmendmentInfo: {
         itemsBeingAmended: [
             'ENROLLEE_ACCESS',
@@ -332,11 +356,8 @@ const someOthers: DraftSubmissionType = {
     documents: [
         {
             s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc',
-        },
-        {
-            s3URL: 'www.example.com/foo.png',
-            name: 'dummy doc2',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT_RELATED'],
         },
     ],
     contractType: 'AMENDMENT',
@@ -363,12 +384,14 @@ const someOthers: DraftSubmissionType = {
     rateType: 'AMENDMENT',
     rateDocuments: [
         {
-            s3URL: 'www.example.com/test.png',
-            name: 'dummy rate doc',
+            s3URL: 'www.example.com/foo.png',
+            name: 'rates cert 1',
+            documentCategories: ['RATES_RELATED'],
         },
         {
-            s3URL: 'www.example.com/test2.png',
-            name: 'dummy rate doc2',
+            s3URL: 'www.example.com/foo.png',
+            name: 'rates cert 2',
+            documentCategories: ['RATES_RELATED'],
         },
     ],
     rateDateStart: new Date(Date.UTC(2021, 4, 22)),
@@ -425,8 +448,9 @@ const basicCompleteLiteral: StateSubmissionType = {
     contractDateEnd: new Date(Date.UTC(2022, 4, 21)),
     contractDocuments: [
         {
-            name: 'test doc',
-            s3URL: 'https://s3.com/test',
+            s3URL: 'www.example.com/foo.png',
+            name: 'contract doc',
+            documentCategories: ['CONTRACT'],
         },
     ],
     managedCareEntities: ['PIHP'],

--- a/services/app-web/src/common-code/proto/stateSubmission/toDomain.ts
+++ b/services/app-web/src/common-code/proto/stateSubmission/toDomain.ts
@@ -3,6 +3,7 @@ import { draftSubmissionTypeSchema } from './draftSubmissionSchema'
 import {
     DraftSubmissionType,
     StateSubmissionType,
+    DocumentCategoryType,
     ActuarialFirmType,
     ContractAmendmentInfo,
     FederalAuthority,
@@ -178,6 +179,10 @@ function parseProtoDocuments(
     return replaceNullsWithUndefineds(docs).map((doc) => ({
         s3URL: doc.s3Url,
         name: doc.name,
+        documentCategories: protoEnumArrayToDomain(
+            statesubmission.DocumentCategory,
+            doc.documentCategories
+        ) as DocumentCategoryType[],
     }))
 }
 

--- a/services/app-web/src/common-code/proto/stateSubmission/toProtoBuffer.ts
+++ b/services/app-web/src/common-code/proto/stateSubmission/toProtoBuffer.ts
@@ -155,6 +155,10 @@ const toProtoBuffer = (
             contractDocuments: domainData.contractDocuments.map((doc) => ({
                 s3Url: doc.s3URL,
                 name: doc.name,
+                documentCategories: domainEnumArrayToProto(
+                    statesubmission.DocumentCategory,
+                    doc.documentCategories
+                ),
             })),
             contractAmendmentInfo: contractAmendmentInfo
                 ? {
@@ -193,6 +197,10 @@ const toProtoBuffer = (
                 rateDocuments: domainData.rateDocuments.map((doc) => ({
                     s3Url: doc.s3URL,
                     name: doc.name,
+                    documentCategories: domainEnumArrayToProto(
+                        statesubmission.DocumentCategory,
+                        doc.documentCategories
+                    ),
                 })),
                 actuaryContacts: domainData.actuaryContacts.map(
                     (actuaryContact) => {
@@ -230,6 +238,10 @@ const toProtoBuffer = (
         documents: domainData.documents.map((doc) => ({
             s3Url: doc.s3URL,
             name: doc.name,
+            documentCategories: domainEnumArrayToProto(
+                statesubmission.DocumentCategory,
+                doc.documentCategories
+            ),
         })),
     }
 

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -679,6 +679,7 @@ describe('ContractDetails', () => {
                     {
                         name: 'aasdf3423af',
                         s3URL: 's3://bucketname/key/fileName',
+                        documentCategories: ['CONTRACT' as const],
                     },
                 ],
             }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.test.tsx
@@ -858,10 +858,12 @@ describe('ContractDetails', () => {
                             {
                                 name: 'testFile.doc',
                                 s3URL: expect.any(String),
+                                documentCategories: ['CONTRACT'],
                             },
                             {
                                 name: 'testFile.pdf',
                                 s3URL: expect.any(String),
+                                documentCategories: ['CONTRACT'],
                             },
                         ],
                     }),

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -32,6 +32,7 @@ import {
     isDateRangeEmpty,
 } from '../../../formHelpers'
 import {
+    Document,
     DraftSubmission,
     ContractType,
     FederalAuthority,
@@ -286,11 +287,12 @@ export const ContractDetails = ({
                     formDataDocuments.push({
                         name: fileItem.name,
                         s3URL: fileItem.s3URL,
+                        documentCategories: ['CONTRACT'],
                     })
                 }
                 return formDataDocuments
             },
-            [] as { name: string; s3URL: string }[]
+            [] as Document[]
         )
 
         const updatedDraft = updatesFromSubmission(draftSubmission)
@@ -369,7 +371,7 @@ export const ContractDetails = ({
                         className={styles.formContainer}
                         id="ContractDetailsForm"
                         aria-label="Contract Details Form"
-                        aria-describedby='form-guidance'
+                        aria-describedby="form-guidance"
                         onSubmit={(e) => {
                             setShouldValidate(true)
                             setFocusErrorSummaryHeading(true)
@@ -379,7 +381,9 @@ export const ContractDetails = ({
                         <fieldset className="usa-fieldset">
                             <legend className="srOnly">Contract Details</legend>
                             {formAlert && formAlert}
-                            <span id="form-guidance">All fields are required</span>
+                            <span id="form-guidance">
+                                All fields are required
+                            </span>
 
                             {shouldValidate && (
                                 <ErrorSummary

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -7,6 +7,7 @@ import styles from '../StateSubmissionForm.module.scss'
 import {
     DraftSubmission,
     UpdateDraftSubmissionInput,
+    Document,
 } from '../../../gen/gqlClient'
 import { useS3 } from '../../../contexts/S3Context'
 import { isS3Error } from '../../../s3'
@@ -184,11 +185,12 @@ export const Documents = ({
                         formDataDocuments.push({
                             name: fileItem.name,
                             s3URL: fileItem.s3URL,
+                            documentCategories: [],
                         })
                     }
                     return formDataDocuments
                 },
-                [] as { name: string; s3URL: string }[]
+                [] as Document[]
             )
 
             const updatedDraft = updatesFromSubmission(draftSubmission)

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -578,6 +578,7 @@ describe('RateDetails', () => {
                     {
                         name: 'aasdf3423af',
                         s3URL: 's3://bucketname/key/fileName',
+                        documentCategories: ['RATES' as const],
                     },
                 ],
                 rateType: null,

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -761,10 +761,12 @@ describe('RateDetails', () => {
                             {
                                 name: 'testFile.doc',
                                 s3URL: expect.any(String),
+                                documentCategories: ['RATES'],
                             },
                             {
                                 name: 'testFile.pdf',
                                 s3URL: expect.any(String),
+                                documentCategories: ['RATES'],
                             },
                         ],
                     }),

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from 'uuid'
 import styles from '../StateSubmissionForm.module.scss'
 
 import {
+    Document,
     DraftSubmission,
     RateType,
     UpdateDraftSubmissionInput,
@@ -82,7 +83,8 @@ export const RateDetails = ({
     // Rate documents state management
     const { deleteFile, getKey, getS3URL, scanFile, uploadFile } = useS3()
     const [fileItems, setFileItems] = React.useState<FileItemT[]>([])
-    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] = React.useState(false)
+    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
+        React.useState(false)
     const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
 
     const hasValidFiles =
@@ -250,11 +252,12 @@ export const RateDetails = ({
                     formDataDocuments.push({
                         name: fileItem.name,
                         s3URL: fileItem.s3URL,
+                        documentCategories: ['RATES'],
                     })
                 }
                 return formDataDocuments
             },
-            [] as { name: string; s3URL: string }[]
+            [] as Document[]
         )
 
         const updatedDraft = updatesFromSubmission(draftSubmission)

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.test.tsx
@@ -248,6 +248,7 @@ describe('StateSubmissionForm', () => {
                 {
                     name: 'somedoc.pdf',
                     s3URL: 's3://bucketName/key',
+                    documentCategories: ['CONTRACT_RELATED'],
                 },
             ]
             const mockSubmission = mockDraft()

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -260,16 +260,34 @@ export function mockStateSubmission(): StateSubmission {
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A submitted submission',
         submittedAt: new Date(),
-        documents: [{ s3URL: 'bar', name: 'foo' }],
+        documents: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+        ],
         contractType: 'BASE',
-        contractDocuments: [{ s3URL: 'bar', name: 'foo' }],
+        contractDocuments: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['CONTRACT' as const],
+            },
+        ],
         contractDateStart: new Date(),
         contractDateEnd: new Date(),
         contractAmendmentInfo: null,
         managedCareEntities: ['ENROLLMENT_PROCESS'],
         federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
         rateType: 'NEW',
-        rateDocuments: [{ s3URL: 'bar', name: 'foo' }],
+        rateDocuments: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['RATES' as const],
+            },
+        ],
         rateDateStart: new Date(),
         rateDateEnd: new Date(),
         rateDateCertified: new Date(),


### PR DESCRIPTION
## Summary
This is the backend work for the document categorization epic 

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-5476

#### Test cases covered

No need test cases added but existing tests edited to handle documents that have `documentCategories`.

## QA guidance
The app should work as before. Silently contract documents are put in the 'CONTRACT' category, rates into 'RATES', and for now supporting documents have an empty array of categories. Eventually this work will be hooked into the frontend via the supporting docs table.
