### PR TITLE
Add OTEL layer to uploads

### DIFF
--- a/services/uploads/collector.yml
+++ b/services/uploads/collector.yml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp:
+    endpoint: https://gov-otlp.nr-data.net:4317
+    headers:
+      api-key: $NR_LICENSE_KEY
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -8,6 +8,7 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-idempotency-helper
   - serverless-iam-helper
+  - serverless-webpack
 
 # The `provider` block defines where your service will be deployed
 provider:
@@ -70,6 +71,11 @@ custom:
       - prod
       - main
 
+environment:
+  PATH_TO_AV_DEFINITIONS: 'lambda/s3-antivirus/av-definitions'
+  AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
+  OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yml
+
 layers:
   clamDefs:
     package:
@@ -83,9 +89,10 @@ functions:
     memorySize: 3008
     layers:
       - !Ref ClamDefsLambdaLayer
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-0-1:1
     environment:
       CLAMAV_BUCKET_NAME: !Ref ClamDefsBucket
-      PATH_TO_AV_DEFINITIONS: 'lambda/s3-antivirus/av-definitions'
+
   avDownloadDefinitions:
     handler: src/download-definitions.lambdaHandleEvent
     events:
@@ -94,9 +101,9 @@ functions:
     memorySize: 1024
     layers:
       - !Ref ClamDefsLambdaLayer
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-0-1:1
     environment:
       CLAMAV_BUCKET_NAME: !Ref ClamDefsBucket
-      PATH_TO_AV_DEFINITIONS: 'lambda/s3-antivirus/av-definitions'
 
 resources:
   Resources:

--- a/services/uploads/webpack.config.js
+++ b/services/uploads/webpack.config.js
@@ -1,0 +1,54 @@
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const nodeExternals = require('webpack-node-externals');
+const slsw = require('serverless-webpack');
+const path = require('path');
+const isLocal = slsw.lib.webpack.isLocal;
+
+const extensions = [
+    '.mjs',
+    '.js',
+    '.jsx',
+    '.json',
+    '.ts',
+    '.tsx',
+    '.graphql',
+    '.gql',
+];
+module.exports = {
+    entry: slsw.lib.entries,
+    target: 'node',
+    context: __dirname,
+    mode: isLocal ? 'development' : 'production',
+    performance: {
+        hints: false,
+    },
+    externals: [
+        nodeExternals({
+            modulesDir: path.resolve(__dirname, '../../node_modules'),
+        }),
+        'aws-sdk',
+    ],
+    devtool: 'source-map',
+    resolve: {
+        symlinks: false,
+        extensions: extensions,
+        modules: [path.resolve(__dirname, 'node_modules'), 'node_modules'],
+    },
+    plugins: [
+        new CopyWebpackPlugin({
+            patterns: [
+                {
+                    from: path.resolve(__dirname, 'collector.yml'),
+                    transform(content) {
+                        return content
+                            .toString()
+                            .replace(
+                                '$NR_LICENSE_KEY',
+                                process.env.NR_LICENSE_KEY
+                            );
+                    },
+                },
+            ],
+        }),
+    ],
+};


### PR DESCRIPTION
## Summary

This adds the OTEL lambda layer to the uploads service in order to instrument the av scanning lambdas.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-16495