### PR TITLE
Update copy on homepage to include unexecuted contracts

### DIFF
--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -63,8 +63,9 @@ export const Landing = (): React.ReactElement => {
                                     dual demonstration contracts)
                                 </li>
                                 <li>State directed preprints</li>
-                                <li>Unexecuted/draft documents</li>
+                                <li>Documents for pre-review</li>
                                 <li>Rate-only submissions</li>
+                                <li>CHIP-only submissions</li>
                             </ul>
 
                             <h2>Before you begin:</h2>
@@ -76,6 +77,9 @@ export const Landing = (): React.ReactElement => {
                                 <li>
                                     Each contract action can tie to one or more
                                     managed care programs
+                                </li>
+                                <li>
+                                    Contracts may be fully executed or unexecuted by some or all parties
                                 </li>
                             </ul>
                         </Grid>


### PR DESCRIPTION
Changes made to homepage:
- Added "Contracts may be fully executed or unexecuted by some or all parties" to the before you begin section
- Added "CHIP-only submissions" to list of what we don't accept yet
- Reworded "draft documents" to "documents for pre-approval"

![Screen Shot 2022-03-07 at 3 11 35 PM](https://user-images.githubusercontent.com/4196834/157110907-9b705aef-70ab-4727-837b-2fdb0cd9f5eb.png)

