### PR TITLE
Focus file list when there are file errors (#13946)

### DIFF
--- a/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
+++ b/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
@@ -132,7 +132,7 @@ export const FileItem = ({
     return (
         <>
             <div className={styles.fileItemText}>
-                <div role="progressbar" aria-valuetext={statusValue} aria-label={`Status of file ${name}`}>
+                <div role="progressbar" aria-valuetext={statusValue} aria-label={`File status`}>
                     <img
                         id={item.id}
                         data-testid="file-input-preview-image"

--- a/services/app-web/src/components/FileUpload/FileItemList/FileItemsList.tsx
+++ b/services/app-web/src/components/FileUpload/FileItemList/FileItemsList.tsx
@@ -27,6 +27,8 @@ export const FileItemsList = ({
         <ul
             data-testid="file-input-preview-list"
             className={styles.fileItemsList}
+            id="file-items-list"
+            tabIndex={-1}
         >
             {fileItems.map((item) => (
                 <li

--- a/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
+++ b/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`FileItemList component renders correctly 1`] = `
 <ul
   className="fileItemsList"
   data-testid="file-input-preview-list"
+  id="file-items-list"
+  tabIndex={-1}
 >
   <li
     className="fileItem usa-file-input__preview"
@@ -13,7 +15,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemText"
     >
       <div
-        aria-label="Status of file testFile.pdf"
+        aria-label="File status"
         aria-valuetext="uploading"
         role="progressbar"
       >
@@ -65,7 +67,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemText"
     >
       <div
-        aria-label="Status of file testFile2.pdf"
+        aria-label="File status"
         aria-valuetext="error"
         role="progressbar"
       >
@@ -130,7 +132,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemText"
     >
       <div
-        aria-label="Status of file testFile3.pdf"
+        aria-label="File status"
         aria-valuetext="error"
         role="progressbar"
       >
@@ -190,7 +192,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemText"
     >
       <div
-        aria-label="Status of file testFile4.pdf"
+        aria-label="File status"
         aria-valuetext=""
         role="progressbar"
       >
@@ -237,7 +239,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemText"
     >
       <div
-        aria-label="Status of file testFile4.pdf"
+        aria-label="File status"
         aria-valuetext="error"
         role="progressbar"
       >

--- a/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.stories.tsx
+++ b/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.stories.tsx
@@ -27,3 +27,20 @@ ErrorSummaryMultiple.args = {
         summary: "You must provide a summary"
     }
 }
+
+const ErrorSummaryFocusIdsTemplate : Story<ErrorSummaryProps> = (args) => <>
+  <ErrorSummary {...args} />
+  <label>Title: <input name="title"></input></label>
+  <ul tabIndex={-1} id="list">
+    <li>Item 1</li>
+    <li>Item with error</li>
+  </ul>
+</>
+
+export const ErrorSummaryFocusIds = ErrorSummaryFocusIdsTemplate.bind({})
+ErrorSummaryFocusIds.args = {
+    errors: {
+        title: "You must provide a title",
+        "#list" : "You have errors in your list",
+    }
+}

--- a/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
+++ b/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
@@ -29,9 +29,11 @@ const ErrorSummaryMessage = ({
             href={href}
             className={classnames(styles.message)}
             data-testid="error-summary-message"
+            onClick={(event) => {
                 const fieldElement: HTMLElement | null = document.querySelector(fieldSelector);
             
                 if (fieldElement) {
+                    event.preventDefault();
                     fieldElement.focus();
                 }
             }}

--- a/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
+++ b/services/app-web/src/components/Form/ErrorSummary/ErrorSummary.tsx
@@ -10,15 +10,26 @@ type ErrorSummaryMessageProps = {
 const ErrorSummaryMessage = ({
     errorKey, message
 }: ErrorSummaryMessageProps): React.ReactElement => {
+    let fieldSelector : string;
+    let href: string;
+
+    // Treat keys that begin with # as ids
+    if (errorKey.startsWith("#")) {
+        fieldSelector = errorKey;
+        href = errorKey
+
+    // Otherwise, assume that keys correspond to name attributes and ids
+    } else {
+        href = "#" + errorKey
+        fieldSelector = `[name="${errorKey}"]`;
+    }
+
     return (
         <a
-            href={"#" + errorKey}
+            href={href}
             className={classnames(styles.message)}
             data-testid="error-summary-message"
-            onClick={() => {
-                const fieldElement: HTMLElement | null = document.querySelector(
-                    `[name="${errorKey}"]`
-                );
+                const fieldElement: HTMLElement | null = document.querySelector(fieldSelector);
             
                 if (fieldElement) {
                     fieldElement.focus();
@@ -59,6 +70,11 @@ export type ErrorSummaryProps = {
  *
  * This component relies on the errors object returned by Formik, so it should generally
  * rendered inside of a Formik form context.
+ * 
+ * By default, keys in the errors property are assumed to correspond to the name attribute
+ * of the relevant form inputs. By passing a key that begins with a number sign ("#"),
+ * you can have it treated as an ID. This is useful when you want to focus something that
+ * doesn't have a name attribute when an error message is clicked.
  */
 export const ErrorSummary = ({
     errors, headingRef

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -131,6 +131,9 @@ export const ContractDetails = ({
             : showFileUploadError && !hasValidFiles
             ? ' You must remove all documents with error messages before continuing'
             : undefined
+    const documentsErrorKey =
+        fileItems.length === 0 ? 'documents' : '#file-items-list'
+
     // Error summary state management
     const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
     const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
@@ -386,8 +389,7 @@ export const ContractDetails = ({
                                     errors={
                                         documentsErrorMessage
                                             ? {
-                                                  documents:
-                                                      documentsErrorMessage,
+                                                  [documentsErrorKey]: documentsErrorMessage,
                                                   ...errors,
                                               }
                                             : errors

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
@@ -376,8 +376,10 @@ describe('Documents', () => {
             await waitFor(() => {
                 expect(mockUpdateDraftFn).not.toHaveBeenCalled()
                 expect(
-                    screen.queryByText('Remove files with errors')
-                ).toBeInTheDocument()
+                    screen.getAllByText(
+                        'You must remove all documents with error messages before continuing'
+                    )
+                ).toHaveLength(2) 
             })
         })
 
@@ -620,8 +622,10 @@ describe('Documents', () => {
             await waitFor(() => {
                 expect(mockUpdateDraftFn).not.toHaveBeenCalled()
                 expect(
-                    screen.queryByText('Remove files with errors')
-                ).toBeInTheDocument()
+                    screen.getAllByText(
+                        'You must remove all documents with error messages before continuing'
+                    )
+                ).toHaveLength(2)                
             })
         })
     })

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../components/FileUpload'
 import { updatesFromSubmission } from '../updateSubmissionTransform'
 import { PageActions } from '../PageActions'
+import { ErrorSummary } from '../../../components/Form'
 
 type DocumentProps = {
     draftSubmission: DraftSubmission
@@ -52,6 +53,8 @@ export const Documents = ({
             : showFileUploadError && !hasValidFiles
             ? ' You must remove all documents with error messages before continuing'
             : undefined
+    const documentsErrorKey =
+        fileItems.length === 0 ? 'documents' : '#file-items-list'
 
     // Error summary state management
     const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
@@ -221,15 +224,18 @@ export const Documents = ({
                 <fieldset className="usa-fieldset">
                     <legend className="srOnly">Supporting Documents</legend>
 
-                    {documentsErrorMessage && (
-                        <Alert
-                            type="error"
-                            heading="Remove files with errors"
-                            className="margin-bottom-2"
-                        >
-                            {documentsErrorMessage}
-                        </Alert>
-                    )}
+                    <ErrorSummary
+                        errors={
+                            documentsErrorMessage
+                                ? {
+                                        [documentsErrorKey]:
+                                            documentsErrorMessage,
+                                    }
+                                : {}
+                        }
+                        headingRef={errorSummaryHeadingRef}
+                    />
+
                     {formAlert && formAlert}
                     <FileUpload
                         id="documents"

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Alert, Form as UswdsForm, Link } from '@trussworks/react-uswds'
+import { Form as UswdsForm, Link } from '@trussworks/react-uswds'
 import { useHistory } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -101,6 +101,8 @@ export const RateDetails = ({
             : showFileUploadError && !hasValidFiles
             ? ' You must remove all documents with error messages before continuing'
             : undefined
+    const documentsErrorKey =
+        fileItems.length === 0 ? 'rateDocuments' : '#file-items-list'
 
     const fileItemsFromDraftSubmission: FileItemT[] | undefined =
         (draftSubmission?.rateDocuments &&
@@ -331,7 +333,7 @@ export const RateDetails = ({
                                             errors={
                                                 documentsErrorMessage
                                                     ? {
-                                                          documents:
+                                                          [documentsErrorKey]:
                                                               documentsErrorMessage,
                                                           ...errors,
                                                       }


### PR DESCRIPTION
## Summary

Within forms that allow uploads:
* Clicking on the error messages for validation errors within the file list (duplicate files or upload/scan errors) will now focus the file list
* Errors related to files not being selected will continue to focus the file input when clicked

I attempted to implement this by passing `React.Ref`s down into the `ErrorSummary`, but in the end the behavior was flakey, there was a lot more code, and ultimately I fell back to the approach used here.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-13946

#### Test cases covered

I didn't add unit tests for this functionality due to the limitations with JSDOM and Jest that we uncovered in an earlier story. I did add a new story to Storybook, though, that shows the functionality.

## QA guidance

* Trigger file errors and verify that the file list is focused when activating the error message in the error summary.
* Verify the file input is still focused when no files have been selected.
