### PR TITLE
Refactor flakey FileUpload unit test

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.test.tsx
@@ -1,4 +1,9 @@
-import { render, waitFor, screen } from '@testing-library/react'
+import {
+    render,
+    waitFor,
+    waitForElementToBeRemoved,
+    screen,
+} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { FileUpload, FileUploadProps, S3FileData } from './FileUpload'
@@ -284,6 +289,7 @@ describe('FileUpload component', () => {
             userEvent.upload(input, [TEST_DOC_FILE])
             userEvent.upload(input, [TEST_PDF_FILE])
             userEvent.upload(input, [TEST_DOC_FILE])
+
             // while uploading/scanning
             await waitFor(() => {
                 expect(screen.getByText(/3 files added/)).toBeInTheDocument()
@@ -292,16 +298,19 @@ describe('FileUpload component', () => {
                 ).toBeInTheDocument()
             })
             // when complete
-            await waitFor(() => {
-                expect(screen.queryAllByText(/Uploading/).length).toBe(0)
-                expect(screen.queryAllByText(/Scanning/).length).toBe(0)
-            })
+            await waitForElementToBeRemoved(() =>
+                screen.queryAllByText(/Uploading/)
+            )
+
+            await waitForElementToBeRemoved(() =>
+                screen.queryAllByText(/Scanning/)
+            )
+
             await waitFor(() => {
                 expect(
                     screen.getByText(/2 complete, 1 error, 0 pending/)
                 ).toBeInTheDocument()
             })
-         
         })
     })
     describe('drag and drop behavior', () => {

--- a/services/app-web/src/components/FileUpload/FileUpload.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.test.tsx
@@ -1,7 +1,6 @@
 import {
     render,
     waitFor,
-    waitForElementToBeRemoved,
     screen,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'

--- a/services/app-web/src/components/FileUpload/FileUpload.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.test.tsx
@@ -282,36 +282,6 @@ describe('FileUpload component', () => {
                 expect(screen.getByText(/2 files added/)).toBeInTheDocument()
             )
         })
-        it('displays complete, errors, and pending in list - (X complete, X error(s), X pending', async () => {
-            await render(<FileUpload {...testProps} accept=".pdf,.txt" />)
-
-            const input = screen.getByTestId('file-input-input')
-            userEvent.upload(input, [TEST_DOC_FILE])
-            userEvent.upload(input, [TEST_PDF_FILE])
-            userEvent.upload(input, [TEST_DOC_FILE])
-
-            // while uploading/scanning
-            await waitFor(() => {
-                expect(screen.getByText(/3 files added/)).toBeInTheDocument()
-                expect(
-                    screen.getByText(/0 complete, 1 error, 2 pending/)
-                ).toBeInTheDocument()
-            })
-            // when complete
-            await waitForElementToBeRemoved(() =>
-                screen.queryAllByText(/Uploading/)
-            )
-
-            await waitForElementToBeRemoved(() =>
-                screen.queryAllByText(/Scanning/)
-            )
-
-            await waitFor(() => {
-                expect(
-                    screen.getByText(/2 complete, 1 error, 0 pending/)
-                ).toBeInTheDocument()
-            })
-        })
     })
     describe('drag and drop behavior', () => {
         it('does not accept a drop file that has an invalid type', async () => {

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
@@ -17,12 +17,13 @@ describe('documents', () => {
             cy.findByTestId('file-input-input').attachFile(
                 'documents/trussel-guide.pdf'
             )
+            cy.findByText(/0 complete, 1 error, 1 pending/).should('exist')
             cy.waitForDocumentsToLoad()
+            cy.findByText(/1 complete, 1 error, 0 pending/).should('exist')
             cy.findByText('Duplicate file').should('exist')
-
-            // Add two valid documents and one duplicate, then navigate back
             cy.visit(`/submissions/${draftSubmissionID}/documents`)
-            // HM-TODO: Why doesn't level attribute work here?
+
+            // Add two more valid documents, then navigate back
             cy.findByRole('heading', { name: /Supporting documents/ })
             cy.findByTestId('file-input-input').attachFile([
                 'documents/trussel-guide.pdf',
@@ -31,15 +32,20 @@ describe('documents', () => {
             cy.findByTestId('file-input-input').attachFile(
                 'documents/trussel-guide.pdf'
             )
+
+            cy.findByText(/3 files added/).should('exist')
+            cy.findByText(/0 complete, 1 error, 2 pending/).should('exist')
+
             cy.waitForDocumentsToLoad()
             cy.findByText('Duplicate file').should('exist')
             cy.findByTestId('file-input-preview-list')
                 .findAllByRole('listitem')
                 .should('have.length', 3)
+            cy.findByText(/2 complete, 1 error, 0 pending/)
             cy.navigateForm('Back')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
-            // reload page, see two documents,  duplicate was discarded on Back
+            // reload page, see two documents, duplicate was discarded on Back
             cy.visit(`/submissions/${draftSubmissionID}/documents`)
             cy.findByTestId('file-input-preview-list')
                 .findAllByRole('listitem')


### PR DESCRIPTION
## Summary
Move the tests of our new accessibility file upload summary  - (X complete, X error, X pending) text that updates as files scan and complete -  into Cypress. Jest tests are flaking and only randomly for unclear reasons. This is blocking our promote workflow. https://github.com/CMSgov/managed-care-review/actions/runs/1714316813 

Let's test this same behavior with Cypress instead.
