### PR TITLE
Add aria-describedby to submission description

### DIFF
--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -375,6 +375,10 @@ export const SubmissionType = ({
                                 )}
                                 hint={
                                     <>
+
+                                        <p id="submissionDescriptionHelp">
+                                            Provide a 1-2 paragraph summary of your submission that highlights any important changes CMS reviewers will need to be aware of
+                                        </p>
                                         <Link
                                             variant="external"
                                             asCustom={ReactRouterLink}
@@ -386,11 +390,6 @@ export const SubmissionType = ({
                                         >
                                             View description examples
                                         </Link>
-
-                                        <p id="submissionDescriptionHelp">
-                                            Provide a description of any major
-                                            changes or updates
-                                        </p>
                                     </>
                                 }
                             />

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -369,6 +369,7 @@ export const SubmissionType = ({
                                 id="submissionDescription"
                                 name="submissionDescription"
                                 aria-required
+                                aria-describedby='submissionDescriptionHelp'
                                 showError={showFieldErrors(
                                     errors.submissionDescription
                                 )}
@@ -386,7 +387,7 @@ export const SubmissionType = ({
                                             View description examples
                                         </Link>
 
-                                        <p>
+                                        <p id="submissionDescriptionHelp">
                                             Provide a description of any major
                                             changes or updates
                                         </p>


### PR DESCRIPTION
Add `aria-describedby` to submission description so that SR's will read the help text associated with the textarea.

I also made a copy change to the hint text based on the feedback and iteration we had after our Nov. PP test. 