### PR TITLE
Fix Slack Alert Color

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -367,6 +367,6 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: Deploy Alerts
           SLACK_ICON_EMOJI: ':bell:'
-          SLACK_COLOR: ${{job.status}}
+          SLACK_COLOR: ${{ failure }}
           SLACK_FOOTER: ''
           MSG_MINIMAL: actions url,commit


### PR DESCRIPTION
## Summary
This changes the failure on promote alert to Red. {{ job.status }} was (is) always success.

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-14660

