### PR TITLE
Handle user switching between contract/rates and contract-only

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -101,7 +101,7 @@ export const FileUpload = ({
         setFileItems((prevItems) => {
             const newItems = [...prevItems]
             return newItems.map((item) => {
-                if (item.documentCategories.length === 0 || isContractOnly) {
+                if (renderMode === 'table' && isContractOnly) {
                     return {
                         ...item,
                         documentCategories: ['CONTRACT_RELATED'],
@@ -111,7 +111,7 @@ export const FileUpload = ({
                 }
             })
         })
-    }, [isContractOnly])
+    }, [renderMode, isContractOnly])
 
     const isDuplicateItem = (
         existingList: FileItemT[],

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -33,7 +33,7 @@ export type FileUploadProps = {
     deleteFile: (key: string) => Promise<void>
     onFileItemsUpdate: ({ fileItems }: { fileItems: FileItemT[] }) => void
     isContractOnly?: boolean
-    shouldDisplayMissingCategoriesError?: boolean // by default, false. the parent component may read current files list and requirements of the form to determine otherwise. 
+    shouldDisplayMissingCategoriesError?: boolean // by default, false. the parent component may read current files list and requirements of the form to determine otherwise.
 } & JSX.IntrinsicElements['input']
 
 /*  FileUpload handles async file upload to S3 and displays inline errors per file.
@@ -58,7 +58,7 @@ export const FileUpload = ({
     deleteFile,
     onFileItemsUpdate,
     isContractOnly,
-    shouldDisplayMissingCategoriesError = false, 
+    shouldDisplayMissingCategoriesError = false,
     ...inputProps
 }: FileUploadProps): React.ReactElement => {
     const [fileItems, setFileItems] = useState<FileItemT[]>(initialItems || [])
@@ -95,6 +95,24 @@ export const FileUpload = ({
         onFileItemsUpdate({ fileItems })
     }, [fileItems, onFileItemsUpdate])
 
+    React.useEffect(() => {
+        /* guard against empty documentCategories when user starts with contract & rates
+        and switches to contract-only */
+        setFileItems((prevItems) => {
+            const newItems = [...prevItems]
+            return newItems.map((item) => {
+                if (item.documentCategories.length === 0 || isContractOnly) {
+                    return {
+                        ...item,
+                        documentCategories: ['CONTRACT_RELATED'],
+                    } as FileItemT
+                } else {
+                    return item
+                }
+            })
+        })
+    }, [isContractOnly])
+
     const isDuplicateItem = (
         existingList: FileItemT[],
         currentItem: FileItemT
@@ -102,7 +120,7 @@ export const FileUpload = ({
 
     const isMissingCategoriesItem = (fileItem: FileItemT) => {
         if (!shouldDisplayMissingCategoriesError) return false // either no missing categories or else missing categories are not relevant
-        return fileItem.documentCategories.length === 0 
+        return fileItem.documentCategories.length === 0
     }
 
     const isAcceptableFile = (file: File): boolean => {


### PR DESCRIPTION
## Summary

@MegMurphy found a bug, detailed [in this ticket](https://qmacbis.atlassian.net/browse/OY2-10582?focusedCommentId=106447)

This one is tricky, because to fix the bug Meghan found, which was an actual showstopper, we'll be introducing a little strangeness: if the user

1) selects contract-only
2) uploads a supporting document
3) goes back to select contract and rates
4) returns to the supporting documents page

then they'll see the checkbox for `Contract related` already checked.  I can't think of a non-horrible way to avoid this, while fixing the original bug, but I'm all ears.

Would this state of affairs be acceptable @MegMurphy @joshmfranklin ?