### PR TITLE
Modify avDownloadDefinitions to upload and download all clamAV files, not just the 3 named ones

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -49,7 +49,7 @@ custom:
       # This script is run locally when running 'serverless deploy'
       package:initialize: |
         set -e
-        curl -L --output lambda_layer.zip https://github.com/CMSgov/lambda-clamav-layer/releases/download/0.6/lambda_layer.zip
+        curl -L --output lambda_layer.zip https://github.com/CMSgov/lambda-clamav-layer/releases/download/0.7/lambda_layer.zip
       deploy:finalize: |
         rm lambda_layer.zip
         serverless invoke --stage ${self:custom.stage} --function avDownloadDefinitions -t Event

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -27,6 +27,7 @@ provider:
             - s3:PutObjectAcl
             - s3:PutObjectTagging
             - s3:PutObjectVersionTagging
+            - s3:DeleteObject
             - s3:ListBucket
           Resource:
             - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-uploads-${AWS::AccountId}/*

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -127,7 +127,7 @@ async function uploadAVDefinitions() {
             Delete: {
                 Objects: s3DefinitionFileFullKeys,
             },
-        }).promse();
+        }).promise();
     } catch (err) {
         utils.generateSystemMessage(
             `Error deleting current definition files: ${s3DefinitionFileFullKeys}`

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -15,7 +15,7 @@ const S3 = new AWS.S3();
 async function listBucketFiles(bucketName) {
     try {
         const listFilesResult = await S3.listObjectsV2({
-            Bucket: constants.CLAMAV_BUCKET_NAME,
+            Bucket: bucketName,
         }).promise();
 
         const keys = listFilesResult.Contents.map((c) => c.Key);
@@ -130,7 +130,7 @@ async function uploadAVDefinitions() {
                 Bucket: constants.CLAMAV_BUCKET_NAME,
                 Delete: {
                     Objects: s3DefinitionFileFullKeys.map((k) => {
-                        Key: k;
+                        return { Key: k };
                     }),
                 },
             }).promise();

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -65,7 +65,9 @@ function updateAVDefinitonsWithFreshclam() {
 async function downloadAVDefinitions() {
     // list all the files in that bucket
     utils.generateSystemMessage('Downloading Definitions');
-    var definitionFileKeys = await listBucketFiles(constants.CLAMAV_BUCKET_NAME)
+    const allFileKeys = await listBucketFiles(constants.CLAMAV_BUCKET_NAME);
+
+    const definitionFileKeys = allFileKeys
         .filter((key) => key.startsWith(constants.PATH_TO_AV_DEFINITIONS))
         .map((fullPath) => path.basename(fullPath));
 
@@ -115,9 +117,11 @@ async function uploadAVDefinitions() {
     // delete all the definitions currently in the bucket.
     // first list them.
     utils.generateSystemMessage('Uploading Definitions');
-    var s3DefinitionFileFullKeys = await listBucketFiles(
-        constants.CLAMAV_BUCKET_NAME
-    ).filter((key) => key.startsWith(constants.PATH_TO_AV_DEFINITIONS));
+    const s3AllFullKeys = await listBucketFiles(constants.CLAMAV_BUCKET_NAME);
+
+    const s3DefinitionFileFullKeys = s3AllFullKeys.filter((key) =>
+        key.startsWith(constants.PATH_TO_AV_DEFINITIONS)
+    );
 
     // If there are any s3 Definition files in the s3 bucket, delete them.
     if (s3DefinitionFileFullKeys.length != 0) {

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -197,11 +197,12 @@ async function uploadAVDefinitions() {
  */
 function scanLocalFile(pathToFile) {
     try {
-        execSync(
+        let avResult = execSync(
             `${constants.PATH_TO_CLAMAV} -v -a --stdout -d /tmp/ ${pathToFile}`
         );
 
         utils.generateSystemMessage('SUCCESSFUL SCAN, FILE CLEAN');
+        console.log(avResult.toString());
 
         return constants.STATUS_CLEAN_FILE;
     } catch (err) {

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -64,7 +64,7 @@ function updateAVDefinitonsWithFreshclam() {
  */
 async function downloadAVDefinitions() {
     // list all the files in that bucket
-    util.generateSystemMessage('Downloading Definitions');
+    utils.generateSystemMessage('Downloading Definitions');
     var definitionFileKeys = await listBucketFiles(constants.CLAMAV_BUCKET_NAME)
         .filter((key) => key.startsWith(constants.PATH_TO_AV_DEFINITIONS))
         .map((fullPath) => path.basename(fullPath));
@@ -114,7 +114,7 @@ async function downloadAVDefinitions() {
 async function uploadAVDefinitions() {
     // delete all the definitions currently in the bucket.
     // first list them.
-    util.generateSystemMessage('Uploading Definitions');
+    utils.generateSystemMessage('Uploading Definitions');
     var s3DefinitionFileFullKeys = await listBucketFiles(
         constants.CLAMAV_BUCKET_NAME
     ).filter((key) => key.startsWith(constants.PATH_TO_AV_DEFINITIONS));

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -14,12 +14,16 @@ const S3 = new AWS.S3();
  */
 function updateAVDefinitonsWithFreshclam() {
     try {
+        console.log('BEFORE', fs.readdirSync(constants.FRESHCLAM_WORK_DIR));
+
         let executionResult = execSync(
             `${constants.PATH_TO_FRESHCLAM} --config-file=${constants.FRESHCLAM_CONFIG} --datadir=${constants.FRESHCLAM_WORK_DIR}`
         );
 
         utils.generateSystemMessage('Update message');
         console.log(executionResult.toString());
+
+        console.log('AFTER', fs.readdirSync(constants.FRESHCLAM_WORK_DIR));
 
         if (executionResult.stderr) {
             utils.generateSystemMessage('stderr');
@@ -94,7 +98,10 @@ async function uploadAVDefinitions() {
                     Bucket: constants.CLAMAV_BUCKET_NAME,
                     Key: `${constants.PATH_TO_AV_DEFINITIONS}/${filenameToUpload}`,
                     Body: fs.createReadStream(
-                        path.join('/tmp/', filenameToUpload)
+                        path.join(
+                            constants.FRESHCLAM_WORK_DIR,
+                            filenameToUpload
+                        )
                     ),
                     ACL: 'public-read',
                 };

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -129,7 +129,9 @@ async function uploadAVDefinitions() {
             await S3.deleteObjects({
                 Bucket: constants.CLAMAV_BUCKET_NAME,
                 Delete: {
-                    Objects: s3DefinitionFileFullKeys,
+                    Objects: s3DefinitionFileFullKeys.map((k) => {
+                        Key: k;
+                    }),
                 },
             }).promise();
             utils.generateSystemMessage(

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -121,19 +121,22 @@ async function uploadAVDefinitions() {
         throw err;
     }
 
-    try {
-        const deleteFileResult = await S3.deleteObjects({
-            Bucket: constants.CLAMAV_BUCKET_NAME,
-            Delete: {
-                Objects: s3DefinitionFileFullKeys,
-            },
-        }).promise();
-    } catch (err) {
-        utils.generateSystemMessage(
-            `Error deleting current definition files: ${s3DefinitionFileFullKeys}`
-        );
-        console.log(err);
-        throw err;
+    // If there are any s3 Definition files in the s3 bucket, delete them.
+    if (s3DefinitionFileFullKeys.length != 0) {
+        try {
+            const deleteFileResult = await S3.deleteObjects({
+                Bucket: constants.CLAMAV_BUCKET_NAME,
+                Delete: {
+                    Objects: s3DefinitionFileFullKeys,
+                },
+            }).promise();
+        } catch (err) {
+            utils.generateSystemMessage(
+                `Error deleting current definition files: ${s3DefinitionFileFullKeys}`
+            );
+            console.log(err);
+            throw err;
+        }
     }
 
     // list all the files in the work dir

--- a/services/uploads/src/constants.js
+++ b/services/uploads/src/constants.js
@@ -4,7 +4,7 @@
  * The following variables have to be set:
  *
  * CLAMAV_BUCKET_NAME: Name of the bucket where ClamAV and its definitions are stored
- * PATH_TO_AV_DEFINITIONS: Path in S3 where the definitions are stored. 3 files are expected (see CLAMAV_DEFINITIONS_FILES)
+ * PATH_TO_AV_DEFINITIONS: Path in S3 where the definitions are stored.
  *
  * The following variables can be overridden:
  *
@@ -35,9 +35,6 @@ const VIRUS_SCAN_TIMESTAMP_KEY =
     process.env.VIRUS_SCAN_TIMESTAMP_KEY || 'virusScanTimestamp';
 const MAX_FILE_SIZE = process.env.MAX_FILE_SIZE || '314572800';
 
-// List of CLAMAV definition files. These are the compressed files.
-const CLAMAV_DEFINITIONS_FILES = ['main.cvd', 'daily.cvd', 'bytecode.cvd'];
-
 module.exports = {
     CLAMAV_BUCKET_NAME: CLAMAV_BUCKET_NAME,
     PATH_TO_AV_DEFINITIONS: PATH_TO_AV_DEFINITIONS,
@@ -45,7 +42,6 @@ module.exports = {
     PATH_TO_CLAMAV: PATH_TO_CLAMAV,
     FRESHCLAM_CONFIG: FRESHCLAM_CONFIG,
     FRESHCLAM_WORK_DIR: FRESHCLAM_WORK_DIR,
-    CLAMAV_DEFINITIONS_FILES: CLAMAV_DEFINITIONS_FILES,
     STATUS_CLEAN_FILE: STATUS_CLEAN_FILE,
     STATUS_INFECTED_FILE: STATUS_INFECTED_FILE,
     STATUS_ERROR_PROCESSING_FILE: STATUS_ERROR_PROCESSING_FILE,


### PR DESCRIPTION
## Summary

In a continuing effor to solve our [issues stemming from our version of ClamAV getting outdated](https://docs.google.com/document/d/1V3OUC9ryF24YY-kQccUhMfKH4JRWXVAp7vhPH2ckW5M/edit#heading=h.oxwb3xfooa6j), this PR restores everything to working order. 

The command `freshclam` is used to download the latest version of the virus definition files. When we updated to the latest version of clamAV, that command started to behave differently. Before it always downloaded the antivirus files in a compressed format, so our service was hard coded to upload and download those files only. After updating, freshclam started to download the daily list in an uncompressed format. (though, confusingly and as of yet unexplained, it still downloaded in the compressed format the first time it ran)

I made two changes to address this. First I added an to our freshclam config that forces it to always save compressed files. Secondly, I modified our uploads service to upload and download _all_ the files that freshclam produces, making managing the particular format of the virus defintions database no longer something we need to track. freshclam always produces files that clamscan can read, so it’s not our problem anymore. 

This PR has both the file upload/download changes and includes upgrading to the latest version of ClamAV.

### Notes 

downloading the defintions from s3 only takes a couple seconds for the scan lambda, the bulk of that time is spent by the actual scan function, apparently because of how long it takes to actually read those compressed files. This is to say I don’t think that potentially increasing the number of files we’re uploading and downloading is not going to impact how long scanning takes. 

Unfortunately, some formatting changes makes this PR a little harder to read than it would otherwise. 