### PR TITLE
Copy change: display accepted file formats and adjust submission summary copy for "effective dates"

### DIFF
--- a/services/app-web/src/common-code/formatters/pluralizer.test.ts
+++ b/services/app-web/src/common-code/formatters/pluralizer.test.ts
@@ -10,4 +10,8 @@ describe('pluralize', () => {
         expect(pluralize('goat', 1)).toBe('goat')
         expect(pluralize('goat', 2)).toBe('goats')
     })
+      it('pluralizes zero correctly', () => {
+        expect(`I have no ${pluralize('goat', 0)}`).toBe('I have no goats')
+        expect(`0 ${pluralize('file', 0)} added`).toBe('0 files added')
+      })
 })

--- a/services/app-web/src/common-code/formatters/pluralizer.ts
+++ b/services/app-web/src/common-code/formatters/pluralizer.ts
@@ -1,5 +1,5 @@
 export const pluralize = (word: string, count: number): string => {
-    const isPlural = count > 1;
+    const isPlural = count !== 1;
     switch (word) {
         case "do":
             return isPlural ? "do" : "does";

--- a/services/app-web/src/components/FileUpload/FileUpload.module.scss
+++ b/services/app-web/src/components/FileUpload/FileUpload.module.scss
@@ -1,7 +1,12 @@
 .fileInput {
     max-width: none;
 }
-
+.fileInputHint{
+    display: flex;
+    flex-direction: column;
+    color: #71767a;
+    margin-bottom: 0.5rem;
+}
 .fileItemsList {
     list-style-type: none;
     display: inline-block;

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -351,7 +351,7 @@ export const FileUpload = ({
                 <span
                     id={`${id}-hint`}
                     aria-labelledby={id}
-                    className="usa-hint margin-top-1"
+                    className={styles.fileInputHint}
                 >
                     {hint}
                 </span>

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -7,13 +7,13 @@ import {
 } from '../../../testHelpers/apolloHelpers'
 
 describe('ContractDetailsSummarySection', () => {
-    const draftSubmission = mockContractAndRatesDraft()
-    const stateSubmission = mockStateSubmission()
+    const draftContractAndRatesSubmission = mockContractAndRatesDraft()
+    const stateBaseContractOnlySubmission = mockStateSubmission()
 
     it('can render draft submission without errors (review and submit behavior)', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
-                submission={draftSubmission}
+                submission={draftContractAndRatesSubmission}
                 navigateTo="contract-details"
             />
         )
@@ -36,7 +36,7 @@ describe('ContractDetailsSummarySection', () => {
 
     it('can render state submission on summary page without errors (submission summary behavior)', () => {
         renderWithProviders(
-            <ContractDetailsSummarySection submission={stateSubmission} />
+            <ContractDetailsSummarySection submission={stateBaseContractOnlySubmission} />
         )
 
         expect(
@@ -56,7 +56,7 @@ describe('ContractDetailsSummarySection', () => {
     it('can render all contract details fields', () => {
         renderWithProviders(
             <ContractDetailsSummarySection
-                submission={draftSubmission}
+                submission={draftContractAndRatesSubmission}
                 navigateTo="contract-details"
             />
         )
@@ -65,7 +65,7 @@ describe('ContractDetailsSummarySection', () => {
             screen.getByRole('definition', { name: 'Contract action type' })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('definition', { name: 'Contract effective dates' })
+            screen.getByRole('definition', { name: 'Contract amendment effective dates' })
         ).toBeInTheDocument()
         expect(
             screen.getByRole('definition', { name: 'Managed care entities' })
@@ -92,11 +92,11 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
 
-    it('can hide contract amendment fields for base contract submission', () => {
+    it('displays correct text content for contract a base contract', () => {
         renderWithProviders(
-            <ContractDetailsSummarySection submission={stateSubmission} />
+            <ContractDetailsSummarySection submission={stateBaseContractOnlySubmission} />
         )
-
+        expect(screen.getByText('Contract effective dates')).toBeInTheDocument()
         expect(
             screen.queryByText('Items being amended')
         ).not.toBeInTheDocument()
@@ -110,5 +110,26 @@ describe('ContractDetailsSummarySection', () => {
                 'Is this related to coverage and reimbursement for vaccine administration?'
             )
         ).not.toBeInTheDocument()
+    })
+
+      it('displays correct text content for a contract amendment', () => {
+          renderWithProviders(
+            <ContractDetailsSummarySection submission={draftContractAndRatesSubmission} />
+        )
+         expect(screen.getByText('Contract amendment effective dates')).toBeInTheDocument()
+        expect(
+            screen.queryByText('Items being amended')
+        ).toBeInTheDocument()
+
+                expect(
+            screen.queryByText(
+                'Is this contract action related to the COVID-19 public health emergency'
+            )
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByText(
+                'Is this related to coverage and reimbursement for vaccine administration?'
+            )
+        ).toBeInTheDocument()
     })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -140,7 +140,7 @@ export const ContractDetailsSummarySection = ({
                     right={
                         <DataDetail
                             id="contractEffectiveDates"
-                            label="Contract effective dates"
+                            label={submission.contractType === "BASE"? "Contract effective dates": "Contract amendment effective dates"}
                             data={`${dayjs(submission.contractDateStart).format(
                                 'MM/DD/YYYY'
                             )} to ${dayjs(submission.contractDateEnd).format(

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -67,7 +67,7 @@ describe('RateDetailsSummarySection', () => {
         ).toBeInTheDocument()
         expect(
             screen.getByRole('definition', {
-                name: 'Effective dates of rate amendment',
+                name: 'Rate amendment effective dates',
             })
         ).toBeInTheDocument()
     })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -107,7 +107,7 @@ export const RateDetailsSummarySection = ({
                         submission.rateAmendmentInfo ? (
                             <DataDetail
                                 id="effectiveRatingPeriod"
-                                label="Effective dates of rate amendment"
+                                label="Rate amendment effective dates"
                                 data={`${dayjs(
                                     submission.rateAmendmentInfo
                                         .effectiveDateStart

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -418,7 +418,7 @@ export const ContractDetails = ({
                                                 Document definitions and
                                                 requirements
                                             </Link>
-                                            <span className="srOnly">
+                                            <span>
                                                 This input only accepts PDF,
                                                 CSV, DOC, DOCX, XLS, XLSX files.
                                             </span>

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -255,7 +255,7 @@ export const Documents = ({
                                 >
                                     Document definitions and requirements
                                 </Link>
-                                <span className="srOnly">
+                                <span>
                                     This input only accepts PDF, CSV, DOC, DOCX,
                                     XLS, XLSX files.
                                 </span>

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -363,7 +363,7 @@ export const RateDetails = ({
                                                     Document definitions and
                                                     requirements
                                                 </Link>
-                                                <span className="srOnly">
+                                                <span>
                                                     This input only accepts PDF,
                                                     CSV, DOC, DOCX, XLS, XLSX
                                                     files.


### PR DESCRIPTION
## Summary
Copy change: Add copy on accepted file formats when uploading documents
Copy change: Use "Contract amendment effective dates"  for contract amendment submissions + change "Effective dates of rate amendment" to "Rate amendment effective dates"

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-15638
https://qmacbis.atlassian.net/browse/OY2-15523

#### Test cases added
`ContractDetailsSummarySection.test.tsx` (component used both on review and submit and submission summary
- displays correct text content for a contract amendment
- displays correct text content for a base contract

## QA guidance

Tickets have a good description of whats changed here
