### PR TITLE
Remove double alerts on promote fail

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -182,17 +182,6 @@ jobs:
           name: cypress-videos
           path: tests/cypress/videos
 
-      - name: Alert Slack On Failure
-        uses: rtCamp/action-slack-notify@v2
-        if: failure()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: Deploy Alerts
-          SLACK_ICON_EMOJI: ':bell:'
-          SLACK_COLOR: ${{job.status}}
-          SLACK_FOOTER: ''
-          MSG_MINIMAL: actions url,commit
-
   promote-infra-val:
     needs: [dev-cypress, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
@@ -268,17 +257,6 @@ jobs:
         with:
           name: cypress-videos
           path: tests/cypress/videos
-
-      - name: Alert Slack On Failure
-        uses: rtCamp/action-slack-notify@v2
-        if: failure()
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_USERNAME: Deploy Alerts
-          SLACK_ICON_EMOJI: ':bell:'
-          SLACK_COLOR: ${{job.status}}
-          SLACK_FOOTER: ''
-          MSG_MINIMAL: actions url,commit
 
   promote-infra-prod:
     needs: [cypress-val, unit-tests]


### PR DESCRIPTION
## Summary

We just got two alerts on a promote failure, and it looks like it's because in #777 we added the condition to alert on a cypress val or prod 'skipped' state. This will happen whenever cypress-dev fails, in addition to other cases of earlier failure.

This removes the redundant case of when cypress alerts on failure in dev or val.
