### PR TITLE
Update CMS submission email to include key dates

### DIFF
--- a/services/app-api/emailer/templates.test.ts
+++ b/services/app-api/emailer/templates.test.ts
@@ -56,8 +56,8 @@ describe('Email templates', () => {
         it('includes expected data summary for a contract only submission', () => { 
             const sub: StateSubmissionType  = {
                 ...mockContractOnlySubmission(),
-                contractDateStart: new Date('01-01-2021'),
-                contractDateEnd: new Date('01-01-2025')
+                contractDateStart: new Date('01/01/2021'),
+                contractDateEnd: new Date('01/01/2025')
             }
             const template = newPackageCMSEmailTemplate(
                 sub,
@@ -81,7 +81,7 @@ describe('Email templates', () => {
                expect(template).toEqual(
                    expect.objectContaining({
                        bodyText: expect.stringContaining(
-                           'Contract effective dates: 2021-01-01 to 2025-01-01'
+                           'Contract effective dates: 01/01/2021 to 01/01/2025'
                        ),
                    })
                )
@@ -91,10 +91,10 @@ describe('Email templates', () => {
         it('includes expected data summary for a contract and rates submission', () => {
              const sub: StateSubmissionType = {
                  ...mockContractAndRatesSubmission(),
-                 contractDateStart: new Date('01-01-2021'),
-                 contractDateEnd: new Date('01-01-2025'),
-                 rateDateStart: new Date('01-01-2021'),
-                 rateDateEnd: new Date('01-01-2022'),
+                 contractDateStart: new Date('01/01/2021'),
+                 contractDateEnd: new Date('01/01/2025'),
+                 rateDateStart: new Date('01/01/2021'),
+                 rateDateEnd: new Date('01/01/2022'),
              }
             const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
               
@@ -108,7 +108,7 @@ describe('Email templates', () => {
               expect(template).toEqual(
                   expect.objectContaining({
                       bodyText: expect.stringContaining(
-                         'Rating period: 2021-01-01 to 2022-01-01'
+                         'Rating period: 01/01/2021 to 01/01/2022'
                       ),
                   })
               )
@@ -116,7 +116,7 @@ describe('Email templates', () => {
                expect(template).toEqual(
                    expect.objectContaining({
                        bodyText: expect.stringContaining(
-                           'Contract effective dates: 2021-01-01 to 2025-01-01'
+                           'Contract effective dates: 01/01/2021 to 01/01/2025'
                        ),
                    })
                )
@@ -125,10 +125,10 @@ describe('Email templates', () => {
         it('includes expected data summary for a contract amendment submission', () => {
                  const sub: StateSubmissionType = {
                      ...mockContractAmendmentSubmission(),
-                     contractDateStart: new Date('01-01-2021'),
-                     contractDateEnd: new Date('01-01-2025'),
-                     rateDateStart: new Date('01-01-2021'),
-                     rateDateEnd: new Date('01-01-2022'),
+                     contractDateStart: new Date('01/01/2021'),
+                     contractDateEnd: new Date('01/01/2025'),
+                     rateDateStart: new Date('01/01/2021'),
+                     rateDateEnd: new Date('01/01/2022'),
                  }
             const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
             
@@ -142,7 +142,7 @@ describe('Email templates', () => {
                      expect(template).toEqual(
                          expect.objectContaining({
                              bodyText: expect.stringContaining(
-                                 'Rating period: 2021-01-01 to 2022-01-01'
+                                 'Rating period: 01/01/2021 to 01/01/2022'
                              ),
                          })
                      )
@@ -150,7 +150,7 @@ describe('Email templates', () => {
                      expect(template).toEqual(
                          expect.objectContaining({
                              bodyText: expect.stringContaining(
-                                 'Contract amendment effective dates: 2021-01-01 to 2025-01-01'
+                                 'Contract amendment effective dates: 01/01/2021 to 01/01/2025'
                              ),
                          })
                      )

--- a/services/app-api/emailer/templates.test.ts
+++ b/services/app-api/emailer/templates.test.ts
@@ -1,0 +1,285 @@
+import {testEmailConfig, mockContractAmendmentSubmission, mockContractOnlySubmission, mockContractAndRatesSubmission, mockUser} from '../testHelpers/emailerHelpers'
+import {
+    submissionName,
+    StateSubmissionType
+} from '../../app-web/src/common-code/domain-models'
+import {newPackageCMSEmailTemplate, newPackageStateEmailTemplate} from './'
+
+describe('Email templates', () => {
+    describe('CMS email', () => {
+        it('to addresses list includes review email addresses from email config', () => {
+            const sub = mockContractOnlySubmission()
+            const template = newPackageCMSEmailTemplate(
+                sub,
+                testEmailConfig
+            )
+            testEmailConfig.cmsReviewSharedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.arrayContaining([
+                            emailAddress
+                        ]),
+                    })
+                )
+            })
+        })
+
+        it('subject line is correct', () => {
+            const sub  = mockContractOnlySubmission()
+            const name = submissionName(sub)
+            const template = newPackageCMSEmailTemplate(sub,testEmailConfig)
+            
+            expect(template).toEqual(
+                expect.objectContaining({
+                    subject: expect.stringContaining(
+                        `TEST New Managed Care Submission: ${name}`
+                    )
+                })
+            )
+        })
+
+
+        it('includes warning about unofficial submission', () => {
+            const sub = mockContractOnlySubmission()
+            const template = newPackageCMSEmailTemplate( sub, testEmailConfig)
+             expect(template).toEqual(
+                 expect.objectContaining({
+                     bodyText: expect.stringMatching(
+                         /This is NOT an official submission/
+                     ),
+                 })
+             )
+
+        })
+
+
+        it('includes expected data summary for a contract only submission', () => { 
+            const sub: StateSubmissionType  = {
+                ...mockContractOnlySubmission(),
+                contractDateStart: new Date('01-01-2021'),
+                contractDateEnd: new Date('01-01-2025')
+            }
+            const template = newPackageCMSEmailTemplate(
+                sub,
+                testEmailConfig
+            )
+              expect(template).toEqual(
+                  expect.objectContaining({
+                      bodyText: expect.stringContaining(
+                          'Submission type: Contract action only'
+                      ),
+                  })
+              )
+              expect(template).not.toEqual(
+                  expect.objectContaining({
+                      bodyText: expect.stringContaining(
+                          'Rating period:'
+                      ),
+                  })
+              )
+
+               expect(template).toEqual(
+                   expect.objectContaining({
+                       bodyText: expect.stringContaining(
+                           'Contract effective dates: 2021-01-01 to 2025-01-01'
+                       ),
+                   })
+               )
+
+
+        })
+        it('includes expected data summary for a contract and rates submission', () => {
+             const sub: StateSubmissionType = {
+                 ...mockContractAndRatesSubmission(),
+                 contractDateStart: new Date('01-01-2021'),
+                 contractDateEnd: new Date('01-01-2025'),
+                 rateDateStart: new Date('01-01-2021'),
+                 rateDateEnd: new Date('01-01-2022'),
+             }
+            const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
+              
+              expect(template).toEqual(
+                  expect.objectContaining({
+                      bodyText: expect.stringContaining(
+                          'Submission type: Contract action and rate certification'
+                      ),
+                  })
+              )
+              expect(template).toEqual(
+                  expect.objectContaining({
+                      bodyText: expect.stringContaining(
+                         'Rating period: 2021-01-01 to 2022-01-01'
+                      ),
+                  })
+              )
+
+               expect(template).toEqual(
+                   expect.objectContaining({
+                       bodyText: expect.stringContaining(
+                           'Contract effective dates: 2021-01-01 to 2025-01-01'
+                       ),
+                   })
+               )
+
+        })
+        it('includes expected data summary for a contract amendment submission', () => {
+                 const sub: StateSubmissionType = {
+                     ...mockContractAmendmentSubmission(),
+                     contractDateStart: new Date('01-01-2021'),
+                     contractDateEnd: new Date('01-01-2025'),
+                     rateDateStart: new Date('01-01-2021'),
+                     rateDateEnd: new Date('01-01-2022'),
+                 }
+            const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
+            
+            expect(template).toEqual(
+                         expect.objectContaining({
+                             bodyText: expect.stringContaining(
+                                 'Submission type: Contract action and rate certification'
+                             ),
+                         })
+                     )
+                     expect(template).toEqual(
+                         expect.objectContaining({
+                             bodyText: expect.stringContaining(
+                                 'Rating period: 2021-01-01 to 2022-01-01'
+                             ),
+                         })
+                     )
+
+                     expect(template).toEqual(
+                         expect.objectContaining({
+                             bodyText: expect.stringContaining(
+                                 'Contract amendment effective dates: 2021-01-01 to 2025-01-01'
+                             ),
+                         })
+                     )
+
+        })
+        it('includes link to submission', () => {
+            const sub = mockContractAmendmentSubmission()
+            const template = newPackageCMSEmailTemplate(
+                sub,
+                testEmailConfig
+            )
+             expect(template).toEqual(
+                 expect.objectContaining({
+                     bodyText: expect.stringContaining(
+                         `http://localhost/submissions/${sub.id}`
+                     ),
+                 })
+             )
+        })
+
+    })
+     describe('State email', () => {
+         it('to addresses list includes current user', () => {
+             const sub = mockContractOnlySubmission()
+             const user = mockUser()
+             const template = newPackageStateEmailTemplate(
+                 sub,
+                 user,
+                 testEmailConfig
+             )
+            expect(template).toEqual(
+                expect.objectContaining({
+                    toAddresses: expect.arrayContaining(
+                        [ user.email]
+                    )
+                })
+            )
+        })
+
+        it('to addresses list includes all state contacts on submission', () => {
+            const sub: StateSubmissionType = {...mockContractOnlySubmission(), stateContacts: [{name: 'test1', titleRole: 'Foo1', email: 'test1@example.com'}, {name: 'test2', titleRole: 'Foo2', email: 'test2@example.com'}]}
+            const user = mockUser()
+            const template = newPackageStateEmailTemplate(
+                sub,
+                user,
+                testEmailConfig
+            )
+            sub.stateContacts.forEach( contact => {
+                 expect(template).toEqual(expect.objectContaining({
+                     toAddresses: expect.arrayContaining([contact.email]),
+                 }))
+            })
+    
+        })
+
+         
+         it('subject line is correct and clearly states submission is complete', () => {
+             const sub = mockContractOnlySubmission()
+             const name = submissionName(sub)
+             const user = mockUser()
+             const template = newPackageStateEmailTemplate(
+                 sub,
+                 user,
+                 testEmailConfig
+             )
+
+             expect(template).toEqual(
+                 expect.objectContaining({
+                     subject: expect.stringContaining(
+                         `TEST ${name} was sent to CMS`
+                     ),
+                      bodyText: expect.stringContaining(
+                           `${name} was successfully submitted.`
+                    ),
+      
+                 })
+             )
+         })
+
+         it('includes warning about unofficial submission', () => {
+             const sub = mockContractOnlySubmission()
+             const user = mockUser()
+             const template = newPackageStateEmailTemplate(
+                 sub,
+                 user,
+                 testEmailConfig
+             )
+             expect(template).toEqual(
+                 expect.objectContaining({
+                     bodyText: expect.stringMatching(
+                         /This is NOT an official submission/
+                     ),
+                 })
+             )
+         })
+
+        it('includes link to submission', () => {
+            const sub = mockContractAmendmentSubmission()
+            const user = mockUser()
+            const template = newPackageStateEmailTemplate(
+                sub,
+                user,
+                testEmailConfig
+            )
+            expect(template).toEqual(
+                expect.objectContaining({
+                    bodyText: expect.stringContaining(
+                        `http://localhost/submissions/${sub.id}`
+                    ),
+                })
+            )
+        })
+    
+        it('includes information about what is next', () => {
+            const sub = mockContractAmendmentSubmission()
+            const user = mockUser()
+            const template = newPackageStateEmailTemplate(
+                sub,
+                user,
+                testEmailConfig
+            )
+            expect(template).toEqual(
+                expect.objectContaining({
+                    bodyText: expect.stringContaining(
+                        'What comes next:'
+                    ),
+                })
+            )
+        })
+
+     })
+})

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -29,11 +29,11 @@ const newPackageCMSEmailTemplate = (
             ? 'Contract amendment effective dates'
             : 'Contract effective dates'
     }: ${
-        dayjs(submission.contractDateStart).format('YYYY-MM-DD') +
+        dayjs(submission.contractDateStart).format('MM/DD/YYYY') +
         ' to ' +
-        dayjs(submission.contractDateEnd).format('YYYY-MM-DD')
+        dayjs(submission.contractDateEnd).format('MM/DD/YYYY')
     }`
-    const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `Rating period: ${dayjs(submission.rateDateStart).format('YYYY-MM-DD') + ' to ' + dayjs(submission.rateDateEnd).format('YYYY-MM-DD')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
+    const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `Rating period: ${dayjs(submission.rateDateStart).format('MM/DD/YYYY') + ' to ' + dayjs(submission.rateDateEnd).format('MM/DD/YYYY')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
 
     return {
         toAddresses: reviewerEmails,

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -1,5 +1,5 @@
 import { URL } from 'url'
-
+import dayjs from 'dayjs'
 import {
     SubmissionType,
     StateSubmissionType,
@@ -22,8 +22,18 @@ const newPackageCMSEmailTemplate = (
         config.baseUrl
     ).href
     const isTestEnvironment = config.stage !== 'prod'
-
     const reviewerEmails = config.cmsReviewSharedEmails
+
+    const contractEffectiveDatesText = `${
+        submission.contractType === 'AMENDMENT'
+            ? 'Contract amendment effective dates'
+            : 'Contract effective dates'
+    }: ${
+        dayjs(submission.contractDateStart).format('YYYY-MM-DD') +
+        ' to ' +
+        dayjs(submission.contractDateEnd).format('YYYY-MM-DD')
+    }`
+    const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `Rating period: ${dayjs(submission.rateDateStart).format('YYYY-MM-DD') + ' to ' + dayjs(submission.rateDateEnd).format('YYYY-MM-DD')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
 
     return {
         toAddresses: reviewerEmails,
@@ -35,8 +45,10 @@ const newPackageCMSEmailTemplate = (
         ${submissionName(submission)} was received from ${submission.stateCode}.
 
             Submission type: ${SubmissionTypeRecord[submission.submissionType]}
+            ${contractEffectiveDatesText}
+            ${ratingPeriod}
             Submission description: ${submission.submissionDescription}
-
+  
             View submission: ${submissionURL}`,
         bodyHTML: `
             <span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
@@ -47,6 +59,10 @@ const newPackageCMSEmailTemplate = (
             Submission type: ${
                 SubmissionTypeRecord[submission.submissionType]
             }<br />
+            ${contractEffectiveDatesText}
+            <br />
+            ${ratingPeriod}
+            <br />
             Submission description: ${
                 submission.submissionDescription
             }<br /><br />

--- a/services/app-api/testHelpers/emailerHelpers.ts
+++ b/services/app-api/testHelpers/emailerHelpers.ts
@@ -1,0 +1,212 @@
+    import {EmailConfiguration, EmailData,
+        Emailer,
+        newPackageCMSEmailTemplate,
+        newPackageStateEmailTemplate,
+    } from '../emailer'
+    import { StateSubmissionType, CognitoUserType, CognitoStateUserType } from '../../app-web/src/common-code/domain-models'
+
+       
+    const testEmailConfig: EmailConfiguration = {
+        stage: 'LOCAL',
+        baseUrl: 'http://localhost',
+        emailSource: 'emailSource@example.com',
+        cmsReviewSharedEmails: ['cmsreview1@example.com', 'cmsreview2@example.com']
+   }
+    const testEmailer = (customConfig?: EmailConfiguration): Emailer => {
+        const config = customConfig || testEmailConfig
+        return {
+            sendEmail: jest.fn(
+                async (emailData: EmailData): Promise<void | Error> => {
+                    console.log('Email content' + emailData)
+                }
+            ),
+            sendCMSNewPackage: function async(
+                submission: StateSubmissionType
+            ): Promise<void | Error> {
+                const emailData = newPackageCMSEmailTemplate(submission, config)
+                return this.sendEmail(emailData)
+            },
+            sendStateNewPackage: function async(
+                submission: StateSubmissionType,
+                user: CognitoUserType
+            ): Promise<void | Error> {
+                const emailData = newPackageStateEmailTemplate(
+                    submission,
+                    user,
+                    config
+                )
+                return this.sendEmail(emailData)
+            },
+        }
+    }
+    
+   const mockUser = (): CognitoStateUserType  => {
+        return {
+            role: 'STATE_USER',
+            email: 'test+state+user@example.com',
+            name: 'Test State User',
+            state_code: 'MN',
+            }
+   }
+   
+   const mockContractAndRatesSubmission = (
+       submissionPartial?: Partial<StateSubmissionType>
+   ): StateSubmissionType => {
+       return {
+           createdAt: new Date(),
+           updatedAt: new Date(),
+           status: 'SUBMITTED',
+           stateNumber: 3,
+           id: 'test-abc-125',
+           stateCode: 'MN',
+           programIDs: ['snbc'],
+           submissionType: 'CONTRACT_AND_RATES',
+           submissionDescription: 'A submitted submission',
+           submittedAt: new Date(),
+           documents: [
+               {
+                   s3URL: 'bar',
+                   name: 'foo',
+                   documentCategories: ['RATES_RELATED' as const],
+               },
+           ],
+           contractType: 'BASE',
+           contractDocuments: [
+               {
+                   s3URL: 'bar',
+                   name: 'foo',
+                   documentCategories: ['CONTRACT' as const],
+               },
+           ],
+           contractDateStart: new Date(),
+           contractDateEnd: new Date(),
+           managedCareEntities: ['ENROLLMENT_PROCESS'],
+           federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
+           rateType: 'NEW',
+           rateDocuments: [
+               {
+                   s3URL: 'bar',
+                   name: 'foo',
+                   documentCategories: ['RATES' as const],
+               },
+           ],
+           rateDateStart: new Date(),
+           rateDateEnd: new Date(),
+           rateDateCertified: new Date(),
+           rateAmendmentInfo: null,
+           stateContacts: [
+               {
+                   name: 'Test Person',
+                   titleRole: 'A Role',
+                   email: 'test+state+contact@example.com',
+               },
+           ],
+           actuaryContacts: [],
+           ...submissionPartial
+       }
+   }
+   
+   const mockContractOnlySubmission = (
+       submissionPartial?: Partial<StateSubmissionType>
+   ): StateSubmissionType => {
+       return {
+           createdAt: new Date(),
+           updatedAt: new Date(),
+           status: 'SUBMITTED',
+           stateNumber: 3,
+           id: 'test-abc-125',
+           stateCode: 'MN',
+           programIDs: ['snbc'],
+           submissionType: 'CONTRACT_ONLY',
+           submissionDescription: 'A submitted submission',
+           submittedAt: new Date(),
+           documents: [
+               {
+                   s3URL: 'bar',
+                   name: 'foo',
+                   documentCategories: ['RATES_RELATED' as const],
+               },
+           ],
+           contractType: 'BASE',
+           contractDocuments: [
+               {
+                   s3URL: 'bar',
+                   name: 'foo',
+                   documentCategories: ['CONTRACT' as const],
+               },
+           ],
+           contractDateStart: new Date(),
+           contractDateEnd: new Date(),
+           managedCareEntities: ['ENROLLMENT_PROCESS'],
+           federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
+           rateDocuments: [],
+           stateContacts: [
+               {
+                   name: 'Test Person',
+                   titleRole: 'A Role',
+                   email: 'test+state+contact@example.com',
+               },
+           ],
+           actuaryContacts: [],
+           ...submissionPartial,
+       }
+   }
+
+const mockContractAmendmentSubmission = (
+    submissionPartial?: Partial<StateSubmissionType>
+): StateSubmissionType => {
+    return {
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        status: 'SUBMITTED',
+        stateNumber: 3,
+        id: 'test-abc-125',
+        stateCode: 'MN',
+        programIDs: ['snbc'],
+        submissionType: 'CONTRACT_AND_RATES',
+        submissionDescription: 'A submitted submission',
+        submittedAt: new Date(),
+        documents: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+        ],
+        contractType: 'AMENDMENT',
+        contractDocuments: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['CONTRACT' as const],
+            },
+        ],
+        contractDateStart: new Date(),
+        contractDateEnd: new Date(),
+        managedCareEntities: ['ENROLLMENT_PROCESS'],
+        federalAuthorities: ['VOLUNTARY', 'BENCHMARK'],
+        rateType: 'NEW',
+        rateDocuments: [
+            {
+                s3URL: 'bar',
+                name: 'foo',
+                documentCategories: ['RATES' as const],
+            },
+        ],
+        rateDateStart: new Date(),
+        rateDateEnd: new Date(),
+        rateDateCertified: new Date(),
+        rateAmendmentInfo: null,
+        stateContacts: [
+            {
+                name: 'Test Person',
+                titleRole: 'A Role',
+                email: 'test+state+contact@example.com',
+            },
+        ],
+        actuaryContacts: [],
+        ...submissionPartial,
+    }
+}
+
+   export {testEmailConfig, mockContractAmendmentSubmission, mockContractOnlySubmission, mockContractAndRatesSubmission, mockUser, testEmailer}

--- a/services/app-api/testHelpers/gqlHelpers.ts
+++ b/services/app-api/testHelpers/gqlHelpers.ts
@@ -270,4 +270,5 @@ export {
     createAndUpdateTestDraftSubmission,
     fetchTestDraftSubmissionById,
     fetchTestStateSubmissionById,
+    defaultContext
 }


### PR DESCRIPTION
## Summary
Update CMS submission email to include key dates

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-15321


#### Test cases covered
- I added `templates.test.ts` which includes several new unit tests that cover all of the current logic in our email templates (including new dates work).
-  Simplified `submitDraftSubmission.test.ts` accordingly.
- Added `emailerHelpers.ts`
- Exported the `defaultContext` used in our gql handlers for tests - that way the tests can determine who is the "current user"

## QA guidance
Make a submission, then check shared email to ensure CMS email includes new dates fields
