### PR TITLE
Bump max_old_space_size for Node OOM

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -82,7 +82,7 @@ jobs:
       - name: deploy app-api
         id: deploy-app-api
         env:
-          NODE_OPTIONS: --max_old_space_size=8192
+          NODE_OPTIONS: --max_old_space_size=6000
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_DEFAULT_REGION: ${{ secrets.aws_default_region }}

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -82,7 +82,7 @@ jobs:
       - name: deploy app-api
         id: deploy-app-api
         env:
-          NODE_OPTIONS: --max_old_space_size=4096
+          NODE_OPTIONS: --max_old_space_size=8192
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_DEFAULT_REGION: ${{ secrets.aws_default_region }}

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -47,6 +47,7 @@ jobs:
       - name: deploy app-web
         id: deploy-app-web
         env:
+          NODE_OPTIONS: --max_old_space_size=6000
           AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
           AWS_DEFAULT_REGION: ${{ secrets.aws_default_region }}


### PR DESCRIPTION
## Summary

One of our [promotes](https://github.com/CMSgov/managed-care-review/runs/5149243994?check_suite_focus=true) hit an OOM while building `app-web` in prod. This is to bump the [`max_old_space_size`](https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes) to help avoid OOMing and spend less time in GC.

