### PR TITLE
Add aria label for file remove and retry buttons that includes file name

### DIFF
--- a/services/app-web/src/components/FileUpload/FileItem/FileItem.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileItem/FileItem.test.tsx
@@ -68,13 +68,23 @@ describe('FileItem component', () => {
 
         expect(screen.getByText(uploadComplete.name)).toBeInTheDocument()
     })
+
+    it('includes appropriate aria- attributes', () => {
+        render(<FileItem item={uploadError} {...buttonActionProps} />)
+
+        expect(screen.getByLabelText(`Retry upload for ${uploadError.name} document`)).toBeInTheDocument()
+        expect(
+            screen.getByLabelText(`Remove ${uploadError.name} document`)
+        ).toBeInTheDocument()
+    })
+
     it('button actions work as expected', () => {
         render(<FileItem item={uploadError} {...buttonActionProps} />)
 
-        userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        userEvent.click(screen.getByRole('button', { name: /Retry/ }))
         expect(buttonActionProps.retryItem).toHaveBeenCalled()
 
-        userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+        userEvent.click(screen.getByRole('button', { name: /Remove/ }))
         expect(buttonActionProps.deleteItem).toHaveBeenCalled()
     })
 
@@ -84,9 +94,9 @@ describe('FileItem component', () => {
         const imageEl = screen.getByTestId('file-input-preview-image')
         expect(imageEl).toHaveClass('is-loading')
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
     })
 
     it('displays loading image, scanning text, and remove button when status is SCANNING', () => {
@@ -95,9 +105,9 @@ describe('FileItem component', () => {
         const imageEl = screen.getByTestId('file-input-preview-image')
         expect(imageEl).toHaveClass('is-loading')
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
     })
 
     it('displays file image and remove button when status is UPLOAD_COMPLETE', () => {
@@ -106,9 +116,9 @@ describe('FileItem component', () => {
         expect(imageEl).not.toHaveClass('is-loading')
         expect(imageEl).toHaveClass('usa-file-input__preview-image--pdf')
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
     })
 
     it('displays upload failed message and both retry and remove buttons when status is UPLOAD_ERROR', () => {
@@ -118,16 +128,16 @@ describe('FileItem component', () => {
         expect(imageEl).not.toHaveClass('is-loading')
         expect(screen.getByText('Upload failed')).toBeInTheDocument()
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('button', { name: 'Retry' })
+            screen.getByRole('button', { name: /Retry/ })
         ).toBeInTheDocument()
 
-        userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        userEvent.click(screen.getByRole('button', { name: /Retry/ }))
         expect(buttonActionProps.retryItem).toHaveBeenCalled()
 
-        userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+        userEvent.click(screen.getByRole('button', { name: /Remove/ }))
         expect(buttonActionProps.deleteItem).toHaveBeenCalled()
     })
 
@@ -140,10 +150,10 @@ describe('FileItem component', () => {
             screen.getByText('Failed security scan, please remove')
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
         expect(
-            screen.queryByRole('button', { name: 'Retry' })
+            screen.queryByRole('button', { name: /Retry/ })
         ).toBeInTheDocument()
     })
 
@@ -154,9 +164,9 @@ describe('FileItem component', () => {
         expect(imageEl).not.toHaveClass('is-loading')
         expect(screen.getByText('Duplicate file')).toBeInTheDocument()
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
     })
 
     it('displays unexpected error message and remove button when status is UPLOAD_ERROR but file reference is undefined (this is an unexpected state but it would mean the upload cannot be retried)', () => {
@@ -174,8 +184,8 @@ describe('FileItem component', () => {
             screen.getByText('Unexpected error. Please remove.')
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('button', { name: 'Remove' })
+            screen.getByRole('button', { name: /Remove/ })
         ).toBeInTheDocument()
-        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+        expect(screen.queryByRole('button', { name: /Retry/ })).toBeNull()
     })
 })

--- a/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
+++ b/services/app-web/src/components/FileUpload/FileItem/FileItem.tsx
@@ -132,7 +132,11 @@ export const FileItem = ({
     return (
         <>
             <div className={styles.fileItemText}>
-                <div role="progressbar" aria-valuetext={statusValue} aria-label={`File status`}>
+                <div
+                    role="progressbar"
+                    aria-valuetext={statusValue}
+                    aria-label={`File status`}
+                >
                     <img
                         id={item.id}
                         data-testid="file-input-preview-image"
@@ -169,6 +173,7 @@ export const FileItem = ({
             <div className={styles.fileItemButtons}>
                 <Button
                     type="button"
+                    aria-label={`Remove ${name} document`}
                     size="small"
                     unstyled
                     onClick={handleDelete}
@@ -179,6 +184,7 @@ export const FileItem = ({
                     <Button
                         type="button"
                         size="small"
+                        aria-label={`Retry upload for ${name} document`}
                         unstyled
                         onClick={handleRetry}
                     >

--- a/services/app-web/src/components/FileUpload/FileItemList/FileItemsList.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileItemList/FileItemsList.test.tsx
@@ -94,10 +94,10 @@ describe('FileItemList component', () => {
         const fileItems = [uploadError]
         render(<FileItemsList fileItems={fileItems} {...buttonActionProps} />)
 
-        userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        userEvent.click(screen.getByRole('button', { name: /Retry/ }))
         expect(buttonActionProps.retryItem).toHaveBeenCalled()
 
-        userEvent.click(screen.getByRole('button', { name: 'Remove' }))
+        userEvent.click(screen.getByRole('button', { name: /Remove/ }))
         expect(buttonActionProps.deleteItem).toHaveBeenCalled()
     })
 

--- a/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
+++ b/services/app-web/src/components/FileUpload/FileItemList/__snapshots__/FileItemsList.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemButtons"
     >
       <button
+        aria-label="Remove testFile.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -107,6 +108,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemButtons"
     >
       <button
+        aria-label="Remove testFile2.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -115,6 +117,7 @@ exports[`FileItemList component renders correctly 1`] = `
         Remove
       </button>
       <button
+        aria-label="Retry upload for testFile2.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -167,6 +170,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemButtons"
     >
       <button
+        aria-label="Remove testFile3.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -175,6 +179,7 @@ exports[`FileItemList component renders correctly 1`] = `
         Remove
       </button>
       <button
+        aria-label="Retry upload for testFile3.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -222,6 +227,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemButtons"
     >
       <button
+        aria-label="Remove testFile4.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}
@@ -279,6 +285,7 @@ exports[`FileItemList component renders correctly 1`] = `
       className="fileItemButtons"
     >
       <button
+        aria-label="Remove testFile4.pdf document"
         className="usa-button usa-button--small usa-button--unstyled"
         data-testid="button"
         onClick={[Function]}

--- a/services/app-web/src/components/FileUpload/FileUpload.test.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.test.tsx
@@ -266,7 +266,7 @@ describe('FileUpload component', () => {
             expect(props.onFileItemsUpdate).toHaveBeenCalled()
         })
 
-        userClickByRole(screen, 'button', { name: 'Retry' })
+        userClickByRole(screen, 'button', { name: /Retry/ })
         await waitFor(() => expect(props.uploadFile).toHaveBeenCalled())
     })
 

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.test.tsx
@@ -275,7 +275,7 @@ describe('Documents', () => {
         })
 
         // Remove duplicate document and remove error
-        userEvent.click(screen.queryAllByText('Remove')[0])
+        userEvent.click(screen.queryAllByText(/Remove/)[0])
         expect(screen.queryAllByText(TEST_DOC_FILE.name).length).toBe(1)
         expect(screen.queryByText('Duplicate file')).toBeNull()
     })


### PR DESCRIPTION
## Summary
#### Related issues
https://qmacbis.atlassian.net/browse/OY2-15635

#### Test cases covered
- add aria- attributes to file items

## QA guidance
- Test in JAWS - the remove button should now announce "Remove FILE_NAME document"
