### PR TITLE
Add revisions table

### DIFF
--- a/services/app-api/postgres/findStateSubmission.ts
+++ b/services/app-api/postgres/findStateSubmission.ts
@@ -6,6 +6,7 @@ import {
 import { toDomain } from '../../app-web/src/common-code/proto/stateSubmission'
 import { findUniqueSubmissionWrapper } from './findDraftSubmission'
 import { isStoreError, StoreError } from './storeError'
+import { getCurrentRevision } from './submissionWithRevisionsHelpers'
 
 export async function findStateSubmission(
     client: PrismaClient,
@@ -21,7 +22,11 @@ export async function findStateSubmission(
         return findResult
     }
 
-    const decodeResult = toDomain(findResult.submissionFormProto)
+    const currentRevisionOrError = getCurrentRevision(id, findResult)
+    if (isStoreError(currentRevisionOrError)) return currentRevisionOrError
+    const currentRevision = currentRevisionOrError
+    
+    const decodeResult = toDomain(currentRevision.submissionFormProto)
 
     if (decodeResult instanceof Error) {
         console.log('ERROR: decoding protobuf; id: ', id, decodeResult)

--- a/services/app-api/postgres/insertDraftSubmission.ts
+++ b/services/app-api/postgres/insertDraftSubmission.ts
@@ -89,7 +89,14 @@ export async function insertDraftSubmission(
             data: {
                 id: draft.id,
                 stateCode: draft.stateCode,
-                submissionFormProto: buffer,
+                revisions: {
+                    create:
+                   { 
+                       id: uuidv4(),
+                       createdAt: new Date(),
+                       submissionFormProto: buffer
+                    }
+                }
             },
         })
     } catch (e: unknown) {

--- a/services/app-api/postgres/storeError.test.ts
+++ b/services/app-api/postgres/storeError.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable jest/no-conditional-expect */
-/* eslint-disable jest/no-try-expect */
 import { v4 as uuidv4 } from 'uuid'
 import { PrismaClient } from '@prisma/client'
 import { DraftSubmissionType } from '../../app-web/src/common-code/domain-models'
@@ -83,7 +82,13 @@ describe('storeError', () => {
                 data: {
                     id: draft.id,
                     stateCode: draft.stateCode,
-                    submissionFormProto: buffer,
+                    revisions: {
+                        create: {
+                            id: uuidv4(),
+                            createdAt: new Date(),
+                            submissionFormProto: buffer,
+                        },
+                    },
                 },
             })
 
@@ -91,7 +96,13 @@ describe('storeError', () => {
                 data: {
                     id: draft.id,
                     stateCode: draft.stateCode,
-                    submissionFormProto: buffer,
+                    revisions: {
+                        create: {
+                            id: uuidv4(),
+                            createdAt: new Date(),
+                            submissionFormProto: buffer,
+                        },
+                    },
                 },
             })
 

--- a/services/app-api/postgres/submissionWithRevisionsHelpers.ts
+++ b/services/app-api/postgres/submissionWithRevisionsHelpers.ts
@@ -1,0 +1,34 @@
+import { StateSubmission, StateSubmissionRevision } from '@prisma/client'
+import { StoreError } from './storeError'
+
+export type StateSubmissionWithRevisions = StateSubmission & {
+    revisions: StateSubmissionRevision[]
+}
+
+// Return first revision associated with a submission or return a StoreError if there is submission or revisions
+// used validate prisma results have useable submission
+const getCurrentRevision = (
+    submissionID: string,
+    submissionResult: StateSubmissionWithRevisions | null
+): StateSubmissionRevision | StoreError => {
+    if (!submissionResult)
+        return {
+            code: 'UNEXPECTED_EXCEPTION' as const,
+            message: `No submission found for id: ${submissionID}`,
+        }
+
+    if (!submissionResult.revisions || submissionResult.revisions.length < 1)
+        return {
+            code: 'UNEXPECTED_EXCEPTION' as const,
+            message: `No revisions found for submission id: ${submissionID}`,
+        }
+
+    // TODO FIGURE OUT HOW TO ENSURE PROPERLY ORDERED REVISIONS HERE
+    return submissionResult.revisions[0]
+}
+
+
+
+export {
+    getCurrentRevision
+}

--- a/services/app-api/postgres/updateDraftSubmission.ts
+++ b/services/app-api/postgres/updateDraftSubmission.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, StateSubmission, StateSubmissionRevision } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 import {
     DraftSubmissionType,
     isDraftSubmission,
@@ -12,27 +12,7 @@ import {
     isStoreError,
     StoreError,
 } from './storeError'
-
-type SubmissionWithRevisions = StateSubmission & {
-    revisions: StateSubmissionRevision[];
-}
-// Used validate prisma results have useable submission with existing revision
-const getCurrentRevision = (submissionID: string, submissionResult: SubmissionWithRevisions | null): StateSubmissionRevision| StoreError => {
-    if (!submissionResult)
-        return {
-            code: 'UNEXPECTED_EXCEPTION' as const,
-            message: `No submission found for id: ${submissionID}`,
-        }
-
-    if (!submissionResult.revisions || submissionResult.revisions.length < 1)
-        return {
-            code: 'UNEXPECTED_EXCEPTION' as const,
-            message: `No revisions found for submission id: ${submissionID}`,
-        }
-
-    // TODO FIGURE OUT HOW TO ENSURE PROPERLY ORDERED REVISIONS HERE
-    return submissionResult.revisions[0]
-}
+import {getCurrentRevision} from './submissionWithRevisionsHelpers'
 
 export async function updateSubmissionWrapper(
     client: PrismaClient,

--- a/services/app-api/prisma/migrations/20220208221835_add_revisions_table/migration.sql
+++ b/services/app-api/prisma/migrations/20220208221835_add_revisions_table/migration.sql
@@ -1,0 +1,19 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- CreateTable
+CREATE TABLE "StateSubmissionRevision" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "submissionID" TEXT NOT NULL,
+    "submissionFormProto" BYTEA NOT NULL,
+
+    CONSTRAINT "StateSubmissionRevision_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "StateSubmissionRevision" ADD CONSTRAINT "StateSubmissionRevision_submissionID_fkey" FOREIGN KEY ("submissionID") REFERENCES "StateSubmission"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateRevisionForEachExistingSubmission
+INSERT INTO "StateSubmissionRevision" 
+SELECT uuid_generate_v4() AS "id", now() AS "createdAt", "id" AS "submissionID","submissionFormProto"
+FROM "StateSubmission";

--- a/services/app-api/prisma/migrations/20220209210827_remove_proto_from_state_submission/migration.sql
+++ b/services/app-api/prisma/migrations/20220209210827_remove_proto_from_state_submission/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `submissionFormProto` on the `StateSubmission` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "StateSubmission" DROP COLUMN "submissionFormProto";

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -20,9 +20,18 @@ model TestUser {
 
 // The StateSubmission Form Data
 model StateSubmission {
-  id                  String @id
-  state               State  @relation(fields: [stateCode], references: [stateCode])
+  id                  String                    @id
+  state               State                     @relation(fields: [stateCode], references: [stateCode])
   stateCode           String
+  submissionFormProto Bytes
+  revisions           StateSubmissionRevision[]
+}
+
+model StateSubmissionRevision {
+  id                  String          @id
+  createdAt           DateTime        
+  submission          StateSubmission @relation(fields: [submissionID], references: [id])
+  submissionID        String
   submissionFormProto Bytes
 }
 

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -23,7 +23,6 @@ model StateSubmission {
   id                  String                    @id
   state               State                     @relation(fields: [stateCode], references: [stateCode])
   stateCode           String
-  submissionFormProto Bytes
   revisions           StateSubmissionRevision[]
 }
 


### PR DESCRIPTION
## Summary
Add “revisions” table to postgres

## Related Issue
https://qmacbis.atlassian.net/browse/OY2-14193

## QA guidance
- All app-api tests pass unchanged
- Revisions table has the proper information in Postico
- Revisions table has proper relationship with StateSubmission table (used SQL query to confirm) 
