### PR TITLE
Adjust contacts page tests

### DIFF
--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
@@ -167,7 +167,7 @@ describe('Contacts', () => {
         })
     })
 
-    it('after "Add actuary contact" button click, it should focus on the field name of the new actuarycontact', async () => {
+    it('after "Add actuary contact" button click, it should focus on the field name of the new actuary contact', async () => {
         const mock = mockContactAndRatesDraft()
         const mockUpdateDraftFn = jest.fn()
 
@@ -263,6 +263,7 @@ describe('Contacts', () => {
             expect(addActuaryContactButton).toHaveFocus()
         })
     })
+
     it('when there are multiple state contacts, they should numbered', async () => {
         const mock = mockContactAndRatesDraft()
         const mockUpdateDraftFn = jest.fn()
@@ -308,5 +309,124 @@ describe('Contacts', () => {
                 screen.getByText('Additional actuary contact 1')
             ).toBeInTheDocument()
         })
+    })
+
+    it('when there are multiple state and actuary contacts, remove button works as expected', async () => {
+        const mock = mockContactAndRatesDraft()
+        const mockUpdateDraftFn = jest.fn()
+
+        renderWithProviders(
+            <Contacts draftSubmission={mock} updateDraft={mockUpdateDraftFn} />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        // add state contact
+        userEvent.type(
+            screen.getAllByLabelText('Name')[0],
+            'State Contact Person'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Title/Role')[0],
+            'State Contact Title'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Email')[0],
+            'statecontact@test.com'
+        )
+        expect(screen.queryAllByTestId('errorMessage').length).toBe(0)
+
+        // add actuary contact
+        userEvent.type(
+            screen.getAllByLabelText('Name')[1],
+            'Actuary Contact Person'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Title/Role')[1],
+            'Actuary Contact Title'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Email')[1],
+            'actuarycontact@test.com'
+        )
+
+        userEvent.click(screen.getAllByLabelText('Mercer')[0])
+
+        userEvent.click(
+            screen.getByText(
+                `OACT can communicate directly with the state’s actuary but should copy the state on all written communication and all appointments for verbal discussions.`
+            )
+        )
+
+        expect(screen.queryAllByTestId('errorMessage').length).toBe(0)
+
+        // Add additional state contact
+        userEvent.click(
+            screen.getByRole('button', {
+                name: /Add another state contact/,
+            })
+        )
+
+
+        userEvent.type(
+            screen.getAllByLabelText('Name')[1],
+            'State Contact Person 2'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Title/Role')[1],
+            'State Contact Title 2'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Email')[1],
+            'statecontact2@test.com'
+        )
+        expect(screen.queryAllByTestId('errorMessage').length).toBe(0)
+
+        // Add additional actuary contact
+        userEvent.click(
+            screen.getByRole('button', {
+                name: /Add another actuary contact/,
+            })
+        )
+
+        userEvent.type(
+            screen.getAllByLabelText('Name')[1],
+            'Actuary Contact Person 2'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Title/Role')[1],
+            'Actuary Contact Title 2'
+        )
+        userEvent.type(
+            screen.getAllByLabelText('Email')[1],
+            'actuarycontact2@test.com'
+        )
+        // Select additional actuarial firm
+        userEvent.click(screen.getAllByLabelText('Mercer')[1])
+
+        // Remove additional state contact
+        expect(
+            screen.getAllByRole('button', { name: /Remove contact/ }).length
+        ).toBe(2) // there are two remove contact buttons on screen, one for state one for actuary
+        userEvent.click(
+            screen.getAllByRole('button', { name: /Remove contact/ })[0]
+        )
+
+        expect(screen.queryByText('State contact 2')).toBeNull()
+
+        // Remove additional actuary contact
+        expect(
+            screen.getAllByRole('button', { name: /Remove contact/ }).length
+        ).toBe(1) // there is only 1 button on screen, for actuary 
+
+        userEvent.click(
+            screen.getAllByRole('button', { name: /Remove contact/ })[0]
+        )
+
+       expect(screen.queryByText('Additional actuary contact 1')).toBeNull()
+       
     })
 })

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/contacts.spec.ts
@@ -1,7 +1,7 @@
 describe('contacts', () => {
-    it('can navigate to and from contacts page', () => {
+    it('can navigate to and from contacts page with contract only submission', () => {
         cy.logInAsStateUser()
-        cy.startNewContractOnlySubmission()
+       cy.startNewContractOnlySubmission()
 
         // Navigate to contacts page
         cy.location().then((fullUrl) => {
@@ -10,51 +10,33 @@ describe('contacts', () => {
             const draftSubmissionId = pathnameArray[2]
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
 
-            // Navigate to contract details page by clicking back for contract only submission
+            // On contacts page, navigate BACK
             cy.navigateForm('BACK')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
-            // Navigate to type page to switch to contract and rates submission
-            cy.visit(`/submissions/${draftSubmissionId}/type`)
-            cy.findByText('Contract action and rate certification').click()
-            cy.navigateForm('CONTINUE')
 
-            // Navigate to contacts page
+            // On contacts page, SAVE_DRAFT
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
-
-            // Navigate to rate details page by clicking back for contract and rates submission
-             cy.navigateForm('BACK')
-            cy.findByRole('heading', { level: 2, name: /Rate details/ })
-
-            // Navigate to contacts page
-            cy.visit(`/submissions/${draftSubmissionId}/contacts`)
-
-            // Navigate to dashboard page by clicking save as draft
-           cy.navigateForm('SAVE_DRAFT')
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
+            cy.navigateForm('SAVE_DRAFT')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
-            // Navigate to contacts page
+            // On contacts page, fill out information and CONTINUE
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
-
             cy.fillOutStateContact()
-            cy.fillOutActuaryContact()
-
-            // Navigate to documents page by clicking continue
             cy.navigateForm('CONTINUE')
-            // HM-TODO: Why doesn't level attribute work here?
-            cy.findByRole('heading', { name: /Supporting documents/ })
+            cy.findByRole('heading', { level: 2, name: /Supporting documents/ })
 
             // check accessibility of filled out contacts page
-           cy.navigateForm('BACK')
-            cy.findByRole('heading', { name: /Contacts/ })
+            cy.navigateForm('BACK')
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
             cy.pa11y({
                 actions: ['wait for element #form-guidance to be visible'],
                 hideElements: '.usa-step-indicator',
             })
         })
     })
-
-    it('can add and remove additional state and actuary contacts', () => {
+    it('can navigate to and from contacts page with contract and rates submission', () => {
         cy.logInAsStateUser()
         cy.startNewContractAndRatesSubmission()
 
@@ -65,53 +47,30 @@ describe('contacts', () => {
             const draftSubmissionId = pathnameArray[2]
             cy.visit(`/submissions/${draftSubmissionId}/contacts`)
 
+            // On contacts page, navigate BACK
+            cy.navigateForm('BACK')
+            cy.findByRole('heading', { level: 2, name: /Rate details/ })
+
+            // On contacts page, SAVE_DRAFT
+            cy.visit(`/submissions/${draftSubmissionId}/contacts`)
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
+            cy.navigateForm('SAVE_DRAFT')
+            cy.findByRole('heading', { level: 1, name: /Dashboard/ })
+
+            // On contacts page, fill out information and CONTINUE
+            cy.visit(`/submissions/${draftSubmissionId}/contacts`)
             cy.fillOutStateContact()
             cy.fillOutActuaryContact()
-
-            // Add additional state contact
-            cy.findByRole('button', {
-                name: /Add another state contact/,
-            }).click()
-            cy.findAllByLabelText('Name').eq(1).type('State Contact Person 2')
-            cy.findAllByLabelText('Title/Role')
-                .eq(1)
-                .type('State Contact Title 2')
-            cy.findAllByLabelText('Email').eq(1).type('statecontact2@test.com')
-
-            // Add additional actuary contact
-            cy.findByRole('button', {
-                name: /Add another actuary contact/,
-            }).click()
-            cy.findAllByLabelText('Name').eq(3).type('Actuary Contact Person 2')
-            cy.findAllByLabelText('Title/Role')
-                .eq(3)
-                .type('Actuary Contact Title 2')
-            cy.findAllByLabelText('Email')
-                .eq(3)
-                .type('actuarycontact2@test.com')
-
-            // Select additional actuarial firm
-            cy.findAllByLabelText('Mercer').eq(1).safeClick()
-
-            // Navigate to documents page by clicking continue
             cy.navigateForm('CONTINUE')
-            // HM-TODO: Why doesn't level attribute work here?
-            cy.findByRole('heading', { name: /Supporting documents/ })
+            cy.findByRole('heading', { level: 2, name: /Supporting documents/ })
 
-            // Navigate to contacts page
-            cy.visit(`/submissions/${draftSubmissionId}/contacts`)
-
-            // Remove additional state contact
-            cy.findAllByRole('button', { name: /Remove contact/ })
-                .eq(0)
-                .click()
-            cy.findByText('State contacts 2').should('not.exist')
-
-            // Remove additional actuary contact
-            cy.findAllByRole('button', { name: /Remove contact/ })
-                .eq(0)
-                .click()
-            cy.findByText('Additional actuary contact 1').should('not.exist')
+            // check accessibility of filled out contacts page
+            cy.navigateForm('BACK')
+            cy.findByRole('heading', { level: 2, name: /Contacts/ })
+            cy.pa11y({
+                actions: ['wait for element #form-guidance to be visible'],
+                hideElements: '.usa-step-indicator',
+            })
         })
     })
 })


### PR DESCRIPTION
## Summary
Adjust contacts page Cypress tests, add to jest tests.  This seems to be a specific test spec that keeps flaking and isn't addressed by other attempts.

#### Related issues
Follow up to #862 

#### Test cases covered

- I  moved the testing logic for adding and removing contacts while editing Contacts information down from Cypress (where it was flaky, probably due to re-renders) into jest. This logic is just on the same page anyway, its better suited for React component testing
- I kept two Cypress tests - one testing contract only (no actuary contacts) and one testing contract and rates 
