### PR TITLE
Destroy script in TypeScript

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -13,21 +13,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.5
-      - name: set branch_name
+      - name: set stage_name
         run: |
-          echo "branch_name=$(./scripts/stage_name_for_branch.sh ${{ github.event.ref }})" >> $GITHUB_ENV
+          echo "stage_name=$(./scripts/stage_name_for_branch.sh ${{ github.event.ref }})" >> $GITHUB_ENV
+
+      - name: Setup env
+        uses: ./.github/actions/setup_env
+
+      - name: build scripts
+        shell: bash
+        run: |
+          lerna run build:ci-scripts
 
       - name: lock this branch to prevent concurrent destroys
         run: ./.github/github-lock.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: destroy all
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           STAGE_PREFIX: ${{ secrets.STAGE_PREFIX }}
-        run: ./destroy.sh $STAGE_PREFIX$branch_name
+        run: node ./scripts/destroy_stage.js $stage_name
+
       - name: Alert Slack On Destroy Failure
         uses: rtCamp/action-slack-notify@v2
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ notes/
 /scripts/collect_ci_runtime_stats.js*
 /scripts/recent_actions_cache.json
 /scripts/get-changed-services/index.js*
+/scripts/destroy_stage.js*
 
 services/app-web/public/env-config.js
 services/app-web/storybook-static

--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -1,0 +1,47 @@
+import AWS from 'aws-sdk'
+
+AWS.config.update({
+    region: 'us-east-1',
+})
+
+const stackPrefixes = [
+    'app-web',
+    'app-api',
+    'ui-auth',
+    'uploads',
+    'postgres',
+    'storybook',
+    'infra-api',
+    'ui',
+]
+
+const stage = process.argv[2]
+
+let cf = new AWS.CloudFormation()
+
+await Promise.all(
+    stackPrefixes.map(async (prefix) => {
+        try {
+            const stackParams = {
+                StackName: `${prefix}-${stage}`,
+            }
+            // find the stack and make sure we get one
+            const stack = await cf.describeStacks(stackParams).promise()
+            if (stack.Stacks === undefined) {
+                console.log('could not find stack')
+                return
+            }
+
+            // get the stack ID so we can check it's status
+            let stackId = stack.Stacks[0].StackId
+            await cf.deleteStack(stackParams).promise()
+            await cf
+                .waitFor('stackDeleteComplete', { StackName: stackId })
+                .promise()
+            console.log(stack)
+            return
+        } catch (err) {
+            return Promise.reject(err)
+        }
+    })
+)

--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -1,6 +1,4 @@
 import AWS from 'aws-sdk'
