### PR TITLE
Do not depend on Code Climate publishing success in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
+        continue-on-error: true
         env:
           CC_TEST_REPORTER_ID: cace182021fe88d327fa8d95355ac6081f420e094a214fe77feb5df2f0259e9d
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,7 @@ jobs:
 
       - name: publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
+        continue-on-error: true
         env:
           CC_TEST_REPORTER_ID: cace182021fe88d327fa8d95355ac6081f420e094a214fe77feb5df2f0259e9d
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: publish code coverage
         uses: paambaati/codeclimate-action@v3.0.0
+        continue-on-error: true
         env:
           CC_TEST_REPORTER_ID: cace182021fe88d327fa8d95355ac6081f420e094a214fe77feb5df2f0259e9d
         with:


### PR DESCRIPTION
## Summary
Code Climate is currently having an outage, which is causing CI to fail. This makes it so Code Climate stats publishing doesn't block CI runs from completing.

#### Related issues

https://qmacbis.atlassian.net/browse/OY2-16793