### PR TITLE
Quick fix to form spacing for cross browser consistency

### DIFF
--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.module.scss
@@ -53,10 +53,8 @@
     }
 }
 
-.radioGroup {
-    legend {
-        margin-top: 0;
-    }
+[class^='usa-legend'] {
+    margin-top: 0;
 }
 
 .buttonGroup {


### PR DESCRIPTION
Chrome and Firefox were rendering form spacing differently. It mainly was due to collapsing margins on `<legend>` tags

<img width="1387" alt="Screen_Shot_2022-02-11_at_2_34_08_PM" src="https://user-images.githubusercontent.com/4196834/153657713-6eb7d2c4-191d-4225-acce-e4cbae750cd7.png">

