### PR TITLE
Add email styling tweaks

### DIFF
--- a/services/app-api/emailer/emailer.ts
+++ b/services/app-api/emailer/emailer.ts
@@ -1,8 +1,8 @@
 import { Lambda } from 'aws-sdk'
 import {
     getSESEmailParams,
-    newPackageCMSEmailTemplate,
-    newPackageStateEmailTemplate,
+    newPackageCMSEmail,
+    newPackageStateEmail,
 } from './'
 import {
     StateSubmissionType,
@@ -57,14 +57,14 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
             }
         },
         sendCMSNewPackage: async function (submission: StateSubmissionType) {
-            const emailData = newPackageCMSEmailTemplate(submission, config)
+            const emailData = newPackageCMSEmail(submission, config)
             return await this.sendEmail(emailData)
         },
         sendStateNewPackage: async function (
             submission: StateSubmissionType,
             user: CognitoUserType
         ) {
-            const emailData = newPackageStateEmailTemplate(
+            const emailData = newPackageStateEmail(
                 submission,
                 user,
                 config
@@ -86,7 +86,7 @@ function newLocalEmailer(config: EmailConfiguration): Emailer {
         `)
         },
         sendCMSNewPackage: async (submission: StateSubmissionType) => {
-            const emailData = newPackageCMSEmailTemplate(submission, config)
+            const emailData = newPackageCMSEmail(submission, config)
             const emailRequestParams = getSESEmailParams(emailData)
             console.log(`
             EMAIL SENT
@@ -99,7 +99,7 @@ function newLocalEmailer(config: EmailConfiguration): Emailer {
             submission: StateSubmissionType,
             user: CognitoUserType
         ) => {
-            const emailData = newPackageStateEmailTemplate(
+            const emailData = newPackageStateEmail(
                 submission,
                 user,
                 config

--- a/services/app-api/emailer/index.ts
+++ b/services/app-api/emailer/index.ts
@@ -1,8 +1,8 @@
 export { getSESEmailParams, sendSESEmail } from './awsSES'
 export { newLocalEmailer, newSESEmailer } from './emailer'
 export {
-    newPackageCMSEmailTemplate,
-    newPackageStateEmailTemplate,
+    newPackageCMSEmail,
+    newPackageStateEmail,
 } from './templates'
 
 export type { EmailConfiguration, EmailData, Emailer } from './emailer'

--- a/services/app-api/emailer/templates.test.ts
+++ b/services/app-api/emailer/templates.test.ts
@@ -3,13 +3,13 @@ import {
     submissionName,
     StateSubmissionType
 } from '../../app-web/src/common-code/domain-models'
-import {newPackageCMSEmailTemplate, newPackageStateEmailTemplate} from './'
+import {newPackageCMSEmail, newPackageStateEmail} from './'
 
 describe('Email templates', () => {
     describe('CMS email', () => {
         it('to addresses list includes review email addresses from email config', () => {
             const sub = mockContractOnlySubmission()
-            const template = newPackageCMSEmailTemplate(
+            const template = newPackageCMSEmail(
                 sub,
                 testEmailConfig
             )
@@ -27,7 +27,7 @@ describe('Email templates', () => {
         it('subject line is correct', () => {
             const sub  = mockContractOnlySubmission()
             const name = submissionName(sub)
-            const template = newPackageCMSEmailTemplate(sub,testEmailConfig)
+            const template = newPackageCMSEmail(sub,testEmailConfig)
             
             expect(template).toEqual(
                 expect.objectContaining({
@@ -41,7 +41,7 @@ describe('Email templates', () => {
 
         it('includes warning about unofficial submission', () => {
             const sub = mockContractOnlySubmission()
-            const template = newPackageCMSEmailTemplate( sub, testEmailConfig)
+            const template = newPackageCMSEmail( sub, testEmailConfig)
              expect(template).toEqual(
                  expect.objectContaining({
                      bodyText: expect.stringMatching(
@@ -59,7 +59,7 @@ describe('Email templates', () => {
                 contractDateStart: new Date('01/01/2021'),
                 contractDateEnd: new Date('01/01/2025')
             }
-            const template = newPackageCMSEmailTemplate(
+            const template = newPackageCMSEmail(
                 sub,
                 testEmailConfig
             )
@@ -96,7 +96,7 @@ describe('Email templates', () => {
                  rateDateStart: new Date('01/01/2021'),
                  rateDateEnd: new Date('01/01/2022'),
              }
-            const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
+            const template = newPackageCMSEmail(sub, testEmailConfig)
               
               expect(template).toEqual(
                   expect.objectContaining({
@@ -130,7 +130,7 @@ describe('Email templates', () => {
                      rateDateStart: new Date('01/01/2021'),
                      rateDateEnd: new Date('01/01/2022'),
                  }
-            const template = newPackageCMSEmailTemplate(sub, testEmailConfig)
+            const template = newPackageCMSEmail(sub, testEmailConfig)
             
             expect(template).toEqual(
                          expect.objectContaining({
@@ -158,7 +158,7 @@ describe('Email templates', () => {
         })
         it('includes link to submission', () => {
             const sub = mockContractAmendmentSubmission()
-            const template = newPackageCMSEmailTemplate(
+            const template = newPackageCMSEmail(
                 sub,
                 testEmailConfig
             )
@@ -176,7 +176,7 @@ describe('Email templates', () => {
          it('to addresses list includes current user', () => {
              const sub = mockContractOnlySubmission()
              const user = mockUser()
-             const template = newPackageStateEmailTemplate(
+             const template = newPackageStateEmail(
                  sub,
                  user,
                  testEmailConfig
@@ -193,7 +193,7 @@ describe('Email templates', () => {
         it('to addresses list includes all state contacts on submission', () => {
             const sub: StateSubmissionType = {...mockContractOnlySubmission(), stateContacts: [{name: 'test1', titleRole: 'Foo1', email: 'test1@example.com'}, {name: 'test2', titleRole: 'Foo2', email: 'test2@example.com'}]}
             const user = mockUser()
-            const template = newPackageStateEmailTemplate(
+            const template = newPackageStateEmail(
                 sub,
                 user,
                 testEmailConfig
@@ -211,7 +211,7 @@ describe('Email templates', () => {
              const sub = mockContractOnlySubmission()
              const name = submissionName(sub)
              const user = mockUser()
-             const template = newPackageStateEmailTemplate(
+             const template = newPackageStateEmail(
                  sub,
                  user,
                  testEmailConfig
@@ -233,7 +233,7 @@ describe('Email templates', () => {
          it('includes warning about unofficial submission', () => {
              const sub = mockContractOnlySubmission()
              const user = mockUser()
-             const template = newPackageStateEmailTemplate(
+             const template = newPackageStateEmail(
                  sub,
                  user,
                  testEmailConfig
@@ -250,7 +250,7 @@ describe('Email templates', () => {
         it('includes link to submission', () => {
             const sub = mockContractAmendmentSubmission()
             const user = mockUser()
-            const template = newPackageStateEmailTemplate(
+            const template = newPackageStateEmail(
                 sub,
                 user,
                 testEmailConfig
@@ -267,7 +267,7 @@ describe('Email templates', () => {
         it('includes information about what is next', () => {
             const sub = mockContractAmendmentSubmission()
             const user = mockUser()
-            const template = newPackageStateEmailTemplate(
+            const template = newPackageStateEmail(
                 sub,
                 user,
                 testEmailConfig

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -26,14 +26,14 @@ const newPackageCMSEmail = (
 
     const contractEffectiveDatesText = `${
         submission.contractType === 'AMENDMENT'
-            ? 'Contract amendment effective dates'
-            : 'Contract effective dates'
+            ? '<b>Contract amendment effective dates</b>'
+            : '<b>Contract effective dates</b>'
     }: ${
         dayjs(submission.contractDateStart).format('MM/DD/YYYY') +
         ' to ' +
         dayjs(submission.contractDateEnd).format('MM/DD/YYYY')
     }`
-    const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `Rating period: ${dayjs(submission.rateDateStart).format('MM/DD/YYYY') + ' to ' + dayjs(submission.rateDateEnd).format('MM/DD/YYYY')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
+    const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `<b>Rating period:</b> ${dayjs(submission.rateDateStart).format('MM/DD/YYYY') + ' to ' + dayjs(submission.rateDateEnd).format('MM/DD/YYYY')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
 
     return {
         toAddresses: reviewerEmails,
@@ -42,7 +42,7 @@ const newPackageCMSEmail = (
             isTestEnvironment ? `[${config.stage}] ` : ''
         }TEST New Managed Care Submission: ${submissionName(submission)}`,
         bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-        ${submissionName(submission)} was received from ${submission.stateCode}.
+        Managed Care submission: <b>${submissionName(submission)}</b> was received from <b>${submission.stateCode}</b>.
 
             Submission type: ${SubmissionTypeRecord[submission.submissionType]}
             ${contractEffectiveDatesText}
@@ -56,14 +56,13 @@ const newPackageCMSEmail = (
             ${submissionName(submission)} was received from ${
             submission.stateCode
         }.<br /><br />
-            Submission type: ${
+            <b>Submission type:<b> ${
                 SubmissionTypeRecord[submission.submissionType]
             }<br />
             ${contractEffectiveDatesText}
             <br />
-            ${ratingPeriod}
-            <br />
-            Submission description: ${
+            ${ratingPeriod}${ratingPeriod.length > 0? '<br />' : ''}
+            <b>Submission description:</b> ${
                 submission.submissionDescription
             }<br /><br />
             <a href="${submissionURL}">View submission</a>

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -59,10 +59,10 @@ const newPackageCMSEmail = (
         ).href
     const bodyHTML = `<span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
             <br /><br />
-            ${submissionName(submission)} was received from ${
+            Managed Care submission: <b>${submissionName(submission)}</b> was received from <b>${
             submission.stateCode
-        }.<br /><br />
-            <b>Submission type:<b> ${
+        }</b>.<br /><br />
+            <b>Submission type:</b> ${
                 SubmissionTypeRecord[submission.submissionType]
             }<br />
             ${contractEffectiveDatesText}

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -13,17 +13,36 @@ const SubmissionTypeRecord: Record<SubmissionType, string> = {
     CONTRACT_AND_RATES: 'Contract action and rate certification',
 }
 
+// Clean out HTML tags from an HTML based template
+// this way we still have a text alternative for email client rendering html in plaintext
+// plaintext is also referenced for unit testing
+const stripHTMLFromTemplate = (template: string) => {
+    let formatted = template
+    // remove BR tags and replace them with line break
+    formatted = formatted.replace(/<br>/gi, '\n')
+    formatted = formatted.replace(/<br\s\/>/gi, '\n')
+    formatted = formatted.replace(/<br\/>/gi, '\n')
+
+    // remove P and A tags but preserve what's inside of them
+    formatted = formatted.replace(/<p.*>/gi, '\n')
+    formatted = formatted.replace(
+        /<a.*href="(.*?)".*>(.*?)<\/a>/gi,
+        ' $2 ($1)'
+    )
+
+    // everything else
+   return formatted.replace(/(<([^>]+)>)/gi, '')
+}
+
 const newPackageCMSEmail = (
     submission: StateSubmissionType,
     config: EmailConfiguration
 ): EmailData => {
-    const submissionURL = new URL(
-        `submissions/${submission.id}`,
-        config.baseUrl
-    ).href
+    // config
     const isTestEnvironment = config.stage !== 'prod'
     const reviewerEmails = config.cmsReviewSharedEmails
 
+    // template
     const contractEffectiveDatesText = `${
         submission.contractType === 'AMENDMENT'
             ? '<b>Contract amendment effective dates</b>'
@@ -34,24 +53,11 @@ const newPackageCMSEmail = (
         dayjs(submission.contractDateEnd).format('MM/DD/YYYY')
     }`
     const ratingPeriod = `${submission.submissionType === 'CONTRACT_AND_RATES' ? `<b>Rating period:</b> ${dayjs(submission.rateDateStart).format('MM/DD/YYYY') + ' to ' + dayjs(submission.rateDateEnd).format('MM/DD/YYYY')}`: ''}` // displays nothing if submission is CONTRACT_ONLY
-
-    return {
-        toAddresses: reviewerEmails,
-        sourceEmail: config.emailSource,
-        subject: `${
-            isTestEnvironment ? `[${config.stage}] ` : ''
-        }TEST New Managed Care Submission: ${submissionName(submission)}`,
-        bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-        Managed Care submission: <b>${submissionName(submission)}</b> was received from <b>${submission.stateCode}</b>.
-
-            Submission type: ${SubmissionTypeRecord[submission.submissionType]}
-            ${contractEffectiveDatesText}
-            ${ratingPeriod}
-            Submission description: ${submission.submissionDescription}
-  
-            View submission: ${submissionURL}`,
-        bodyHTML: `
-            <span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+        const submissionURL = new URL(
+            `submissions/${submission.id}`,
+            config.baseUrl
+        ).href
+    const bodyHTML = `<span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
             <br /><br />
             ${submissionName(submission)} was received from ${
             submission.stateCode
@@ -66,7 +72,15 @@ const newPackageCMSEmail = (
                 submission.submissionDescription
             }<br /><br />
             <a href="${submissionURL}">View submission</a>
-        `,
+        `
+    return {
+        toAddresses: reviewerEmails,
+        sourceEmail: config.emailSource,
+        subject: `${
+            isTestEnvironment ? `[${config.stage}] ` : ''
+        }TEST New Managed Care Submission: ${submissionName(submission)}`,
+        bodyText: stripHTMLFromTemplate(bodyHTML),
+        bodyHTML: bodyHTML,
     }
 }
 
@@ -83,27 +97,7 @@ const newPackageStateEmail = (
     const receiverEmails: string[] = [currentUserEmail].concat(
         submission.stateContacts.map((contact) => contact.email)
     )
-    return {
-        toAddresses: receiverEmails,
-        sourceEmail: config.emailSource,
-        subject: `${
-            config.stage !== 'prod' ? `[${config.stage}] ` : ''
-        }TEST ${submissionName(submission)} was sent to CMS`,
-        bodyText: `Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.
-
-            ${submissionName(submission)} was successfully submitted.
-        
-            View submission: ${submissionURL}
-            
-            If you need to make any changes, please contact CMS.
-        
-            What comes next:
-            1. Check for completeness: CMS will review all documentation submitted to ensure all required materials were received.
-            2. CMS review: Your submission will be reviewed by CMS for adherence to federal regulations. If a rate certification is included, it will be reviewed for policy adherence and actuarial soundness.
-            3. Questions: You may receive questions via email from CMS as they conduct their review.
-            4. Decision: Once all questions have been addressed, CMS will contact you with their final recommendation.`,
-        bodyHTML: `
-            <span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
+    const bodyHTML =  `<span style="color:#FF0000;font-weight:bold;">Note: This submission is part of the MC-Review testing process. This is NOT an official submission and will only be used for testing purposes.</span>
             <br /><br />
              ${submissionName(submission)} was successfully submitted.
             <br /><br />
@@ -127,7 +121,15 @@ const newPackageStateEmail = (
 
                 </li>
             </ol>
-        `,
+        `
+    return {
+        toAddresses: receiverEmails,
+        sourceEmail: config.emailSource,
+        subject: `${
+            config.stage !== 'prod' ? `[${config.stage}] ` : ''
+        }TEST ${submissionName(submission)} was sent to CMS`,
+        bodyText: stripHTMLFromTemplate(bodyHTML),
+        bodyHTML: bodyHTML,
     }
 }
 

--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -13,7 +13,7 @@ const SubmissionTypeRecord: Record<SubmissionType, string> = {
     CONTRACT_AND_RATES: 'Contract action and rate certification',
 }
 
-const newPackageCMSEmailTemplate = (
+const newPackageCMSEmail = (
     submission: StateSubmissionType,
     config: EmailConfiguration
 ): EmailData => {
@@ -71,7 +71,7 @@ const newPackageCMSEmailTemplate = (
     }
 }
 
-const newPackageStateEmailTemplate = (
+const newPackageStateEmail = (
     submission: StateSubmissionType,
     user: CognitoUserType,
     config: EmailConfiguration
@@ -132,5 +132,5 @@ const newPackageStateEmailTemplate = (
     }
 }
 
-export { newPackageCMSEmailTemplate, newPackageStateEmailTemplate }
+export { newPackageCMSEmail, newPackageStateEmail }
 

--- a/services/app-api/testHelpers/emailerHelpers.ts
+++ b/services/app-api/testHelpers/emailerHelpers.ts
@@ -17,7 +17,7 @@
         return {
             sendEmail: jest.fn(
                 async (emailData: EmailData): Promise<void | Error> => {
-                    console.log('Email content' + emailData)
+                    console.log('Email content' + JSON.stringify(emailData))
                 }
             ),
             sendCMSNewPackage: function async(

--- a/services/app-api/testHelpers/emailerHelpers.ts
+++ b/services/app-api/testHelpers/emailerHelpers.ts
@@ -1,7 +1,7 @@
     import {EmailConfiguration, EmailData,
         Emailer,
-        newPackageCMSEmailTemplate,
-        newPackageStateEmailTemplate,
+        newPackageCMSEmail,
+        newPackageStateEmail,
     } from '../emailer'
     import { StateSubmissionType, CognitoUserType, CognitoStateUserType } from '../../app-web/src/common-code/domain-models'
 
@@ -23,14 +23,14 @@
             sendCMSNewPackage: function async(
                 submission: StateSubmissionType
             ): Promise<void | Error> {
-                const emailData = newPackageCMSEmailTemplate(submission, config)
+                const emailData = newPackageCMSEmail(submission, config)
                 return this.sendEmail(emailData)
             },
             sendStateNewPackage: function async(
                 submission: StateSubmissionType,
                 user: CognitoUserType
             ): Promise<void | Error> {
-                const emailData = newPackageStateEmailTemplate(
+                const emailData = newPackageStateEmail(
                     submission,
                     user,
                     config


### PR DESCRIPTION
## Summary
Fixed a styling a bug where when rating period wasn't included on emails we were still displaying an extra line break `<br>`. 


Also
- added more styling and text changes I found in the updated [Figma copy](https://www.figma.com/file/a0PPSr65q1G798zV4bhzzO/State-submission-form?node-id=5804%3A49022) for CMS email
-  simplify the relationship between `bodyText` and `bodyHTML` by making a convertor. 
-  did requested renaming of templater functions @macrael 👍 

#### Related issues
follow on for https://qmacbis.atlassian.net/browse/OY2-15321

## Screenshots
BEFORE: what the bug looked like for any submission that doesn't have rates
![Screen Shot 2022-01-27 at 11 38 09 AM](https://user-images.githubusercontent.com/10750442/151419365-5f3500fc-caca-45f3-bddc-5a7f0357b142.png)



AFTER: now with bugfix and styling changes
![Screen Shot 2022-01-27 at 12 58 24 PM](https://user-images.githubusercontent.com/10750442/151425633-b40c1cf4-5445-4087-98a0-071224cf54e5.png)

