### PR TITLE
Update ClamAV layer to latest version 0.6 (ClamAV v0.103.3)

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -48,7 +48,7 @@ custom:
       # This script is run locally when running 'serverless deploy'
       package:initialize: |
         set -e
-        curl -L --output lambda_layer.zip https://github.com/CMSgov/lambda-clamav-layer/releases/download/0.5/lambda_layer.zip
+        curl -L --output lambda_layer.zip https://github.com/CMSgov/lambda-clamav-layer/releases/download/0.6/lambda_layer.zip
       deploy:finalize: |
         rm lambda_layer.zip
         serverless invoke --stage ${self:custom.stage} --function avDownloadDefinitions -t Event


### PR DESCRIPTION
## Summary

ClamAV has been unable to download new virus definitions for two days b/c it was EOL’d. Updating to the latest LTS release should make things work again.

In all environmnents deployed on or after Feb 1, the virus definitions have never been downloaded and virus scanning always fails.

We depend on https://github.com/CMSgov/lambda-clamav-layer/ so I made a new release there with the more recent version of ClamAV.

## QA guidance

If you can log into this review app and upload a file successfully then the fix worked. 