### PR TITLE
Fix bug in uploading files with commas in name

### DIFF
--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -42,7 +42,7 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
                     contentType: file.type,
-                    contentDisposition: `attachment; filename=${file.name}`,
+                    contentDisposition: `attachment; filename=${`file.name`}`,
                 })
 
                 assertIsS3PutResponse(stored)


### PR DESCRIPTION
## Summary

Uploading files with commas in their names was failing in Chrome.  Some googling led me to the `content-disposition` header, and I'm just wrapping the file name in quotes, which resolves the issue.

Closes [15489](https://qmacbis.atlassian.net/browse/OY2-15489)

#### Screenshots

![image](https://user-images.githubusercontent.com/8964335/149185748-2881c0a9-8167-464f-8cad-df409e05c2e9.png)


#### Test cases covered

No changes

## QA guidance

Meghan confirmed this works on the deployed branch, but feel free to try it out for yourself.
