### PR TITLE
Alert if Promote has 'skipped' results

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -353,7 +353,7 @@ jobs:
   slack:
     name: Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [cypress-prod]
+    needs: [cypress-prod, cypress-val]
     if: always()
     steps:
       # this action sets env.WORKFLOW_CONCLUSION so we can call a
@@ -362,7 +362,7 @@ jobs:
 
       - name: Alert Slack On Failure
         uses: rtCamp/action-slack-notify@v2
-        if: env.WORKFLOW_CONCLUSION == 'failure'
+        if: (env.WORKFLOW_CONCLUSION == 'failure' || needs.cypress-prod.result == 'skipped' || needs.cypress-val.result == 'skipped')
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: Deploy Alerts


### PR DESCRIPTION
## Summary

This adds a Slack notification if our val or prod tasks during promote are ever 'skipped', which in our case indicates something is wrong since we always want to promote to each environment. Skips should only ever happen with our "skipping" action in dev PR branches.

#### Related Issues

https://qmacbis.atlassian.net/browse/OY2-15466
