### PR TITLE
Fix date off-by-one and pre-filled today bugs

### DIFF
--- a/services/app-web/src/dateHelpers/gqlDate.ts
+++ b/services/app-web/src/dateHelpers/gqlDate.ts
@@ -2,7 +2,10 @@ import { dayjs } from './dayjs'
 
 // We store calendar dates (dates with no time info) in UTC for consistency.
 // This formats a date correctly like '12/02/2022' for display.
-function formatGQLDate(date: Date): string {
+function formatGQLDate(date: Date | undefined): string | undefined {
+    if (!date) {
+        return undefined
+    }
     return dayjs(date).tz('UTC').format('YYYY-MM-DD')
 }
 

--- a/services/app-web/src/pages/StateSubmission/updateSubmissionTransform.ts
+++ b/services/app-web/src/pages/StateSubmission/updateSubmissionTransform.ts
@@ -1,6 +1,5 @@
 import { base64ToDomain } from '../../common-code/proto/stateSubmission'
-import { DraftSubmission, DraftSubmissionUpdates , Maybe, RateAmendmentInfo, Submission2} from '../../gen/gqlClient'
-import { formatGQLDate } from '../../dateHelpers'
+import { DraftSubmission, DraftSubmissionUpdates , Submission2} from '../../gen/gqlClient'
 /*
     Clean out _typename from submission
     If you pass gql __typename within a mutation input things break; however,  __typename comes down on cached queries by default
@@ -46,33 +45,20 @@ function updatesFromSubmission(draft: DraftSubmission): DraftSubmissionUpdates {
         contractType: draft.contractType,
         contractExecutionStatus: draft.contractExecutionStatus,
         contractDocuments: draft.contractDocuments,
-        contractDateStart: formatGQLDate(draft.contractDateStart),
-        contractDateEnd: formatGQLDate(draft.contractDateEnd),
+        contractDateStart: draft.contractDateStart,
+        contractDateEnd: draft.contractDateEnd,
         federalAuthorities: draft.federalAuthorities,
         managedCareEntities: draft.managedCareEntities,
         contractAmendmentInfo: draft.contractAmendmentInfo,
         rateType: draft.rateType,
         rateDocuments: draft.rateDocuments,
-        rateDateStart: formatGQLDate(draft.rateDateStart),
-        rateDateEnd: formatGQLDate(draft.rateDateEnd),
-        rateDateCertified: formatGQLDate(draft.rateDateCertified),
-        rateAmendmentInfo: updatesFromRateAmendmentInfo(draft.rateAmendmentInfo),
+        rateDateStart: draft.rateDateStart,
+        rateDateEnd: draft.rateDateEnd,
+        rateDateCertified: draft.rateDateCertified,
+        rateAmendmentInfo: draft.rateAmendmentInfo,
         stateContacts: draft.stateContacts,
         actuaryContacts: draft.actuaryContacts,
         actuaryCommunicationPreference: draft.actuaryCommunicationPreference,
-    }
-}
-
-// This is more code that should go away when we finish the refactor
-// Because this sub-object has dates in it, we need to format those dates correctly.
-// we don't need to fix contacts or documents in the same way.
-function updatesFromRateAmendmentInfo(rateInfo: Maybe<RateAmendmentInfo> | undefined): DraftSubmissionUpdates["rateAmendmentInfo"] {
-    if (!rateInfo) {
-        return undefined
-    }
-    return {
-        effectiveDateEnd: formatGQLDate(rateInfo.effectiveDateEnd),
-        effectiveDateStart: formatGQLDate(rateInfo.effectiveDateStart),
     }
 }
 


### PR DESCRIPTION
## Summary

Josh found another pair of date bugs on Val, this addresses them.

Ultimately, I think that this was a typing failure around dates specifically. I think, but haven’t confirmed in depth, that GraphQL uses `any` for our custom types of which Date and DateTime are two. I suspect we could configure the code generator to have a specific type instead, which I think would have caught this bug. 

We fixed some errors we were seeing with our current Domain Model -> GQL conversion but we fixed them on the wrong end. We converted to the GraphQL standard (a string “2022-02-01”) when creating the body of the updateDraftSubmission request. This request was erroring at the API layer because we were sending a Date() instead of a string. 

However, actually, all of our code in the form itself also expects a string, not a Date object, but because of some bad typing somewhere, nothing was complaining about the fact that we were sending the wrong type down. So the fix is to do that conversion when we construct the GQL type being fed as the default into the form instead of when we construct the update body. 

I’ve seen this kind of confusion before, I think there were tests where we were using dates instead of strings and some stuff just worked. 

Long term, creating a custom type for CalendarDate and using that everywhere should stop a bug like this from happening again. Of course in this particular case this bug is in some very temporary conversion code that will go away when we are only using the domain model backed by proto. 

We should investigate other DateTimes we have in our API like createdAt and ensure that they are coming out the right type in the generated GQL code. 

#### Related issues

[Dates update incorrectly when navigating between pages](https://qmacbis.atlassian.net/browse/OY2-17300)
[Dates are automatically filled into the rate details page](https://qmacbis.atlassian.net/browse/OY2-17308)

### QA Guidance

doing a single run through of a conract and rates submission would have triggered the bug. 