### PR TITLE
Address a11y issues in new unlock modal

### DIFF
--- a/services/app-web/src/components/Modal/Modal.stories.tsx
+++ b/services/app-web/src/components/Modal/Modal.stories.tsx
@@ -11,9 +11,8 @@ const Template: Story<ModalProps> = (args) => <Modal {...args} />
 
 export const ModalShow = Template.bind({})
 ModalShow.args = {
-    showModal: true,
     modalHeading: 'Test Modal Title',
-    modalHeadingId: 'testModalTitle',
+    id: 'test-modal',
     children: [
         <div style={{ flexDirection: 'column', display: 'flex', padding: 10}}>
             <label htmlFor={'textarea1'}>Text Box 1</label>

--- a/services/app-web/src/components/Modal/Modal.test.tsx
+++ b/services/app-web/src/components/Modal/Modal.test.tsx
@@ -1,15 +1,17 @@
-import React from 'react'
-import { screen, render } from '@testing-library/react'
+import React , {createRef} from 'react'
+import {ModalRef} from '@trussworks/react-uswds'
+import { screen, render, waitFor } from '@testing-library/react'
 import { Modal } from './Modal';
 
 describe('Modal', () => {
     it('Renders element with modal hidden', () => {
+          const modalRef = createRef<ModalRef>()
         render(
             <div>
                 <Modal
                     id="hiddenModal"
                     modalHeading="Test Modal Title"
-                    showModal={false}
+                    modalRef={modalRef}
                 >
                     <textarea
                         id="textarea"
@@ -23,42 +25,44 @@ describe('Modal', () => {
         expect(screen.getByRole('dialog')).toHaveClass('is-hidden')
     })
 
-    it('Renders element with modal visible with modal title', () => {
+    it('Renders element with modal visible when open is true', async () => {
+        const modalRef = createRef<ModalRef>()
+          const handleOpen = () =>
+            modalRef.current?.toggleModal(undefined, true)
         render(
             <div>
                 <Modal
                     id="hiddenModal"
                     modalHeading="Test Modal Title"
-                    showModal={true}
+                    modalRef={modalRef}
                 >
-                    <textarea
-                        id="textarea"
-                        data-testid="textarea"
-                    />
+                    <textarea id="textarea" data-testid="textarea" />
                 </Modal>
             </div>
         )
+        await waitFor(() => handleOpen())
 
+        expect(modalRef.current?.modalIsOpen).toBe(true)
         expect(screen.getByRole('dialog')).toHaveClass('is-visible')
         expect(screen.getByText('Test Modal Title')).toBeInTheDocument()
         expect(screen.getByTestId('textarea')).toBeInTheDocument()
     })
 
     it('Renders element with modal visible without title', async() => {
+        const modalRef = createRef<ModalRef>()
+        const handleOpen = () =>
+            modalRef.current?.toggleModal(undefined, true)
         render(
             <div>
-                <Modal
-                    id="hiddenModal"
-                    showModal={true}
-                >
-                    <textarea
-                        id="textarea"
-                        data-testid="textarea"
-                    />
+                <Modal id="hiddenModal" modalRef={modalRef}>
+                    <textarea id="textarea" data-testid="textarea" />
                 </Modal>
             </div>
         )
+        
+          await waitFor(() => handleOpen())
 
+          expect(modalRef.current?.modalIsOpen).toBe(true)
         expect(screen.getByRole('dialog')).toHaveClass('is-visible')
         expect(screen.queryByText('Test Modal Title')).toBeNull()
         expect(screen.getByTestId('textarea')).toBeInTheDocument()

--- a/services/app-web/src/components/Modal/Modal.tsx
+++ b/services/app-web/src/components/Modal/Modal.tsx
@@ -10,15 +10,14 @@ import {
     ModalToggleButton
 } from '@trussworks/react-uswds';
 import styles from './Modal.module.scss'
-import { stringMap } from 'aws-sdk/clients/backup';
 
 interface ModalComponentProps {
     id: string,
     modalHeading?: string,
     onSubmit?: () => void,
-    onCancel?: () => void,
     className?: string,
     modalRef: React.RefObject<ModalRef>
+    submitButtonProps?: JSX.IntrinsicElements['button']
 }
 
 export type ModalProps = ModalComponentProps & UswdsModalProps
@@ -28,15 +27,17 @@ export const Modal = ({
     children,
     modalHeading,
     onSubmit,
-    onCancel,
     className,
     modalRef,
+    submitButtonProps,
     ...divProps
 }: ModalProps): React.ReactElement  => {
-
+    
 
     return (
         <UswdsModal
+            aria-labelledby={`${id}-heading`}
+            aria-describedby={`${id}-description`}
             {...divProps}
             id={id}
             ref={modalRef}
@@ -45,13 +46,13 @@ export const Modal = ({
             {modalHeading && (
                 <ModalHeading id={`${id}-heading`}>{modalHeading}</ModalHeading>
             )}
-            {children}
+            <div id={`${id}-modal-description`}>{children}</div>
             <ModalFooter>
                 <ButtonGroup className="float-right">
                     <ModalToggleButton
                         data-testid="modal-cancel"
                         modalRef={modalRef}
-                        id={`${id}=closer`}
+                        id={`${id}-closer`}
                         closer
                         outline
                     >
@@ -61,8 +62,9 @@ export const Modal = ({
                         type="button"
                         aria-label="Submit"
                         data-testid="modal-submit"
-                        id={`${id}=submit`}
+                        id={`${id}-submit`}
                         onClick={onSubmit}
+                        {...submitButtonProps}
                     >
                         Submit
                     </Button>

--- a/services/app-web/src/components/Modal/Modal.tsx
+++ b/services/app-web/src/components/Modal/Modal.tsx
@@ -42,7 +42,6 @@ export const Modal = ({
             {...divProps}
             ref={modalRef}
             className={`${styles.modal} ${className}`}
-            forceAction
         >
             {modalHeading && (
                 <ModalHeading id={modalHeadingId}>

--- a/services/app-web/src/components/Modal/Modal.tsx
+++ b/services/app-web/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react'
+import React from 'react'
 import {
     Button,
     ButtonGroup,
@@ -6,66 +6,62 @@ import {
     ModalFooter,
     ModalHeading,
     ModalRef,
-    ModalProps as UswdsModalProps
+    ModalProps as UswdsModalProps,
+    ModalToggleButton
 } from '@trussworks/react-uswds';
 import styles from './Modal.module.scss'
+import { stringMap } from 'aws-sdk/clients/backup';
 
 interface ModalComponentProps {
+    id: string,
     modalHeading?: string,
-    modalHeadingId?: string,
     onSubmit?: () => void,
     onCancel?: () => void,
-    showModal: boolean,
     className?: string,
+    modalRef: React.RefObject<ModalRef>
 }
 
 export type ModalProps = ModalComponentProps & UswdsModalProps
 
 export const Modal = ({
+    id,
     children,
     modalHeading,
-    modalHeadingId,
     onSubmit,
     onCancel,
-    showModal,
     className,
+    modalRef,
     ...divProps
 }: ModalProps): React.ReactElement  => {
-    const modalRef = useRef<ModalRef>(null)
 
-    useEffect(() => {
-        modalRef.current?.toggleModal(undefined, showModal)
-    },[showModal])
 
     return (
         <UswdsModal
             {...divProps}
+            id={id}
             ref={modalRef}
             className={`${styles.modal} ${className}`}
         >
             {modalHeading && (
-                <ModalHeading id={modalHeadingId}>
-                    {modalHeading}
-                </ModalHeading>
+                <ModalHeading id={`${id}-heading`}>{modalHeading}</ModalHeading>
             )}
             {children}
             <ModalFooter>
                 <ButtonGroup className="float-right">
-                    <Button
-                        type="button"
-                        key="cancelButton"
-                        aria-label="Cancel"
+                    <ModalToggleButton
                         data-testid="modal-cancel"
-                        onClick={onCancel}
+                        modalRef={modalRef}
+                        id={`${id}=closer`}
+                        closer
                         outline
                     >
                         Cancel
-                    </Button>
+                    </ModalToggleButton>
                     <Button
                         type="button"
-                        key="submitButton"
                         aria-label="Submit"
                         data-testid="modal-submit"
+                        id={`${id}=submit`}
                         onClick={onSubmit}
                     >
                         Submit

--- a/services/app-web/src/components/PoliteErrorMessage/PoliteErrorMessage.tsx
+++ b/services/app-web/src/components/PoliteErrorMessage/PoliteErrorMessage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React,  {forwardRef} from 'react'
 import classnames from 'classnames'
 
 type PoliteErrorMessageProps = {
@@ -7,13 +7,14 @@ type PoliteErrorMessageProps = {
     className?: string
 } & JSX.IntrinsicElements['span']
 
+export type PoliteErrorMessageRef = React.Ref<HTMLSpanElement> | null
 // This component is almost the same as react-uswds ErrorMessage, but by default polite :). It also is more flexible in handling other html attributes and aria-roles through remaining props
-export const PoliteErrorMessage = ({
+export const PoliteErrorMessage = forwardRef(({
     children,
     className,
     id,
     ...remainingProps
-}: PoliteErrorMessageProps): React.ReactElement => {
+}: PoliteErrorMessageProps, ref: PoliteErrorMessageRef): React.ReactElement => {
     const classes = classnames('usa-error-message', className)
 
     return (
@@ -24,10 +25,11 @@ export const PoliteErrorMessage = ({
             role="alert"
             aria-live="polite"
             {...remainingProps}
+            ref={ref}
         >
             {children}
         </span>
     )
-}
+})
 
 export default PoliteErrorMessage

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -1,7 +1,6 @@
 import {
     Alert, Button,
-    ButtonGroup,
-    GridContainer, Modal, ModalFooter, ModalHeading, ModalRef, ModalToggleButton
+    GridContainer, ModalRef, ModalToggleButton
 } from '@trussworks/react-uswds'
 import React, { useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
@@ -14,6 +13,7 @@ import {
     useSubmitDraftSubmissionMutation
 } from '../../../gen/gqlClient'
 import { PageActionsContainer } from '../PageActions'
+import {Modal} from '../../../components/Modal'
 import styles from './ReviewSubmit.module.scss'
 
 
@@ -48,9 +48,7 @@ export const ReviewSubmit = ({
         setUserVisibleError(error)
     }
 
-    const handleFormSubmit = async (e: React.FormEvent): Promise<void> => {
-        e.preventDefault()
-
+    const handleFormSubmit = async (): Promise<void> => {
         try {
             const data = await submitDraftSubmission({
                 variables: {
@@ -145,35 +143,16 @@ export const ReviewSubmit = ({
             </PageActionsContainer>
 
             <Modal
-                ref={modalRef}
-                aria-labelledby="review-and-submit-modal-heading"
-                aria-describedby="review-and-submit-modal-description"
+                modalRef={modalRef}
                 id="review-and-submit-modal"
+                modalHeading="Ready to submit?"
+                submitButtonProps={{ className: styles.submitButton }}
+                onSubmit={handleFormSubmit}
             >
-                <ModalHeading id="review-and-submit-modal-heading">
-                    Ready to submit?
-                </ModalHeading>
-                <p id="review-and-submit-description">
+                <p>
                     Submitting this package will send it to CMS to begin their
                     review.
                 </p>
-                <ModalFooter>
-                    <ButtonGroup className="float-right">
-                        <ModalToggleButton modalRef={modalRef} closer outline>
-                            Cancel
-                        </ModalToggleButton>
-                        <Button
-                            type="button"
-                            key="submitButton"
-                            aria-label="Submit"
-                            data-testid="modal-submit"
-                            className={styles.submitButton}
-                            onClick={handleFormSubmit}
-                        >
-                            Submit
-                        </Button>
-                    </ButtonGroup>
-                </ModalFooter>
             </Modal>
         </GridContainer>
     )

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -228,14 +228,18 @@ export const StateSubmissionForm = (): React.ReactElement => {
         })
         return specificContent ?? <GenericErrorPage />
     }
+    if (
+        (fetchData && formDataError === 'NOT_FOUND') ||
+        (fetchData && !formDataFromLatestRevision)
+    ) {
+        return <Error404 />
+    }
+
 
     if (formDataError === 'MALFORMATTED_DATA') {
         return <GenericErrorPage />
     }
 
-    if (formDataError === 'NOT_FOUND' || (fetchData &&  !formDataFromLatestRevision)) {
-        return <Error404 />
-    }
 
     if (formDataError === 'WRONG_SUBMISSION_STATUS') {
         return <ErrorInvalidSubmissionStatus />

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -102,6 +102,8 @@ export const SubmissionSummary = (): React.ReactElement => {
     )
 
     // Unlock modal state
+    const [focusErrorsInModal, setFocusErrorsInModal] = useState(true)
+    const modalErrorRef = useRef<HTMLDivElement>(null)
     const modalRef = useRef<ModalRef>(null)
     const modalFormInitialValues = {
         unlockReason: '',
@@ -206,17 +208,25 @@ export const SubmissionSummary = (): React.ReactElement => {
         }
     }, [updateHeading, pathname, packageData])
 
+    // Focus errors in the unlock modal on initial click when errors exist
+    useEffect(() => {
+        if (
+            focusErrorsInModal &&
+            formik.errors.unlockReason &&
+            modalErrorRef.current
+        ) {
+            modalErrorRef.current.focus()
+        }
+        setFocusErrorsInModal(false)
+    }, [focusErrorsInModal, formik.errors, modalErrorRef])
 
     // Clear form data when unlock modal closes without changes
     useEffect(() => {
-        console.log(formik.dirty)
-        console.log(modalRef.current)
         if (formik.dirty && !modalRef?.current?.modalIsOpen ) {
-                console.log('trying to reset here')
                 formik.resetForm()
         }
     }, [formik, modalRef.current?.modalIsOpen])
-          console.log(modalRef.current)
+
     if (loading || !submissionAndRevisions || !packageData) {
         return (
             <GridContainer>
@@ -230,7 +240,6 @@ export const SubmissionSummary = (): React.ReactElement => {
         return <GenericErrorPage /> // api failure or protobuf decode failure
 
     const onModalSubmit = async (values: typeof modalFormInitialValues) => {
-        console.log('in modal submit')
         const { unlockReason } = values
         await onUnlock(unlockReason)
         modalRef.current?.toggleModal(undefined, false)
@@ -369,7 +378,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                     id="unlock-modal"
                     aria-labelledby="unlockModalHeading"
                     onSubmit={() => {
-                        console.log('in this')
+                        setFocusErrorsInModal(true)
                         formik.handleSubmit()
                     }}
                     modalRef={modalRef}
@@ -379,6 +388,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                             {formik.errors.unlockReason && (
                                 <PoliteErrorMessage
                                     role="alert"
+                                    ref={modalErrorRef}
                                 >
                                     {formik.errors.unlockReason}
                                 </PoliteErrorMessage>
@@ -397,6 +407,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                                 maxLength={300}
                                 isTextArea
                                 data-testid="unlockReason"
+                                aria-label="Reason for unlocking submission"
                                 aria-describedby="unlockReason-info"
                                 className={styles.unlockReasonTextarea}
                                 aria-required

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -103,7 +103,6 @@ export const SubmissionSummary = (): React.ReactElement => {
 
     // Unlock modal state
     const [focusErrorsInModal, setFocusErrorsInModal] = useState(true)
-    const modalErrorRef = useRef<HTMLDivElement>(null)
     const modalRef = useRef<ModalRef>(null)
     const modalFormInitialValues = {
         unlockReason: '',
@@ -208,17 +207,24 @@ export const SubmissionSummary = (): React.ReactElement => {
         }
     }, [updateHeading, pathname, packageData])
 
-    // Focus errors in the unlock modal on initial click when errors exist
+    // Focus unlockReason field in the unlock modal on submit click when errors exist
     useEffect(() => {
         if (
             focusErrorsInModal &&
-            formik.errors.unlockReason &&
-            modalErrorRef.current
+            formik.errors.unlockReason
         ) {
-            modalErrorRef.current.focus()
+            const fieldElement: HTMLElement | null = document.querySelector(
+                `[name="unlockReason"]`
+            )
+
+            if (fieldElement) {
+                fieldElement.focus()
+                setFocusErrorsInModal(false)
+            } else {
+                console.log('Attempting to focus element that does not exist')
+            }
         }
-        setFocusErrorsInModal(false)
-    }, [focusErrorsInModal, formik.errors, modalErrorRef])
+    }, [focusErrorsInModal, formik.errors])
 
     // Clear form data when unlock modal closes without changes
     useEffect(() => {
@@ -388,7 +394,6 @@ export const SubmissionSummary = (): React.ReactElement => {
                             {formik.errors.unlockReason && (
                                 <PoliteErrorMessage
                                     role="alert"
-                                    ref={modalErrorRef}
                                 >
                                     {formik.errors.unlockReason}
                                 </PoliteErrorMessage>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -1,12 +1,16 @@
 import { GraphQLErrors } from '@apollo/client/errors'
 import {
     Alert,
-    Button,
     GridContainer,
     Link,
     CharacterCount,
+    ModalRef,
+    ModalToggleButton,
+    FormGroup
 } from '@trussworks/react-uswds'
-import React, { useEffect, useState } from 'react'
+import * as Yup from 'yup'
+import { useFormik} from 'formik'
+import React, { useEffect, useState, useRef } from 'react'
 import { NavLink, useLocation, useParams} from 'react-router-dom'
 import sprite from 'uswds/src/img/sprite.svg'
 import {submissionName, SubmissionUnionType, UpdateInfoType } from '../../common-code/domain-models'
@@ -16,7 +20,7 @@ import {
     ContactsSummarySection, ContractDetailsSummarySection,
     RateDetailsSummarySection, SubmissionTypeSummarySection, SupportingDocumentsSummarySection
 } from '../../components/SubmissionSummarySection'
-import { SubmissionUnlockedBanner, PoliteErrorMessage, Modal } from '../../components'
+import { SubmissionUnlockedBanner,Modal, PoliteErrorMessage, } from '../../components'
 import { useAuth } from '../../contexts/AuthContext'
 import { usePage } from '../../contexts/PageContext'
 import {
@@ -32,17 +36,17 @@ import { Error404 } from '../Errors/Error404'
 
 import styles from './SubmissionSummary.module.scss'
 
-function unlockModalButton(onClick: () => void, disabled: boolean) {
+function UnlockModalButton({disabled, modalRef} : {disabled: boolean, modalRef: React.RefObject<ModalRef> }) {
     return (
-        <Button
+        <ModalToggleButton
+            modalRef={modalRef}
+            className={styles.submitButton}
             data-testid="form-submit"
-            type="button"
-            outline
-            onClick={onClick}
             disabled={disabled}
+            opener
         >
             Unlock submission
-        </Button>
+        </ModalToggleButton>
     )
 }
 
@@ -80,18 +84,37 @@ async function unlockMutationWrapper(unlockStateSubmission: UnlockStateSubmissio
 }
 
 export const SubmissionSummary = (): React.ReactElement => {
+    // Page level state
     const { id } = useParams<{ id: string }>()
     const { pathname } = useLocation()
     const { loggedInUser } = useAuth()
     const { updateHeading } = usePage()
-    const [pageLevelAlert, setPageLevelAlert] = useState<
-        string | undefined
+    const [pageLevelAlert, setPageLevelAlert] = useState<string | undefined>(
+        undefined
+    )
+
+    // Api fetched data state
+    const [packageData, setPackageData] = useState<
+        SubmissionUnionType | undefined
     >(undefined)
-    const [unlockModalError, setUnlockModalError] = useState<string | undefined>(undefined)
-    const [unlockReason, setUnlockReason] = useState('')
-    const [packageData, setPackageData] = useState<SubmissionUnionType | undefined>(undefined)
-    const [unlockedInfo, setUnlockedInfo] = useState<UpdateInfoType | null>(null)
-    const [showModal, setShowModal] = useState(false)
+    const [unlockedInfo, setUnlockedInfo] = useState<UpdateInfoType | null>(
+        null
+    )
+
+    // Unlock modal state
+    const modalRef = useRef<ModalRef>(null)
+    const modalFormInitialValues = {
+        unlockReason: '',
+    }
+    const formik = useFormik({
+        initialValues: modalFormInitialValues,
+        validationSchema: Yup.object().shape({
+            unlockReason: Yup.string()
+                .max(300, 'Reason for unlocking submission is too long')
+                .defined('Reason for unlocking submission is required'),
+        }),
+        onSubmit: (values) => onModalSubmit(values),
+    })
 
     const { loading, error, data } = useFetchSubmission2Query({
         variables: {
@@ -102,52 +125,73 @@ export const SubmissionSummary = (): React.ReactElement => {
     })
 
     const [unlockStateSubmission] = useUnlockStateSubmissionMutation()
-
     const submissionAndRevisions = data?.fetchSubmission2.submission
 
     // This is a hacky way to fake feature flags before we have feature flags.
-    // please avoid reading env vars outside of index.tsx in general. 
+    // please avoid reading env vars outside of index.tsx in general.
     const environmentName = process.env.REACT_APP_STAGE_NAME || ''
     const isProdEnvironment = ['prod', 'val'].includes(environmentName)
 
-    const displayUnlockButton = !isProdEnvironment && loggedInUser?.role === 'CMS_USER'
+    const displayUnlockButton =
+        !isProdEnvironment && loggedInUser?.role === 'CMS_USER'
 
-    // pull out the correct revision
+    // Pull out the correct revision form api request, display errors for bad dad
     useEffect(() => {
         if (submissionAndRevisions) {
-            // We ignore revisions currently being edited. 
+            // We ignore revisions currently being edited.
             // The summary page should only ever called on a package that has been submitted once
-            const currentRevision = submissionAndRevisions.revisions.find(rev => {
-                // we want the most recent revision that has submission info.
-                return (rev.revision.submitInfo)
-            })
+            const currentRevision = submissionAndRevisions.revisions.find(
+                (rev) => {
+                    // we want the most recent revision that has submission info.
+                    return rev.revision.submitInfo
+                }
+            )
 
             if (!currentRevision) {
-                console.error('ERROR: submission in summary has no submitted revision', submissionAndRevisions.revisions)
-                setPageLevelAlert('Error fetching the submission. Please try again.')
+                console.error(
+                    'ERROR: submission in summary has no submitted revision',
+                    submissionAndRevisions.revisions
+                )
+                setPageLevelAlert(
+                    'Error fetching the submission. Please try again.'
+                )
                 return
             }
 
-            const submissionResult = base64ToDomain(currentRevision.revision.submissionData)
+            const submissionResult = base64ToDomain(
+                currentRevision.revision.submissionData
+            )
             if (submissionResult instanceof Error) {
-                console.error('ERROR: got a proto decoding error', submissionResult)
-                setPageLevelAlert('Error fetching the submission. Please try again.')
+                console.error(
+                    'ERROR: got a proto decoding error',
+                    submissionResult
+                )
+                setPageLevelAlert(
+                    'Error fetching the submission. Please try again.'
+                )
                 return
             }
 
             if (submissionAndRevisions.status === 'UNLOCKED') {
-                const unlockedRevision = submissionAndRevisions.revisions.find(rev => rev.revision.unlockInfo)
+                const unlockedRevision = submissionAndRevisions.revisions.find(
+                    (rev) => rev.revision.unlockInfo
+                )
                 const unlockInfo = unlockedRevision?.revision.unlockInfo
 
                 if (unlockInfo) {
                     setUnlockedInfo({
                         updatedBy: unlockInfo.updatedBy,
                         updatedAt: unlockInfo.updatedAt,
-                        updatedReason: unlockInfo.updatedReason
+                        updatedReason: unlockInfo.updatedReason,
                     })
                 } else {
-                    console.error('ERROR: submission in summary has no revision with unlocked information', submissionAndRevisions.revisions)
-                    setPageLevelAlert('Error fetching the unlocked information. Please try again.')
+                    console.error(
+                        'ERROR: submission in summary has no revision with unlocked information',
+                        submissionAndRevisions.revisions
+                    )
+                    setPageLevelAlert(
+                        'Error fetching the unlocked information. Please try again.'
+                    )
                 }
             }
 
@@ -155,12 +199,24 @@ export const SubmissionSummary = (): React.ReactElement => {
         }
     }, [submissionAndRevisions, setPackageData, setPageLevelAlert])
 
+    // Update header with submission name
     useEffect(() => {
         if (packageData) {
             updateHeading(pathname, submissionName(packageData))
         }
     }, [updateHeading, pathname, packageData])
 
+
+    // Clear form data when unlock modal closes without changes
+    useEffect(() => {
+        console.log(formik.dirty)
+        console.log(modalRef.current)
+        if (formik.dirty && !modalRef?.current?.modalIsOpen ) {
+                console.log('trying to reset here')
+                formik.resetForm()
+        }
+    }, [formik, modalRef.current?.modalIsOpen])
+          console.log(modalRef.current)
     if (loading || !submissionAndRevisions || !packageData) {
         return (
             <GridContainer>
@@ -169,67 +225,75 @@ export const SubmissionSummary = (): React.ReactElement => {
         )
     }
 
-    if (data && (!submissionAndRevisions)) return <Error404 /> // api request resolves but are no revisions likely because invalid submission is queried. This should be "Not Found"
-    if (error || !packageData || !submissionAndRevisions) return <GenericErrorPage /> // api failure or protobuf decode failure
+    if (data && !submissionAndRevisions) return <Error404 /> // api request resolves but are no revisions likely because invalid submission is queried. This should be "Not Found"
+    if (error || !packageData || !submissionAndRevisions)
+        return <GenericErrorPage /> // api failure or protobuf decode failure
 
-    const resetModal = () => {
-        setUnlockModalError(undefined)
-        setUnlockReason('')
-        setShowModal(false)
+    const onModalSubmit = async (values: typeof modalFormInitialValues) => {
+        console.log('in modal submit')
+        const { unlockReason } = values
+        await onUnlock(unlockReason)
+        modalRef.current?.toggleModal(undefined, false)
     }
 
-    const onUnlock = async () => {
-        if (!unlockReason) {
-            setUnlockModalError('Reason for unlocking submission is required')
-            return
-        }
-        if (unlockReason.length > 300) {
-            setUnlockModalError('Reason for unlocking submission is too long')
-            return
-        }
-        const result = await unlockMutationWrapper(unlockStateSubmission, submissionAndRevisions.id, unlockReason)
+    const onUnlock = async (unlockReason: string) => {
+        const result = await unlockMutationWrapper(
+            unlockStateSubmission,
+            submissionAndRevisions.id,
+            unlockReason
+        )
 
         if (result instanceof Error) {
-            console.error('ERROR: got an Apollo Client Error attempting to unlock', result)
+            console.error(
+                'ERROR: got an Apollo Client Error attempting to unlock',
+                result
+            )
             setPageLevelAlert('Error attempting to unlock. Please try again.')
         } else if (isGraphQLErrors(result)) {
             console.error('ERROR: got a GraphQL error response', result)
             if (result[0].extensions.code === 'BAD_USER_INPUT') {
-                setPageLevelAlert('Submission is already unlocked. Please refresh and try again.')
+                setPageLevelAlert(
+                    'Submission is already unlocked. Please refresh and try again.'
+                )
             } else {
-                setPageLevelAlert('Error attempting to unlock. Please try again.')
+                setPageLevelAlert(
+                    'Error attempting to unlock. Please try again.'
+                )
             }
         } else {
             const unlockedSub: Submission2 = result
             console.log('Submission Unlocked', unlockedSub)
         }
-
-        resetModal()
     }
 
-    // temporary kludge while the display data is expecting the wrong format. 
+    // temporary kludge while the display data is expecting the wrong format.
     // This is turning our domain model into the GraphQL model which is what
-    // all our frontend stuff expects right now. 
-    const submission: StateSubmission | DraftSubmission = packageData.status === 'DRAFT' ? {
-        ...packageData,
-        __typename: 'DraftSubmission' as const,
-        name: submissionName(packageData),
-        program: {
-            id: 'bogs-id',
-            name: 'bogus-program'
-        },
-    } : {
-        ...packageData,
-        __typename: 'StateSubmission' as const,
-        name: submissionName(packageData),
-        program: {
-            id: 'bogs-id',
-            name: 'bogus-program'
-        },
-        submittedAt: submissionAndRevisions.intiallySubmittedAt
-    }
+    // all our frontend stuff expects right now.
+    const submission: StateSubmission | DraftSubmission =
+        packageData.status === 'DRAFT'
+            ? {
+                  ...packageData,
+                  __typename: 'DraftSubmission' as const,
+                  name: submissionName(packageData),
+                  program: {
+                      id: 'bogs-id',
+                      name: 'bogus-program',
+                  },
+              }
+            : {
+                  ...packageData,
+                  __typename: 'StateSubmission' as const,
+                  name: submissionName(packageData),
+                  program: {
+                      id: 'bogs-id',
+                      name: 'bogus-program',
+                  },
+                  submittedAt: submissionAndRevisions.intiallySubmittedAt,
+              }
 
-    const disableUnlockButton = ['DRAFT', 'UNLOCKED'].includes(submissionAndRevisions.status)
+    const disableUnlockButton = ['DRAFT', 'UNLOCKED'].includes(
+        submissionAndRevisions.status
+    )
 
     const isContractActionAndRateCertification =
         submission.submissionType === 'CONTRACT_AND_RATES'
@@ -248,7 +312,11 @@ export const SubmissionSummary = (): React.ReactElement => {
 
                 {unlockedInfo && (
                     <SubmissionUnlockedBanner
-                        userType={loggedInUser?.role === 'CMS_USER' ? 'CMS_USER' : 'STATE_USER'}
+                        userType={
+                            loggedInUser?.role === 'CMS_USER'
+                                ? 'CMS_USER'
+                                : 'STATE_USER'
+                        }
                         unlockedBy={unlockedInfo.updatedBy}
                         unlockedOn={unlockedInfo.updatedAt}
                         reason={unlockedInfo.updatedReason}
@@ -275,8 +343,17 @@ export const SubmissionSummary = (): React.ReactElement => {
                     </Link>
                 ) : null}
 
-                <SubmissionTypeSummarySection submission={submission} unlockModalButton={displayUnlockButton ? unlockModalButton(() => setShowModal(true), disableUnlockButton) : undefined} />
-
+                <SubmissionTypeSummarySection
+                    submission={submission}
+                    unlockModalButton={
+                        displayUnlockButton ? (
+                            <UnlockModalButton
+                                modalRef={modalRef}
+                                disabled={disableUnlockButton}
+                            />
+                        ) : undefined
+                    }
+                />
                 <ContractDetailsSummarySection submission={submission} />
 
                 {isContractActionAndRateCertification && (
@@ -289,34 +366,46 @@ export const SubmissionSummary = (): React.ReactElement => {
 
                 <Modal
                     modalHeading="Reason for unlocking submission"
-                    modalHeadingId="unlockModalHeading"
+                    id="unlock-modal"
                     aria-labelledby="unlockModalHeading"
-                    onSubmit={onUnlock}
-                    onCancel={resetModal}
-                    showModal={showModal}
-                    id="unlockSubmissionModal"
+                    onSubmit={() => {
+                        console.log('in this')
+                        formik.handleSubmit()
+                    }}
+                    modalRef={modalRef}
                 >
-                    {unlockModalError && (
-                        <PoliteErrorMessage>{unlockModalError}</PoliteErrorMessage>
-                    )}
-                    <div role="note" aria-labelledby="unlockReason" className="usa-hint margin-top-1">
-                        <p id="unlockReasonHelp">
-                            Provide reason for unlocking
-                        </p>
-                    </div>
-                    <CharacterCount
-                        id={'unlockReason'}
-                        name={'unlockReason'}
-                        maxLength={300}
-                        isTextArea
-                        data-testid="unlockReason"
-                        aria-describedby="unlockReason-info"
-                        className={styles.unlockReasonTextarea}
-                        aria-required
-                        defaultValue={unlockReason}
-                        error={!!unlockModalError}
-                        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setUnlockReason(e.target.value)}
-                    />
+                    <form>
+                        <FormGroup error={Boolean(formik.errors.unlockReason)}>
+                            {formik.errors.unlockReason && (
+                                <PoliteErrorMessage
+                                    role="alert"
+                                >
+                                    {formik.errors.unlockReason}
+                                </PoliteErrorMessage>
+                            )}
+                            <span
+                                id="unlockReason-hint"
+                                role="note"
+                                aria-labelledby="unlockReason"
+                            >
+                                Provide reason for unlocking
+                            </span>
+
+                            <CharacterCount
+                                id="unlockReason"
+                                name="unlockReason"
+                                maxLength={300}
+                                isTextArea
+                                data-testid="unlockReason"
+                                aria-describedby="unlockReason-info"
+                                className={styles.unlockReasonTextarea}
+                                aria-required
+                                error={!!formik.errors.unlockReason}
+                                onChange={formik.handleChange}
+                                defaultValue={formik.values.unlockReason}
+                            />
+                        </FormGroup>
+                    </form>
                 </Modal>
             </GridContainer>
         </div>


### PR DESCRIPTION
## Summary
- Address accessibility issues in unlock modal with ESC key and focus on error. 
- Use shared Modal component on both ReviewSubmit and SubmissionSummary
- Use formik in the unlock modal form to make it easier to display dynamic and changing error messages
- Use the react-uswds Modal ref to handle state instead of adding our own state to the component
- Small bugfix for a page flicker I saw when the user creates a new submission

FYI for anyone interested-  root cause of issues here is 
1. not using an actual <form> semantic element  and a form label  (I used aria-label since we are using a visible label) even though we are submitting form data . That makes the field not be recognized by screenreader
2.   using `forceAction` on react-uswds Modal  - that overrides built in handling for a11y stuff and isn't needed


#### Related issues
https://qmacbis.atlassian.net/browse/OY2-17215

#### Screenshots

#### Test cases covered

Forthcoming... I will add a couple tests for the focus behavior and also the Modal component.

#### QA guidance
Please give this a runthrough with voiceover and let me know what you find. 