### PR TITLE
[OY2-17246] Cypress flakes debugging

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,7 @@
     "videosFolder": "tests/cypress/videos",
     "supportFile": "tests/cypress/support",
     "projectId": "tt5hbz",
+    "defaultCommandTimeout": 10000,
     "retries": {
         "runMode": 2,
         "openMode": 0

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -254,11 +254,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
                     formPages={activeFormPages(draft)}
                     currentFormPage={currentRoute}
                 />
-                <PageBannerAlerts
-                    loggedInUser={loggedInUser}
-                    unlockedInfo={unlockedInfo}
-                    showPageErrorMessage={showPageErrorMessage}
-                />
+                <PageBannerAlerts loggedInUser={loggedInUser} unlockedInfo={unlockedInfo} showPageErrorMessage={showPageErrorMessage}/>
             </div>
             <StateSubmissionContainer>
                 <Switch>
@@ -293,13 +289,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
                         />
                     </Route>
                     <Route path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}>
-                        <ReviewSubmit
-                            draftSubmission={draft}
-                            unlocked={!!unlockedInfo}
-                        />
-                    </Route>
-                    <Route path='*'>
-                        <Error404 />
+                        <ReviewSubmit draftSubmission={draft} unlocked={!!unlockedInfo} />
                     </Route>
                 </Switch>
             </StateSubmissionContainer>

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -254,7 +254,11 @@ export const StateSubmissionForm = (): React.ReactElement => {
                     formPages={activeFormPages(draft)}
                     currentFormPage={currentRoute}
                 />
-                <PageBannerAlerts loggedInUser={loggedInUser} unlockedInfo={unlockedInfo} showPageErrorMessage={showPageErrorMessage}/>
+                <PageBannerAlerts
+                    loggedInUser={loggedInUser}
+                    unlockedInfo={unlockedInfo}
+                    showPageErrorMessage={showPageErrorMessage}
+                />
             </div>
             <StateSubmissionContainer>
                 <Switch>
@@ -289,7 +293,13 @@ export const StateSubmissionForm = (): React.ReactElement => {
                         />
                     </Route>
                     <Route path={RoutesRecord.SUBMISSIONS_REVIEW_SUBMIT}>
-                        <ReviewSubmit draftSubmission={draft} unlocked={!!unlockedInfo} />
+                        <ReviewSubmit
+                            draftSubmission={draft}
+                            unlocked={!!unlockedInfo}
+                        />
+                    </Route>
+                    <Route path='*'>
+                        <Error404 />
                     </Route>
                 </Switch>
             </StateSubmissionContainer>

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -4,17 +4,15 @@ describe('dashboard', () => {
     it('can unlock and resubmit', () => {
         cy.logInAsStateUser()
 
-        // a submitted submission
+        // fill out an entire submission
         cy.startNewContractOnlySubmission()
         cy.fillOutBaseContractDetails()
         cy.findByTestId('unlockedBanner').should('not.exist')
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
         cy.fillOutStateContact()
-        cy.navigateForm('Continue')
-
-        // Skip supporting documents
+        cy.navigateForm('CONTINUE')
         cy.findByRole('heading', {name: /Supporting documents/}).should('exist')
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
         cy.findByRole('heading', {name: /Review and submit/}).should('exist')
 
         // Store submission url for reference later
@@ -23,9 +21,8 @@ describe('dashboard', () => {
             fullUrl.pathname = path.dirname(fullUrl)
 
             // Submit, sent to dashboard
-            cy.intercept('POST', '*/graphql').as('gqlRequest')
             cy.submitStateSubmissionForm()
-            cy.wait('@gqlRequest')
+          
             cy.findByText('Dashboard').should('exist')
             cy.findByText('Programs').should('exist')
 
@@ -37,6 +34,7 @@ describe('dashboard', () => {
             cy.logInAsCMSUser({ initialURL: reviewURL })
 
             // click on the unlock button, type in reason and confirm
+            cy.wait(2000)
             cy.findByRole('button', { name: 'Unlock submission' }).click()
             cy.findByTestId('modalWindow')
                 .should('be.visible')
@@ -91,9 +89,13 @@ describe('dashboard', () => {
                 cy.visit(reviewURL)
 
                 // State user can resubmit and see resubmitted package in dashboard
-                cy.intercept('POST', '*/graphql').as('gqlRequest2')
+                cy.wait('@fetchSubmission2Query')
 
                 //Unlock banner for state user to be present with correct data.
+                 cy.findByRole('heading', {level: 2, name: /Review and submit/})
+                 cy.findByRole('heading', {
+                     name: `Minnesota ${submissionName}`,
+                 }).should('exist')
                 cy.findByTestId('unlockedBanner')
                     .should('exist')
                     .and('contain.text', 'zuko@example.com')
@@ -104,7 +106,7 @@ describe('dashboard', () => {
                     .should('exist')
 
                 cy.submitStateSubmissionForm()
-                cy.wait('@gqlRequest2')
+
                 cy.findByText('Dashboard').should('exist')
 
                 cy.get('table')

--- a/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
@@ -3,7 +3,7 @@ describe('CMS User can view submission', () => {
     //         cy.logInAsStateUser()
     //         cy.waitForApiToLoad()
     //         cy.startNewContractAndRatesSubmission()
-    //         cy.navigateForm('Continue')
+    //         cy.navigateForm('CONTINUE')
     //         cy.findByText(/^MN-PMAP-/).should('exist')
     //         // Fill out contract details
     //         cy.findByText('Base contract').click()
@@ -12,13 +12,13 @@ describe('CMS User can view submission', () => {
     //         cy.findByLabelText('Managed Care Organization (MCO)').safeClick()
     //         cy.findByLabelText('1932(a) State Plan Authority').safeClick()
     //         cy.findAllByTestId('errorMessage').should('have.length', 0)
-    //         cy.navigateForm('Continue')
+    //         cy.navigateForm('CONTINUE')
     //         //Fill out rate details
     //         cy.findByText('New rate certification').click()
     //         cy.findByLabelText('Start date').type('02/29/2024')
     //         cy.findByLabelText('End date').type('02/28/2025')
     //         cy.findByLabelText('Date certified').type('03/01/2024')
-    //         cy.navigateForm('Continue')
+    //         cy.navigateForm('CONTINUE')
     //         // fill out state contacts
     //         cy.findAllByLabelText('Name').eq(0).type('Test Person')
     //         cy.findAllByLabelText('Title/Role').eq(0).type('Fancy Title')
@@ -44,7 +44,7 @@ describe('CMS User can view submission', () => {
     //         cy.findByText('Duplicate file, please remove').should('not.exist')
     //         cy.waitForDocumentsToLoad()
     //         // Navigate review and submit page
-    //         cy.navigateForm('Continue')
+    //         cy.navigateForm('CONTINUE')
     //         // Store submission name for reference later
     //         let submissionId = ''
     //         cy.location().then((fullUrl) => {
@@ -53,9 +53,9 @@ describe('CMS User can view submission', () => {
     //             submissionId = pathnameArray[2]
     //         })
     //         // Submit, sent to dashboard
-    //         cy.navigateForm('Submit')
+    //         cy.navigateForm('SUBMIT')
     //         cy.findByRole('dialog').should('exist')
-    //         cy.navigateForm('Submit')
+    //         cy.navigateForm('SUBMIT')
     //         cy.waitForApiToLoad()
     //         cy.findByText('Dashboard').should('exist')
     //         cy.findByText('PMAP').should('exist')

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -24,23 +24,23 @@ describe('dashboard', () => {
 
         // add a draft submission
         cy.startNewContractAndRatesSubmission()
-        cy.findByRole('button', { name: /Save as draft/ }).click()
+        cy.navigateForm('SAVE_DRAFT')
 
         // a submitted submission
         cy.startNewContractAndRatesSubmission()
 
         cy.fillOutBaseContractDetails()
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
 
         cy.fillOutNewRateCertification()
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
 
         cy.fillOutStateContact()
         cy.fillOutActuaryContact()
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
 
         cy.fillOutSupportingDocuments()
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
 
         // Store submission name for reference later
         let submissionId = ''
@@ -63,7 +63,6 @@ describe('dashboard', () => {
 
         // Submit, sent to dashboard
         cy.submitStateSubmissionForm()
-        cy.waitForApiToLoad()
         cy.findByText('Dashboard').should('exist')
         cy.findByText('Programs').should('exist')
 

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
@@ -11,26 +11,26 @@ describe('contacts', () => {
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
 
             // Navigate to contract details page by clicking back for contract only submission
-            cy.findByRole('button', { name: /Back/ }).click()
+            cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
             cy.findByText('Contract action and rate certification').click()
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
 
             // Navigate to contacts page
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
 
             // Navigate to rate details page by clicking back for contract and rates submission
-            cy.findByRole('button', { name: /Back/ }).click()
+             cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Rate details/ })
 
             // Navigate to contacts page
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
 
             // Navigate to dashboard page by clicking save as draft
-            cy.findByRole('button', { name: /Save as draft/ }).click()
+           cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to contacts page
@@ -40,12 +40,12 @@ describe('contacts', () => {
             cy.fillOutActuaryContact()
 
             // Navigate to documents page by clicking continue
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             // HM-TODO: Why doesn't level attribute work here?
             cy.findByRole('heading', { name: /Supporting documents/ })
 
             // check accessibility of filled out contacts page
-            cy.findByRole('button', { name: /Back/ }).click()
+           cy.navigateForm('BACK')
             cy.findByRole('heading', { name: /Contacts/ })
             cy.pa11y({
                 actions: ['wait for element #form-guidance to be visible'],
@@ -94,7 +94,7 @@ describe('contacts', () => {
             cy.findAllByLabelText('Mercer').eq(1).safeClick()
 
             // Navigate to documents page by clicking continue
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             // HM-TODO: Why doesn't level attribute work here?
             cy.findByRole('heading', { name: /Supporting documents/ })
 

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
@@ -10,14 +10,14 @@ describe('contract details', () => {
             const draftSubmissionId = pathnameArray[2]
 
             // Navigate to type page by clicking back
-            cy.findByRole('button', { name: /Back/ }).click()
+            cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Submission type/ })
 
             // Navigate to contract details page
             cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
 
             // Navigate to dashboard page by clicking save as draft
-            cy.findByRole('button', { name: /Save as draft/ }).click()
+           cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to contract details page
@@ -26,19 +26,19 @@ describe('contract details', () => {
             cy.fillOutBaseContractDetails()
 
             // Navigate to contacts page by clicking continue for contract only submission
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
             // Navigate to type page to switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
             cy.findByText('Contract action and rate certification').click()
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
 
             // Navigate to contract details page
             cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
 
             // Navigate to contacts page by clicking continue for contract and rates submission
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Rate details/ })
         })
     })
@@ -50,11 +50,11 @@ describe('contract details', () => {
         cy.fillOutAmendmentToBaseContractDetails()
 
         // Navigate to contacts page by clicking continue for contract only submission
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
         cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
         // check accessibility of filled out contract details page
-        cy.findByRole('button', { name: /Back/ }).click()
+        cy.navigateForm('BACK')
         cy.pa11y({
             actions: ['wait for element #form-guidance to be visible'],
             hideElements: '.usa-step-indicator',

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contractDetails.spec.ts
@@ -9,35 +9,29 @@ describe('contract details', () => {
             const pathnameArray = pathname.split('/')
             const draftSubmissionId = pathnameArray[2]
 
-            // Navigate to type page by clicking back
-            cy.navigateForm('BACK')
-            cy.findByRole('heading', { level: 2, name: /Submission type/ })
-
-            // Navigate to contract details page
-            cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
-
-            // Navigate to dashboard page by clicking save as draft
-           cy.navigateForm('SAVE_DRAFT')
-            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
-
-            // Navigate to contract details page
-            cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
-
+            // CONTINUE for contract only submission goes to Contacts page
             cy.fillOutBaseContractDetails()
-
-            // Navigate to contacts page by clicking continue for contract only submission
             cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
-            // Navigate to type page to switch to contract and rates submission
+            // BACK to contract details, switch some fields, and SAVE AS DRAFT
+            cy.navigateForm('BACK')
+            cy.findByLabelText(/Prepaid Inpatient Health Plan/).safeClick()
+            cy.findByLabelText(
+                /Primary Care Case Management Entity/
+            ).safeClick()
+            cy.navigateForm('SAVE_DRAFT')
+            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+
+            // Navigate to submission type page, switch to contract and rates submission
             cy.visit(`/submissions/${draftSubmissionId}/type`)
             cy.findByText('Contract action and rate certification').click()
             cy.navigateForm('CONTINUE')
+            cy.findByRole('heading', { level: 2, name: /Contract details/ })
+            // this prevents flakes- watch for step indicator to update to show rerenders after update call are complete
+            cy.findByTestId('step-indicator').contains('span', 'Rate details')
 
-            // Navigate to contract details page
-            cy.visit(`/submissions/${draftSubmissionId}/contract-details`)
-
-            // Navigate to contacts page by clicking continue for contract and rates submission
+            // CONTINUE for contract and rates submission goes to Rate details page
             cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Rate details/ })
         })
@@ -48,8 +42,6 @@ describe('contract details', () => {
         cy.startNewContractOnlySubmission()
 
         cy.fillOutAmendmentToBaseContractDetails()
-
-        // Navigate to contacts page by clicking continue for contract only submission
         cy.navigateForm('CONTINUE')
         cy.findByRole('heading', { level: 2, name: /Contacts/ })
 

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/documents.spec.ts
@@ -57,7 +57,7 @@ describe('documents', () => {
             cy.findByText('Duplicate file, please remove').should('exist')
             cy.findAllByRole('row').should('have.length', 4)
             cy.findByText(/2 complete, 1 error, 0 pending/)
-            cy.navigateForm('Back')
+            cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
             // reload page, see two documents, duplicate was discarded on Back
@@ -69,7 +69,7 @@ describe('documents', () => {
             cy.verifyDocumentsHaveNoErrors()
 
             //  Save as draft
-            cy.navigateForm('Save as draft')
+            cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
         })
     })
@@ -122,11 +122,11 @@ describe('documents', () => {
             cy.findByTestId('file-input-loading-image').should('not.exist')
             cy.verifyDocumentsHaveNoErrors()
 
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Review and submit/ })
 
             // check accessibility of filled out documents page
-            cy.findByRole('button', { name: /Back/ }).click()
+            cy.navigateForm('BACK')
             cy.pa11y({
                 actions: ['wait for element #documents-hint to be visible'],
                 hideElements: '.usa-step-indicator',

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -15,7 +15,7 @@ describe('new submission', () => {
         cy.fillOutContractActionOnly()
 
         // Navigate to contract details page by clicking continue for contract only submission
-        cy.navigateForm('CONTINUE')
+        cy.navigateForm('CONTINUE_FROM_START_NEW')
         cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
         // check accessibility of filled out SubmissionType page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -15,11 +15,11 @@ describe('new submission', () => {
         cy.fillOutContractActionOnly()
 
         // Navigate to contract details page by clicking continue for contract only submission
-        cy.navigateForm('Continue')
+        cy.navigateForm('CONTINUE')
         cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
         // check accessibility of filled out SubmissionType page
-        cy.findByRole('button', { name: /Back/ }).click()
+        cy.navigateForm('BACK')
         cy.pa11y({
             actions: ['wait for element #form-guidance to be visible'],
             hideElements: '.usa-step-indicator',

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -11,14 +11,14 @@ describe('rate details', () => {
             cy.visit(`/submissions/${draftSubmissionId}/rate-details`)
 
             // Navigate to contract details page by clicking back
-            cy.findByRole('button', { name: /Back/ }).click()
+           cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to rate details page
             cy.visit(`/submissions/${draftSubmissionId}/rate-details`)
 
             // Navigate to dashboard page by clicking save as draft
-            cy.findByRole('button', { name: /Save as draft/ }).click()
+            cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to rate details page
@@ -27,7 +27,7 @@ describe('rate details', () => {
             cy.fillOutNewRateCertification()
 
             // Navigate to contacts page by clicking continue
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
         })
     })
@@ -46,11 +46,11 @@ describe('rate details', () => {
             cy.fillOutAmendmentToPriorRateCertification()
 
             // Navigate to contacts page by clicking continue
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contacts/ })
 
             // check accessibility of filled out rate details page
-            cy.findByRole('button', { name: /Back/ }).click()
+            cy.navigateForm('BACK')
             cy.pa11y({
                 actions: ['wait for element #form-guidance to be visible'],
                 hideElements: '.usa-step-indicator',

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -40,7 +40,7 @@ describe('review and submit', () => {
             const draftSubmissionId = pathnameArray[2]
             cy.visit(`/submissions/${draftSubmissionId}/review-and-submit`)
 
-            cy.submitStateSubmissionForm()
+            cy.submitStateSubmissionForm(false)
             cy.findAllByTestId('modalWindow').should('be.hidden')
             cy.findByRole('heading', { level: 4, name: /Submission Error/ })
         })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -11,7 +11,7 @@ describe('review and submit', () => {
             cy.visit(`/submissions/${draftSubmissionId}/review-and-submit`)
 
             // Navigate to documents page by clicking back
-            cy.findByRole('button', { name: /Back/ }).click()
+            cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Supporting documents/ })
 
             // Navigate to review and submit page
@@ -24,7 +24,7 @@ describe('review and submit', () => {
             cy.findByText('Download all contract documents').should('not.exist')
 
             // Navigate to dashboard page by clicking save as draft
-            cy.findByRole('button', { name: /Save as draft/ }).click()
+            cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
         })
     })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -18,7 +18,7 @@ describe('submission type', () => {
             cy.visit(`/submissions/${draftSubmissionId}/type`)
 
             // Navigate to contract details page by clicking continue for contract only submission
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
         })
     })
@@ -37,7 +37,7 @@ describe('submission type', () => {
             cy.findByText('Contract action and rate certification').click()
 
             // Navigate to contract details page by clicking continue for contract and rates submission
-            cy.navigateForm('Continue')
+            cy.navigateForm('CONTINUE')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to type page

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -41,18 +41,3 @@ Cypress.Commands.add('safeClick', { prevSubject: 'element' }, ($element) => {
     return cy.wrap($element).should('exist').should('be.visible').pipe(click)
 })
 
-Cypress.Commands.add(
-    'navigateForm',
-    (buttonAccessibleName: string, waitForLoad = true) => {
-        cy.findByRole('button', {
-            name: buttonAccessibleName,
-        }).safeClick()
-        if (waitForLoad) cy.waitForApiToLoad()
-        cy.findByTestId('state-submission-form-page').should('exist')
-    }
-)
-
-Cypress.Commands.add('waitForApiToLoad', () => {
-    cy.intercept('POST', '*/graphql').as('gqlRequest')
-    cy.wait('@gqlRequest')
-})

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -40,7 +40,7 @@ declare global {
             fillOutSupportingDocuments(): void
             waitForDocumentsToLoad(): void
             verifyDocumentsHaveNoErrors(): void
-            submitStateSubmissionForm(): void
+            submitStateSubmissionForm(success?: boolean): void
             navigateForm(buttonName: FormButtonKey, waitForLoad?: boolean): void
         }
     }

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -13,14 +13,13 @@
 import './commands'
 import './loginCommands'
 import './stateSubmissionFormCommands'
+type FormButtonKey = 'CONTINUE_FROM_START_NEW' | 'CONTINUE' | 'SAVE_DRAFT' | 'BACK' 
 
 declare global {
     namespace Cypress {
         interface Chainable<Subject = any> {
             // commands
             safeClick(): void
-            navigateForm(buttonName: string): Chainable<Element>
-            waitForApiToLoad(): void
 
             // login commands
             logInAsStateUser(): void
@@ -42,6 +41,7 @@ declare global {
             waitForDocumentsToLoad(): void
             verifyDocumentsHaveNoErrors(): void
             submitStateSubmissionForm(): void
+            navigateForm(buttonName: FormButtonKey, waitForLoad?: boolean): void
         }
     }
 }

--- a/tests/cypress/support/loginCommands.ts
+++ b/tests/cypress/support/loginCommands.ts
@@ -59,6 +59,6 @@ Cypress.Commands.add(
             throw new Error(`Auth mode is not defined or is IDM: ${authMode}`)
         } 
         cy.wait('@fetchCurrentUserQuery', { timeout: 20000 })
-        cy.wait('@fetchSubmission2Query') // we only allow CMS users to go to a specific submission on login
+        cy.wait('@fetchSubmission2Query', { timeout: 20000 }) // we only allow CMS users to go to a specific submission on login
     }
 )

--- a/tests/cypress/support/loginCommands.ts
+++ b/tests/cypress/support/loginCommands.ts
@@ -27,7 +27,7 @@ Cypress.Commands.add('logInAsStateUser', () => {
         throw new Error(`Auth mode is not defined or is IDM: ${authMode}`)
     }
     cy.wait('@fetchCurrentUserQuery', {timeout: 20000})
-    cy.wait('@indexSubmissions2Query', {timeout: 20000}) // this is the first request that engages the db
+    cy.wait('@indexSubmissions2Query', {timeout: 80000}) // this is the first request that engages the db, can take really long if its a fresh PR branch
 })
 
 Cypress.Commands.add(

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -233,6 +233,7 @@ Cypress.Commands.add(
             aliasQuery(req, 'indexSubmissions2')
             aliasQuery(req, 'fetchSubmission2')
             aliasMutation(req, 'createDraftSubmission')
+            aliasMutation(req, 'updateDraftSubmission')
         })
 
         cy.findByRole('button', {
@@ -252,7 +253,10 @@ Cypress.Commands.add(
                 'exist'
             ) 
         } else if (buttonKey === 'CONTINUE'){
-            if (waitForLoad) cy.wait('@fetchSubmission2Query')
+            if (waitForLoad){
+                cy.wait('@updateDraftSubmissionMutation')
+                cy.wait('@fetchSubmission2Query')
+            }
             cy.findByTestId('state-submission-form-page').should('exist')
         } else {
             // don't wait for api on BACK

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -196,7 +196,7 @@ Cypress.Commands.add('verifyDocumentsHaveNoErrors', () => {
     cy.findByText('Remove files with errors').should('not.exist')
 })
 
-Cypress.Commands.add('submitStateSubmissionForm', () => {
+Cypress.Commands.add('submitStateSubmissionForm', (success = true) => {
       cy.intercept('POST', '*/graphql', (req) => {
           aliasMutation(req, 'submitDraftSubmission')
           aliasQuery(req, 'indexSubmissions2')
@@ -212,7 +212,9 @@ Cypress.Commands.add('submitStateSubmissionForm', () => {
             cy.findByTestId('review-and-submit-modal-submit').click()
         })
     cy.wait('@submitDraftSubmissionMutation', { timeout: 50000 })
-    cy.wait('@indexSubmissions2Query', { timeout: 50000 })
+    if (success) {
+        cy.wait('@indexSubmissions2Query', { timeout: 50000 })
+    }
 })
 
 type FormButtonKey =  'CONTINUE_FROM_START_NEW'| 'CONTINUE' | 'SAVE_DRAFT' | 'BACK'
@@ -249,10 +251,12 @@ Cypress.Commands.add(
             cy.findByTestId('state-submission-form-page').should(
                 'exist'
             ) 
-        } else {
-            // Going BACK or CONTINUE on a regular form page
+        } else if (buttonKey === 'CONTINUE'){
             if (waitForLoad) cy.wait('@fetchSubmission2Query')
             cy.findByTestId('state-submission-form-page').should('exist')
+        } else {
+            // don't wait for api on BACK
+              cy.findByTestId('state-submission-form-page').should('exist')
         }
 
     }

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -1,3 +1,4 @@
+import { aliasQuery, aliasMutation } from '../utils/graphql-test-utils'
 Cypress.Commands.add('startNewContractOnlySubmission', () => {
     // Must be on '/submissions/new'
     cy.findByTestId('dashboard-page').should('exist')
@@ -8,7 +9,7 @@ Cypress.Commands.add('startNewContractOnlySubmission', () => {
 
     cy.fillOutContractActionOnly()
 
-    cy.navigateForm('Continue')
+    cy.navigateForm('CONTINUE_FROM_START_NEW')
     cy.findByRole('heading', { level: 2, name: /Contract details/ })
 })
 
@@ -22,7 +23,7 @@ Cypress.Commands.add('startNewContractAndRatesSubmission', () => {
 
     cy.fillOutContractActionAndRateCertification()
 
-    cy.navigateForm('Continue')
+    cy.navigateForm('CONTINUE_FROM_START_NEW')
     cy.findByRole('heading', { level: 2, name: /Contract details/ })
 })
 
@@ -196,12 +197,63 @@ Cypress.Commands.add('verifyDocumentsHaveNoErrors', () => {
 })
 
 Cypress.Commands.add('submitStateSubmissionForm', () => {
-    // Must be on '/submissions/:id/review-and-submit'
-    cy.navigateForm('Submit')
-    // HM-TODO: Move this check to dashboard page
+      cy.intercept('POST', '*/graphql', (req) => {
+          aliasMutation(req, 'submitDraftSubmission')
+          aliasQuery(req, 'indexSubmissions2')
+      })
+    cy.findByRole('heading', { level: 2, name: /Review and submit/ })
+    cy.findByRole('button', {
+        name: 'Submit'
+    }).safeClick()
+
     cy.findAllByTestId('modalWindow')
         .should('exist')
         .within(($modal) => {
             cy.findByTestId('review-and-submit-modal-submit').click()
         })
+    cy.wait('@submitDraftSubmissionMutation', { timeout: 50000 })
+    cy.wait('@indexSubmissions2Query', { timeout: 50000 })
 })
+
+type FormButtonKey =  'CONTINUE_FROM_START_NEW'| 'CONTINUE' | 'SAVE_DRAFT' | 'BACK'
+type FormButtons = { [key in FormButtonKey]: string }
+const buttonsWithLabels: FormButtons = {
+    CONTINUE: 'Continue',
+    CONTINUE_FROM_START_NEW: 'Continue',
+    SAVE_DRAFT: 'Save as draft',
+    BACK: 'Back',
+}
+
+Cypress.Commands.add(
+    'navigateForm',
+    (buttonKey: FormButtonKey, waitForLoad = true) => {
+        cy.intercept('POST', '*/graphql', (req) => {
+            aliasQuery(req, 'indexSubmissions2')
+            aliasQuery(req, 'fetchSubmission2')
+            aliasMutation(req, 'createDraftSubmission')
+        })
+
+        cy.findByRole('button', {
+            name: buttonsWithLabels[buttonKey],
+        }).safeClick()
+
+        if (buttonKey === 'SAVE_DRAFT') {
+            if (waitForLoad) cy.wait('@indexSubmissions2Query', { timeout: 20000 })
+            cy.findByTestId('dashboard-page').should('exist')
+
+        } else if (buttonKey === 'CONTINUE_FROM_START_NEW') {
+                 if (waitForLoad){
+                    cy.wait('@createDraftSubmissionMutation', { timeout: 50000 })
+                    cy.wait('@fetchSubmission2Query')
+                 }
+            cy.findByTestId('state-submission-form-page').should(
+                'exist'
+            ) 
+        } else {
+            // Going BACK or CONTINUE on a regular form page
+            if (waitForLoad) cy.wait('@fetchSubmission2Query')
+            cy.findByTestId('state-submission-form-page').should('exist')
+        }
+
+    }
+)


### PR DESCRIPTION
## Summary
Address renewed Cypress flakes since adding unlock epic and monitoring work
- remove generic references to `gqlRequest` and replace with named aliases for each our queries and mutations. Look for `aliasQuery` and `aliasMutation` references.
-  This follows cypress best practice for gql which we first tried out with login helper https://docs.cypress.io/guides/testing-strategies/working-with-graphql#Modifying-a-Query-or-Mutation-Response 
- Remove generic `cy.wait` whenever possible as per https://docs.cypress.io/guides/references/best-practices#Unnecessary-Waiting
- I reworked the contract details test because I saw flaky behavior even locally when switch the submission type from contract only to contract rates and then trying to submit

#### Related issues
https://qmacbis.atlassian.net/browse/OY2-17246 