-import { ConfigurationServicePlaceholders } from 'aws-sdk/lib/config_service_placeholders'
-import { version } from 'prettier'
 
 AWS.config.update({
     region: 'us-east-1',
@@ -25,97 +23,122 @@ const stage = process.argv[2]
 const cf = new AWS.CloudFormation()
 const s3 = new AWS.S3()
 
-await Promise.all(
-    stackPrefixes.map(async (prefix) => {
-        try {
-            const sn = `${prefix}-${stage}`
-            await clearServerlessDeployBucket(sn)
-            await deleteStack(sn)
-            return
-        } catch (err) {
-            return Promise.reject(err)
-        }
-    })
-)
+async function main() {
+    Promise.all(
+        stackPrefixes.map(async (prefix) => {
+            try {
+                const sn = `${prefix}-${stage}`
+                const clearBucketOutput = await clearServerlessDeployBucket(sn)
+                if (clearBucketOutput instanceof Error) {
+                    console.log(clearBucketOutput)
+                }
+                const deleteStackOutput = await deleteStack(sn)
+                if (deleteStackOutput instanceof Error) {
+                    console.log(deleteStackOutput)
+                }
+
+                return
+            } catch (err) {
+                return Promise.reject(err)
+            }
+        })
+    )
+}
 
 interface s3ObjectKey {
     Key: string
     VersionId?: string
 }
 
-async function clearServerlessDeployBucket(stackName: string) {
+async function clearServerlessDeployBucket(
+    stackName: string
+): Promise<{} | Error> {
     const stackParams = {
         StackName: stackName,
     }
 
-    try {
-        // get all the resources in the stack
-        const stack = await cf.describeStackResources(stackParams).promise()
-        if (stack.StackResources === undefined) {
-            console.log('could not find stack')
+    // get all the resources in the stack
+    const stack = await cf.describeStackResources(stackParams).promise()
+    if (stack.StackResources === undefined) {
+        return new Error('could not find stack')
+    }
+    // filter the resources to get our S3 buckets
+    const buckets = stack.StackResources.filter((resource) => {
+        return resource.ResourceType === 'AWS::S3::Bucket'
+    })
+
+    // TODO: Suspend bucket versioning.
+
+    // clean out each of those buckets
+    buckets.map(async (bucket) => {
+        console.log(`Deleting ${bucket.PhysicalResourceId}`)
+        const bucketParams = {
+            Bucket: bucket.PhysicalResourceId ?? '',
+        }
+        const objects = await s3.listObjects(bucketParams).promise()
+
+        if (objects.Contents === undefined) {
             return
         }
-        // filter the resources to get our S3 buckets
-        const buckets = stack.StackResources.filter((resource) => {
-            return resource.ResourceType === 'AWS::S3::Bucket'
-        })
 
-        // TODO: Suspend bucket versioning.
+        if (objects.Contents?.length > 0) {
+            const keys: s3ObjectKey[] = objects.Contents?.map((c) => {
+                return { Key: c.Key ?? '' }
+            })
 
-        // clean out each of those buckets
-        buckets.map(async (bucket) => {
-            console.log(`Deleting ${bucket.PhysicalResourceId}`)
-            const bucketParams = {
+            const deleteParams: AWS.S3.DeleteObjectsRequest = {
                 Bucket: bucket.PhysicalResourceId ?? '',
-            }
-            const objects = await s3.listObjects(bucketParams).promise()
-
-            if (objects.Contents === undefined) {
-                return
+                Delete: {
+                    Objects: keys,
+                },
             }
 
-            if (objects.Contents?.length > 0) {
-                const keys: s3ObjectKey[] = objects.Contents?.map((c) => {
-                    return { Key: c.Key ?? '' }
-                })
+            await s3.deleteObjects(deleteParams).promise()
+        }
+    })
 
-                const deleteParams: AWS.S3.DeleteObjectsRequest = {
-                    Bucket: bucket.PhysicalResourceId ?? '',
-                    Delete: {
-                        Objects: keys,
-                    },
-                }
-
-                await s3.deleteObjects(deleteParams).promise()
-            }
-        })
-    } catch (err) {
-        return Promise.reject(err)
-    }
+    return {}
 }
 
-async function deleteStack(stackName: string): Promise<void> {
-    console.log(`Deleting stack ${stackName}`)
+async function deleteStack(stackName: string): Promise<{} | Error> {
+    console.log(`Looking up up stack ${stackName}`)
     const stackParams = {
         StackName: stackName,
     }
 
-    try {
-        // find the stack and make sure we get one
-        const stack = await cf.describeStacks(stackParams).promise()
-        if (stack.Stacks === undefined) {
-            console.log('could not find stack')
-            return
-        }
-        console.log(stack.Stacks[0].Outputs)
+    // find the stack and make sure we get one
+    const stack = await cf.describeStacks(stackParams).promise()
 
-        // get the stack ID so we can check it's status
-        let stackId = stack.Stacks[0].StackId
-        await cf.deleteStack(stackParams).promise()
-        await cf
-            .waitFor('stackDeleteComplete', { StackName: stackId })
-            .promise()
-    } catch (err) {
-        return Promise.reject(err)
+    // AWSError is unfortunately not backed by Error, so we can't just
+    // check it is an instanceof, we don't get good type info :(
+    // https://github.com/aws/aws-sdk-js/issues/2611
+    if (stack.$response.error != null) {
+        return new Error(
+            'Error on describeStacks: ' + stack.$response.error.message
+        )
     }
+
+    if (stack.Stacks === undefined || stack.Stacks.length === 0) {
+        return new Error(`Could not find stack ${stackName}`)
+    }
+
+    console.log(stack.Stacks[0].Outputs)
+
+    console.log(`Deleting stack ${stackName}`)
+    // get the stack ID so we can check it's status
+    let stackId = stack.Stacks[0].StackId
+    const deleteReturn = await cf.deleteStack(stackParams).promise()
+    if (deleteReturn.$response.error != null) {
+        return new Error(
+            'Error on deleteStack: ' + deleteReturn.$response.error.message
+        )
+    }
+
+    await cf.waitFor('stackDeleteComplete', { StackName: stackId }).promise()
+
+    // deleteStack just returns {} if successful, so:
+    return {}
 }
+
+// run the script
+main()

--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -1,5 +1,4 @@
 import AWS from 'aws-sdk'
-import { version } from 'prettier'
 
 AWS.config.update({
     region: 'us-east-1',

--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -22,26 +22,35 @@ let cf = new AWS.CloudFormation()
 await Promise.all(
     stackPrefixes.map(async (prefix) => {
         try {
-            const stackParams = {
-                StackName: `${prefix}-${stage}`,
-            }
-            // find the stack and make sure we get one
-            const stack = await cf.describeStacks(stackParams).promise()
-            if (stack.Stacks === undefined) {
-                console.log('could not find stack')
-                return
-            }
-
-            // get the stack ID so we can check it's status
-            let stackId = stack.Stacks[0].StackId
-            await cf.deleteStack(stackParams).promise()
-            await cf
-                .waitFor('stackDeleteComplete', { StackName: stackId })
-                .promise()
-            console.log(stack)
+            const sn = `${prefix}-${stage}`
+            deleteStack(sn)
             return
         } catch (err) {
             return Promise.reject(err)
         }
     })
 )
+
+async function deleteStack(stackName: string) {
+    const stackParams = {
+        StackName: stackName,
+    }
+
+    try {
+        // find the stack and make sure we get one
+        const stack = await cf.describeStacks(stackParams).promise()
+        if (stack.Stacks === undefined) {
+            console.log('could not find stack')
+            return
+        }
+
+        // get the stack ID so we can check it's status
+        let stackId = stack.Stacks[0].StackId
+        await cf.deleteStack(stackParams).promise()
+        await cf
+            .waitFor('stackDeleteComplete', { StackName: stackId })
+            .promise()
+    } catch (err) {
+        console.log(err)
+    }
+}

--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -1,9 +1,11 @@
 import AWS from 'aws-sdk'
+import { ConfigurationServicePlaceholders } from 'aws-sdk/lib/config_service_placeholders'
+import { version } from 'prettier'
 
 AWS.config.update({
     region: 'us-east-1',
 })
-
+/*
 const stackPrefixes = [
     'app-web',
     'app-api',
@@ -14,16 +16,21 @@ const stackPrefixes = [
     'infra-api',
     'ui',
 ]
+*/
+
+const stackPrefixes = ['app-web']
 
 const stage = process.argv[2]
 
-let cf = new AWS.CloudFormation()
+const cf = new AWS.CloudFormation()
+const s3 = new AWS.S3()
 
 await Promise.all(
     stackPrefixes.map(async (prefix) => {
         try {
             const sn = `${prefix}-${stage}`
-            deleteStack(sn)
+            await clearServerlessDeployBucket(sn)
+            await deleteStack(sn)
             return
         } catch (err) {
             return Promise.reject(err)
@@ -31,7 +38,64 @@ await Promise.all(
     })
 )
 
-async function deleteStack(stackName: string) {
+interface s3ObjectKey {
+    Key: string
+    VersionId?: string
+}
+
+async function clearServerlessDeployBucket(stackName: string) {
+    const stackParams = {
+        StackName: stackName,
+    }
+
+    try {
+        // get all the resources in the stack
+        const stack = await cf.describeStackResources(stackParams).promise()
+        if (stack.StackResources === undefined) {
+            console.log('could not find stack')
+            return
+        }
+        // filter the resources to get our S3 buckets
+        const buckets = stack.StackResources.filter((resource) => {
+            return resource.ResourceType === 'AWS::S3::Bucket'
+        })
+
+        // TODO: Suspend bucket versioning.
+
+        // clean out each of those buckets
+        buckets.map(async (bucket) => {
+            console.log(`Deleting ${bucket.PhysicalResourceId}`)
+            const bucketParams = {
+                Bucket: bucket.PhysicalResourceId ?? '',
+            }
+            const objects = await s3.listObjects(bucketParams).promise()
+
+            if (objects.Contents === undefined) {
+                return
+            }
+
+            if (objects.Contents?.length > 0) {
+                const keys: s3ObjectKey[] = objects.Contents?.map((c) => {
+                    return { Key: c.Key ?? '' }
+                })
+
+                const deleteParams: AWS.S3.DeleteObjectsRequest = {
+                    Bucket: bucket.PhysicalResourceId ?? '',
+                    Delete: {
+                        Objects: keys,
+                    },
+                }
+
+                await s3.deleteObjects(deleteParams).promise()
+            }
+        })
+    } catch (err) {
+        return Promise.reject(err)
+    }
+}
+
+async function deleteStack(stackName: string): Promise<void> {
+    console.log(`Deleting stack ${stackName}`)
     const stackParams = {
         StackName: stackName,
     }
@@ -43,6 +107,7 @@ async function deleteStack(stackName: string) {
             console.log('could not find stack')
             return
         }
+        console.log(stack.Stacks[0].Outputs)
 
         // get the stack ID so we can check it's status
         let stackId = stack.Stacks[0].StackId
@@ -51,6 +116,6 @@ async function deleteStack(stackName: string) {
             .waitFor('stackDeleteComplete', { StackName: stackId })
             .promise()
     } catch (err) {
-        console.log(err)
+        return Promise.reject(err)
     }
 }


### PR DESCRIPTION
## Summary

We've been having an issue where the old `destroy.sh` script will return successfully, but sometimes resources will not completely be removed from AWS. This causes us to sometimes hit resource limits due to dangling, unused AWS resources.

Taking this as an opportunity to rewrite the script in TypeScript and using the `aws-sdk` directly, rather than using `jq` on cli output where we're clearly missing things.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-14896
