### PR TITLE
Double timeout for flaky api test to 10 seconds

### DIFF
--- a/services/app-api/resolvers/updateDraftSubmission.test.ts
+++ b/services/app-api/resolvers/updateDraftSubmission.test.ts
@@ -1,16 +1,15 @@
-import { DraftSubmissionType } from '../../app-web/src/common-code/domain-models'
-import {
-    DraftSubmissionUpdates,
-    CreateDraftSubmissionInput,
-} from '../gen/gqlServer'
 import CREATE_DRAFT_SUBMISSION from '../../app-graphql/src/mutations/createDraftSubmission.graphql'
 import UPDATE_DRAFT_SUBMISSION from '../../app-graphql/src/mutations/updateDraftSubmission.graphql'
+import { DraftSubmissionType } from '../../app-web/src/common-code/domain-models'
+import {
+    CreateDraftSubmissionInput,
+    DraftSubmissionUpdates,
+} from '../gen/gqlServer'
 import {
     constructTestPostgresServer,
     createTestDraftSubmission,
     fetchTestDraftSubmissionById,
 } from '../testHelpers/gqlHelpers'
-
 import { applyUpdates } from './updateDraftSubmission'
 
 describe('updateDraftSubmission', () => {
@@ -297,7 +296,7 @@ describe('updateDraftSubmission', () => {
         expect(resultDraft.rateDateStart).toBe(startDate)
         expect(resultDraft.rateDateEnd).toBe(endDate)
         expect(resultDraft.rateDateCertified).toBe(certifiedDate)
-    })
+    }, 10000)
 
     it('updates a submission to have documents', async () => {
         const server = await constructTestPostgresServer()
@@ -896,7 +895,7 @@ describe('updateDraftSubmission', () => {
             {
                 name: 'myfile.pdf',
                 s3URL: 'fakeS3URL',
-                documentCategories:[ 'RATES_RELATED'],
+                documentCategories: ['RATES_RELATED'],
             },
         ])
 

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -55,7 +55,7 @@ describe('dashboard', () => {
         cy.findByRole('heading', { level: 2, name: /Review and submit/ })
         cy.pa11y({
             actions: ['wait for element #submissionTypeSection to be visible'],
-            threshold: 22, // This ratchet is tracked by https://qmacbis.atlassian.net/browse/OY2-15950
+            threshold: 23, // This ratchet is tracked by https://qmacbis.atlassian.net/browse/OY2-15950
         })
 
         // Submit, sent to dashboard


### PR DESCRIPTION
## Summary
We have a test that is failing from time to time, seems like it might be related to postgres spinning up? We definitely think it’s only started happening post postgres. 

I vaguely remember seeing this in deploy.yml CI runs, but recently it’s only been happening on Promote. 

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-14070


I’ve doubled the timeout of this test, it is a bit suspicious that this particular test has a 2 second delay in it, so maybe we’re just hitting the timeout naturally. 