### PR TITLE
OY2-13875: Add change history to submission summary page

### DIFF
--- a/services/app-api/resolvers/unlockStateSubmission.test.ts
+++ b/services/app-api/resolvers/unlockStateSubmission.test.ts
@@ -58,14 +58,16 @@ describe('unlockStateSubmission', () => {
 
         expect(unlockedSub.revisions[0].revision.submitInfo).toBeNull()
         expect(unlockedSub.revisions[1].revision.submitInfo).toBeDefined()
-        expect(unlockedSub.revisions[1].revision.submitInfo?.updatedAt).toEqual(todaysDate())
+        expect(unlockedSub.revisions[1].revision.submitInfo?.updatedAt.toISOString()).toContain(todaysDate())
+        // check that the date has full ISO time eg. 2022-03-25T03:09:54.864Z
+        expect(unlockedSub.revisions[1].revision.submitInfo?.updatedAt.toISOString()).toContain('Z')
 
         expect(unlockedSub.revisions[0].revision.unlockInfo).toBeDefined()
-        expect(unlockedSub.revisions[0].revision.unlockInfo).toEqual({
-            updatedAt: todaysDate(),
-            updatedBy: 'zuko@example.com',
-            updatedReason: 'Super duper good reason.'
-        })
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedBy).toEqual('zuko@example.com')
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedReason).toEqual('Super duper good reason.')
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain(todaysDate())
+        // check that the date has full ISO time eg. 2022-03-25T03:09:54.864Z
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain('Z')
     })
 
     it('returns a DraftSubmission that can be updated without errors', async () => {
@@ -103,11 +105,11 @@ describe('unlockStateSubmission', () => {
         // After unlock, we should get a draft submission back
         expect(unlockedSub.status).toEqual('UNLOCKED')
         expect(unlockedSub.revisions[0].revision.unlockInfo).toBeDefined()
-        expect(unlockedSub.revisions[0].revision.unlockInfo).toEqual({
-            updatedAt: todaysDate(),
-            updatedBy: 'zuko@example.com',
-            updatedReason: 'Super duper good reason.'
-        })
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedBy).toEqual('zuko@example.com')
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedReason).toEqual('Super duper good reason.')
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain(todaysDate())
+        // check that the date has full ISO time eg. 2022-03-25T03:09:54.864Z
+        expect(unlockedSub.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain('Z')
 
         // after unlock we should be able to update that draft submission and get the results
         const updates = {
@@ -157,11 +159,11 @@ describe('unlockStateSubmission', () => {
 
         const draft = await unlockTestDraftSubmission(cmsServer, stateSubmission.id, 'Very super duper good reason.')
         expect(draft.status).toEqual('UNLOCKED')
-        expect(draft.revisions[0].revision.unlockInfo).toEqual({
-            updatedAt: todaysDate(),
-            updatedBy: 'zuko@example.com',
-            updatedReason: 'Very super duper good reason.'
-        })
+        expect(draft.revisions[0].revision.unlockInfo?.updatedBy).toEqual('zuko@example.com')
+        expect(draft.revisions[0].revision.unlockInfo?.updatedReason).toEqual('Very super duper good reason.')
+        expect(draft.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain(todaysDate())
+        // check that the date has full ISO time eg. 2022-03-25T03:09:54.864Z
+        expect(draft.revisions[0].revision.unlockInfo?.updatedAt.toISOString()).toContain('Z')
     })
 
     it('returns errors if a state user tries to unlock', async () => {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -14,11 +14,8 @@ type Query {
     indexSubmissions: IndexSubmissionsPayload!
 
     # new api
-    fetchSubmission2(
-        input: FetchSubmission2Input!
-    ): FetchSubmission2Payload!
+    fetchSubmission2(input: FetchSubmission2Input!): FetchSubmission2Payload!
     indexSubmissions2: IndexSubmissions2Payload!
-
 }
 
 type Mutation {
@@ -160,7 +157,7 @@ type Submission2 {
 }
 
 type UpdateInformation {
-    updatedAt: Date!
+    updatedAt: DateTime!
     updatedBy: String!
     updatedReason: String!
 }

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
@@ -43,3 +43,7 @@
         }
     }
 }
+
+.tag {
+    font-weight: bold;
+}

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
@@ -1,0 +1,45 @@
+@import '../../styles/uswdsImports.scss';
+@import '../../styles/custom.scss';
+
+.summarySection {
+    margin: units(2) auto;
+    background: $cms-color-white;
+    // padding: units(2) units(4);
+    line-height: units(3);
+    @include u-radius('md');
+
+    h2 {
+        margin: 0;
+        @include u-text('normal');
+    }
+    &:first-of-type {
+        h2 {
+            @include u-text('bold');
+            font-size: size('body', 'lg');
+        }
+    }
+
+    ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+
+        li {
+            padding: units(1) 0;
+        }
+    }
+
+    // align state contacts
+    dl div[class^='grid-container'] {
+        padding: 0;
+
+        div {
+            padding-bottom: units(2);
+        }
+
+        // dont bottom pad last two grid items
+        div:nth-last-child(-n + 2) {
+            padding-bottom: 0;
+        }
+    }
+}

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.module.scss
@@ -2,9 +2,7 @@
 @import '../../styles/custom.scss';
 
 .summarySection {
-    margin: units(2) auto;
     background: $cms-color-white;
-    // padding: units(2) units(4);
     line-height: units(3);
     @include u-radius('md');
 
@@ -18,32 +16,12 @@
             font-size: size('body', 'lg');
         }
     }
-
-    ul {
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-
-        li {
-            padding: units(1) 0;
-        }
-    }
-
-    // align state contacts
-    dl div[class^='grid-container'] {
-        padding: 0;
-
-        div {
-            padding-bottom: units(2);
-        }
-
-        // dont bottom pad last two grid items
-        div:nth-last-child(-n + 2) {
-            padding-bottom: 0;
-        }
-    }
 }
 
 .tag {
     font-weight: bold;
+}
+
+.accordionRows {
+    font-size: 40px;
 }

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.stories.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.stories.tsx
@@ -1,0 +1,58 @@
+import { ChangeHistory } from './ChangeHistory'
+import { Submission2 } from '../../gen/gqlClient'
+
+export default {
+    title: 'Components/ChangeHistory',
+    component: ChangeHistory,
+}
+
+const submissionData: Submission2 = {
+    id: '440d6a53-bb0a-49ae-9a9c-da7c5352789f',
+    stateCode: 'MN',
+    status: 'RESUBMITTED',
+    intiallySubmittedAt: '2022-03-23',
+    revisions: [
+        {
+            revision: {
+                id: '26596de8-852d-4e42-bb0a-c9c9bf78c3de',
+                unlockInfo: {
+                    updatedAt: '2022-03-24T01:18:44.663Z',
+                    updatedBy: 'zuko@example.com',
+                    updatedReason: 'testing stuff',
+                    __typename: 'UpdateInformation',
+                },
+                submitInfo: {
+                    updatedAt: '2022-03-24T01:19:46.154Z',
+                    updatedBy: 'aang@example.com',
+                    updatedReason: 'Placeholder resubmission reason',
+                    __typename: 'UpdateInformation',
+                },
+                createdAt: '2022-03-24T01:18:44.665Z',
+                submissionData: 'alkdfjlasdjf',
+                __typename: 'Revision',
+            },
+            __typename: 'RevisionEdge',
+        },
+        {
+            revision: {
+                id: 'e048cdcf-5b19-4acb-8ead-d7dc2fd6cd30',
+                unlockInfo: null,
+                submitInfo: {
+                    updatedAt: '2022-03-23T02:08:52.259Z',
+                    updatedBy: 'aang@example.com',
+                    updatedReason: 'Initial submission',
+                    __typename: 'UpdateInformation',
+                },
+                createdAt: '2022-03-23T02:08:14.241Z',
+                submissionData: 'weoirna;dfkl',
+                __typename: 'Revision',
+            },
+            __typename: 'RevisionEdge',
+        },
+    ],
+    __typename: 'Submission2',
+}
+
+export const DemoListUploadSuccess = (): React.ReactElement => {
+    return <ChangeHistory submission={submissionData} />
+}

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
@@ -92,4 +92,20 @@ describe('Change History', () => {
             screen.getByText('Placeholder resubmission reason')
         ).not.toBeVisible()
     })
+    it('should list the submission events in reverse chronological order', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(
+            screen.getByText('Placeholder resubmission reason')
+        ).not.toBeVisible()
+        const accordionRows = screen.getAllByRole('button')
+        expect(accordionRows[0]).toHaveTextContent(
+            '03/23/22 9:19pm ET - Submission'
+        )
+        expect(accordionRows[1]).toHaveTextContent(
+            '03/23/22 9:18pm ET - Unlock'
+        )
+        expect(accordionRows[2]).toHaveTextContent(
+            '03/22/22 10:08pm ET - Submission'
+        )
+    })
 })

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ChangeHistory } from './ChangeHistory'
+import { Submission2 } from '../../gen/gqlClient'
+
+const submissionData: Submission2 = {
+    id: '440d6a53-bb0a-49ae-9a9c-da7c5352789f',
+    stateCode: 'MN',
+    status: 'RESUBMITTED',
+    intiallySubmittedAt: '2022-03-23',
+    revisions: [
+        {
+            revision: {
+                id: '26596de8-852d-4e42-bb0a-c9c9bf78c3de',
+                unlockInfo: {
+                    updatedAt: '2022-03-24T01:18:44.663Z',
+                    updatedBy: 'zuko@example.com',
+                    updatedReason: 'testing stuff',
+                    __typename: 'UpdateInformation',
+                },
+                submitInfo: {
+                    updatedAt: '2022-03-24T01:19:46.154Z',
+                    updatedBy: 'aang@example.com',
+                    updatedReason: 'Placeholder resubmission reason',
+                    __typename: 'UpdateInformation',
+                },
+                createdAt: '2022-03-24T01:18:44.665Z',
+                submissionData: 'qpoiuenad',
+                __typename: 'Revision',
+            },
+            __typename: 'RevisionEdge',
+        },
+        {
+            revision: {
+                id: 'e048cdcf-5b19-4acb-8ead-d7dc2fd6cd30',
+                unlockInfo: null,
+                submitInfo: {
+                    updatedAt: '2022-03-23T02:08:52.259Z',
+                    updatedBy: 'aang@example.com',
+                    updatedReason: 'Initial submission',
+                    __typename: 'UpdateInformation',
+                },
+                createdAt: '2022-03-23T02:08:14.241Z',
+                submissionData: 'nmzxcv;lasf',
+                __typename: 'Revision',
+            },
+            __typename: 'RevisionEdge',
+        },
+    ],
+    __typename: 'Submission2',
+}
+
+describe('Change History', () => {
+    it('renders without errors', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(screen.getByText('Change history')).toBeInTheDocument()
+    })
+
+    it('includes an accordion list of changes', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(screen.getByTestId('accordion')).toBeInTheDocument()
+    })
+
+    it('has expected text in the accordion title', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(
+            screen.getByRole('button', {
+                name: '03/23/22 9:19pm ET - Submission',
+            })
+        ).toBeInTheDocument()
+    })
+
+    it('has expected text in the accordion content', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(
+            screen.getByText('Placeholder resubmission reason')
+        ).toBeInTheDocument()
+    })
+
+    it('should expand and collapse the accordion on click', () => {
+        render(<ChangeHistory submission={submissionData} />)
+        expect(
+            screen.getByText('Placeholder resubmission reason')
+        ).not.toBeVisible()
+        const accordionRows = screen.getAllByRole('button')
+        userEvent.click(accordionRows[0])
+        expect(
+            screen.getByText('Placeholder resubmission reason')
+        ).toBeVisible()
+        userEvent.click(accordionRows[0])
+        expect(
+            screen.getByText('Placeholder resubmission reason')
+        ).not.toBeVisible()
+    })
+})

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
@@ -1,44 +1,80 @@
+import React from 'react'
 import { SectionHeader } from '../SectionHeader'
-import { Table } from '@trussworks/react-uswds'
+import { Accordion } from '@trussworks/react-uswds'
 import { Submission2 } from '../../gen/gqlClient'
-import styles from '../SubmissionSummarySection/SubmissionSummarySection.module.scss'
+import { UpdateInfoType } from '../../common-code/domain-models'
+import styles from './ChangeHistory.module.scss'
 export type ChangeHistoryProps = {
     submission: Submission2
+}
+
+type flatRevisions = UpdateInfoType & {
+    kind: 'submit' | 'unlock'
 }
 
 export const ChangeHistory = ({
     submission,
 }: ChangeHistoryProps): React.ReactElement => {
+    const flattenedRevisions = (): flatRevisions[] => {
+        const result: flatRevisions[] = []
+        submission.revisions.forEach((r) => {
+            if (r.revision.submitInfo) {
+                const newSubmit: flatRevisions = {} as flatRevisions
+                newSubmit.updatedAt = r.revision.submitInfo.updatedAt
+                newSubmit.updatedBy = r.revision.submitInfo.updatedBy
+                newSubmit.updatedReason = r.revision.submitInfo.updatedReason
+                newSubmit.kind = 'submit'
+                result.push(newSubmit)
+            }
+            if (r.revision.unlockInfo) {
+                const newUnlock: flatRevisions = {} as flatRevisions
+                newUnlock.updatedAt = r.revision.unlockInfo.updatedAt
+                newUnlock.updatedBy = r.revision.unlockInfo.updatedBy
+                newUnlock.updatedReason = r.revision.unlockInfo.updatedReason
+                newUnlock.kind = 'unlock'
+                result.push(newUnlock)
+            }
+        })
+        return result
+    }
+    const revisedItems = flattenedRevisions().map((r) => {
+        const isInitialSubmission = r.updatedReason === 'Initial submission'
+        const isSubsequentSubmission = r.kind === 'submit'
+        return {
+            title: (
+                <span>
+                    {r.updatedAt} -{' '}
+                    {isSubsequentSubmission ? 'Submission' : 'Unlock'}
+                </span>
+            ),
+            content: isInitialSubmission ? (
+                <React.Fragment>
+                    <div>Submitted by: {r.updatedBy}</div>
+                </React.Fragment>
+            ) : (
+                <React.Fragment>
+                    <div>
+                        {isSubsequentSubmission
+                            ? 'Submitted by: '
+                            : 'Unlocked by: '}{' '}
+                        {r.updatedBy}
+                    </div>
+                    <div>
+                        {isSubsequentSubmission
+                            ? 'Changes made: '
+                            : 'Reason for unlock: '}
+                        {r.updatedReason}
+                    </div>
+                </React.Fragment>
+            ),
+            expanded: false,
+            id: r.updatedAt.toString(),
+        }
+    })
     return (
         <section id="changeHistory" className={styles.summarySection}>
             <SectionHeader header="Change history" />
-            <Table>
-                <tbody>
-                    <tr>
-                        <td>row to expand</td>
-                        <td>
-                            {submission.revisions.map((r) => {
-                                return (
-                                    <div key={r.revision.id}>
-                                        <div>
-                                            {r.revision.submitInfo?.updatedBy}
-                                        </div>
-                                        <div>
-                                            {r.revision.submitInfo?.updatedAt}
-                                        </div>
-                                        <div>
-                                            {
-                                                r.revision.submitInfo
-                                                    ?.updatedReason
-                                            }
-                                        </div>
-                                    </div>
-                                )
-                            })}
-                        </td>
-                    </tr>
-                </tbody>
-            </Table>
+            <Accordion items={revisedItems} />
         </section>
     )
 }

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
@@ -83,7 +83,7 @@ export const ChangeHistory = ({
     return (
         <section id="changeHistory" className={styles.summarySection}>
             <SectionHeader header="Change history" hideBorder />
-            <Accordion items={revisedItems} />
+            <Accordion items={revisedItems} multiselectable />
         </section>
     )
 }

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
@@ -1,0 +1,44 @@
+import { SectionHeader } from '../SectionHeader'
+import { Table } from '@trussworks/react-uswds'
+import { Submission2 } from '../../gen/gqlClient'
+import styles from '../SubmissionSummarySection/SubmissionSummarySection.module.scss'
+export type ChangeHistoryProps = {
+    submission: Submission2
+}
+
+export const ChangeHistory = ({
+    submission,
+}: ChangeHistoryProps): React.ReactElement => {
+    return (
+        <section id="changeHistory" className={styles.summarySection}>
+            <SectionHeader header="Change history" />
+            <Table>
+                <tbody>
+                    <tr>
+                        <td>row to expand</td>
+                        <td>
+                            {submission.revisions.map((r) => {
+                                return (
+                                    <div key={r.revision.id}>
+                                        <div>
+                                            {r.revision.submitInfo?.updatedBy}
+                                        </div>
+                                        <div>
+                                            {r.revision.submitInfo?.updatedAt}
+                                        </div>
+                                        <div>
+                                            {
+                                                r.revision.submitInfo
+                                                    ?.updatedReason
+                                            }
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </td>
+                    </tr>
+                </tbody>
+            </Table>
+        </section>
+    )
+}

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
+import { dayjs } from '../../dateHelpers/dayjs'
 import { SectionHeader } from '../SectionHeader'
 import { Accordion } from '@trussworks/react-uswds'
 import { Submission2 } from '../../gen/gqlClient'
 import { UpdateInfoType } from '../../common-code/domain-models'
 import styles from './ChangeHistory.module.scss'
-export type ChangeHistoryProps = {
+type ChangeHistoryProps = {
     submission: Submission2
 }
 
@@ -42,38 +43,47 @@ export const ChangeHistory = ({
         const isSubsequentSubmission = r.kind === 'submit'
         return {
             title: (
-                <span>
-                    {r.updatedAt} -{' '}
-                    {isSubsequentSubmission ? 'Submission' : 'Unlock'}
-                </span>
+                <div>
+                    {dayjs
+                        .utc(r.updatedAt)
+                        .tz('America/New_York')
+                        .format('MM/DD/YY h:mma')}{' '}
+                    ET - {isSubsequentSubmission ? 'Submission' : 'Unlock'}
+                </div>
             ),
             content: isInitialSubmission ? (
-                <React.Fragment>
-                    <div>Submitted by: {r.updatedBy}</div>
-                </React.Fragment>
+                <>
+                    <span className={styles.tag}>Submitted by:</span>
+                    <span> {r.updatedBy}</span>
+                </>
             ) : (
-                <React.Fragment>
+                <>
                     <div>
-                        {isSubsequentSubmission
-                            ? 'Submitted by: '
-                            : 'Unlocked by: '}{' '}
-                        {r.updatedBy}
+                        <span className={styles.tag}>
+                            {isSubsequentSubmission
+                                ? 'Submitted by: '
+                                : 'Unlocked by: '}{' '}
+                        </span>
+                        <span>{r.updatedBy}</span>
                     </div>
                     <div>
-                        {isSubsequentSubmission
-                            ? 'Changes made: '
-                            : 'Reason for unlock: '}
-                        {r.updatedReason}
+                        <span className={styles.tag}>
+                            {isSubsequentSubmission
+                                ? 'Changes made: '
+                                : 'Reason for unlock: '}
+                        </span>
+                        <span>{r.updatedReason}</span>
                     </div>
-                </React.Fragment>
+                </>
             ),
             expanded: false,
             id: r.updatedAt.toString(),
         }
     })
+    console.log(revisedItems)
     return (
         <section id="changeHistory" className={styles.summarySection}>
-            <SectionHeader header="Change history" />
+            <SectionHeader header="Change history" hideBorder />
             <Accordion items={revisedItems} />
         </section>
     )

--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.tsx
@@ -80,7 +80,6 @@ export const ChangeHistory = ({
             id: r.updatedAt.toString(),
         }
     })
-    console.log(revisedItems)
     return (
         <section id="changeHistory" className={styles.summarySection}>
             <SectionHeader header="Change history" hideBorder />

--- a/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
@@ -53,12 +53,12 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: units(4);
     padding-bottom: units(2);
 }
 
 .summarySectionHeaderBorder {
     border-bottom: 1px solid $theme-color-base-lighter;
+    margin-bottom: units(4);
 }
 
 .summarySectionSubHeader {

--- a/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.module.scss
@@ -55,6 +55,9 @@
     align-items: center;
     margin-bottom: units(4);
     padding-bottom: units(2);
+}
+
+.summarySectionHeaderBorder {
     border-bottom: 1px solid $theme-color-base-lighter;
 }
 

--- a/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
@@ -1,7 +1,5 @@
 import { SectionHeader } from './SectionHeader'
 import { screen } from '@testing-library/react'
-// eslint-disable-next-line testing-library/no-dom-import
-import { prettyDOM } from '@testing-library/dom'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 
 describe('SectionHeader', () => {

--- a/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.test.tsx
@@ -1,5 +1,7 @@
 import { SectionHeader } from './SectionHeader'
 import { screen } from '@testing-library/react'
+// eslint-disable-next-line testing-library/no-dom-import
+import { prettyDOM } from '@testing-library/dom'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 
 describe('SectionHeader', () => {
@@ -40,5 +42,15 @@ describe('SectionHeader', () => {
         expect(
             screen.getByRole('link', { name: 'Edit Page 2' })
         ).toHaveAttribute('href', '/some-edit-path')
+    })
+    it('respects the hideBorder prop', () => {
+        renderWithProviders(
+            <SectionHeader header="This is a section" hideBorder />
+        )
+        expect(
+            screen
+                .getByRole('heading', { name: 'This is a section' })
+                .closest('div')
+        ).not.toHaveClass('summarySectionHeaderBorder')
     })
 })

--- a/services/app-web/src/components/SectionHeader/SectionHeader.tsx
+++ b/services/app-web/src/components/SectionHeader/SectionHeader.tsx
@@ -6,8 +6,9 @@ export type SectionHeaderProps = {
     header: string
     navigateTo?: string
     children?: React.ReactNode
-    sectionId?: string,
-    headerId?: string,
+    sectionId?: string
+    headerId?: string
+    hideBorder?: boolean
 }
 
 export const SectionHeader = ({
@@ -16,9 +17,15 @@ export const SectionHeader = ({
     children,
     sectionId,
     headerId,
-}: SectionHeaderProps & JSX.IntrinsicElements["div"]): React.ReactElement => {
+    hideBorder,
+}: SectionHeaderProps & JSX.IntrinsicElements['div']): React.ReactElement => {
     return (
-        <div className={styles.summarySectionHeader} id={sectionId}>
+        <div
+            className={`${styles.summarySectionHeader} ${
+                !hideBorder ? styles.summarySectionHeaderBorder : ''
+            }`}
+            id={sectionId}
+        >
             <h2 id={headerId}>{header}</h2>
             <div>
                 {navigateTo && (

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -6,21 +6,32 @@ import {
     CharacterCount,
     ModalRef,
     ModalToggleButton,
-    FormGroup
+    FormGroup,
 } from '@trussworks/react-uswds'
 import * as Yup from 'yup'
-import { useFormik} from 'formik'
+import { useFormik } from 'formik'
 import React, { useEffect, useState, useRef } from 'react'
-import { NavLink, useLocation, useParams} from 'react-router-dom'
+import { NavLink, useLocation, useParams } from 'react-router-dom'
 import sprite from 'uswds/src/img/sprite.svg'
-import {submissionName, SubmissionUnionType, UpdateInfoType } from '../../common-code/domain-models'
+import {
+    submissionName,
+    SubmissionUnionType,
+    UpdateInfoType,
+} from '../../common-code/domain-models'
 import { base64ToDomain } from '../../common-code/proto/stateSubmission'
 import { Loading } from '../../components/Loading'
 import {
-    ContactsSummarySection, ContractDetailsSummarySection,
-    RateDetailsSummarySection, SubmissionTypeSummarySection, SupportingDocumentsSummarySection
+    ContactsSummarySection,
+    ContractDetailsSummarySection,
+    RateDetailsSummarySection,
+    SubmissionTypeSummarySection,
+    SupportingDocumentsSummarySection,
 } from '../../components/SubmissionSummarySection'
-import { SubmissionUnlockedBanner,Modal, PoliteErrorMessage, } from '../../components'
+import {
+    SubmissionUnlockedBanner,
+    Modal,
+    PoliteErrorMessage,
+} from '../../components'
 import { useAuth } from '../../contexts/AuthContext'
 import { usePage } from '../../contexts/PageContext'
 import {
@@ -29,14 +40,22 @@ import {
     Submission2,
     UnlockStateSubmissionMutationFn,
     useFetchSubmission2Query,
-    useUnlockStateSubmissionMutation } from '../../gen/gqlClient'
+    useUnlockStateSubmissionMutation,
+} from '../../gen/gqlClient'
 import { isGraphQLErrors } from '../../gqlHelpers'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { Error404 } from '../Errors/Error404'
 
 import styles from './SubmissionSummary.module.scss'
+import { ChangeHistory } from '../../components/ChangeHistory/ChangeHistory'
 
-function UnlockModalButton({disabled, modalRef} : {disabled: boolean, modalRef: React.RefObject<ModalRef> }) {
+function UnlockModalButton({
+    disabled,
+    modalRef,
+}: {
+    disabled: boolean
+    modalRef: React.RefObject<ModalRef>
+}) {
     return (
         <ModalToggleButton
             modalRef={modalRef}
@@ -52,17 +71,21 @@ function UnlockModalButton({disabled, modalRef} : {disabled: boolean, modalRef: 
 }
 
 // This wrapper gets us some reasonable errors out of our unlock call. This would be a good candidate
-// for a more general and generic function so that we can get more sensible errors out of all of the 
+// for a more general and generic function so that we can get more sensible errors out of all of the
 // generated mutations.
-async function unlockMutationWrapper(unlockStateSubmission: UnlockStateSubmissionMutationFn, id: string, unlockedReason: string): Promise<Submission2 | GraphQLErrors | Error> {
+async function unlockMutationWrapper(
+    unlockStateSubmission: UnlockStateSubmissionMutationFn,
+    id: string,
+    unlockedReason: string
+): Promise<Submission2 | GraphQLErrors | Error> {
     try {
         const result = await unlockStateSubmission({
             variables: {
                 input: {
                     submissionID: id,
-                    unlockedReason
-                }
-            }
+                    unlockedReason,
+                },
+            },
         })
 
         if (result.errors) {
@@ -74,7 +97,6 @@ async function unlockMutationWrapper(unlockStateSubmission: UnlockStateSubmissio
         } else {
             return new Error('No errors, and no unlock result.')
         }
-            
     } catch (error) {
         // this can be an errors object
         if ('graphQLErrors' in error) {
@@ -210,10 +232,7 @@ export const SubmissionSummary = (): React.ReactElement => {
 
     // Focus unlockReason field in the unlock modal on submit click when errors exist
     useEffect(() => {
-        if (
-            focusErrorsInModal &&
-            formik.errors.unlockReason
-        ) {
+        if (focusErrorsInModal && formik.errors.unlockReason) {
             const fieldElement: HTMLElement | null = document.querySelector(
                 `[name="unlockReason"]`
             )
@@ -226,7 +245,6 @@ export const SubmissionSummary = (): React.ReactElement => {
             }
         }
     }, [focusErrorsInModal, formik.errors])
-
 
     if (loading || !submissionAndRevisions || !packageData) {
         return (
@@ -374,6 +392,8 @@ export const SubmissionSummary = (): React.ReactElement => {
 
                 <SupportingDocumentsSummarySection submission={submission} />
 
+                <ChangeHistory submission={submissionAndRevisions} />
+
                 <Modal
                     modalHeading="Reason for unlocking submission"
                     id="unlockReason"
@@ -386,16 +406,11 @@ export const SubmissionSummary = (): React.ReactElement => {
                     <form>
                         <FormGroup error={Boolean(formik.errors.unlockReason)}>
                             {formik.errors.unlockReason && (
-                                <PoliteErrorMessage
-                                    role="alert"    
-                                >
+                                <PoliteErrorMessage role="alert">
                                     {formik.errors.unlockReason}
                                 </PoliteErrorMessage>
                             )}
-                            <span
-                                id="unlockReason-hint"
-                                role="note"
-                            >
+                            <span id="unlockReason-hint" role="note">
                                 Provide reason for unlocking
                             </span>
 

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -57,6 +57,7 @@ describe('dashboard', () => {
             ignore: [
                 'definition-list',
                 'dlitem',
+                'color-contrast',
             ],
             hideElements: '.usa-step-indicator'
         })
@@ -109,6 +110,7 @@ describe('dashboard', () => {
                 ignore: [
                     'definition-list',
                     'dlitem',
+                    'color-contrast',
                 ],
             })
 


### PR DESCRIPTION
## Summary

Closes [#13875](https://qmacbis.atlassian.net/browse/OY2-13875)

Adds a history of unlocks and submissions to the bottom of the submission summary page, formatted as a list of accordions.

#### Screenshots

<img width="879" alt="image" src="https://user-images.githubusercontent.com/8964335/160041431-a76cd114-758c-48c8-bd8f-07bc8f702c09.png">

#### Test cases covered

Accordions are there, open and close, have correct content.
Also had to add a test to Section Header, because I had to tweak it to allow rending without a bottom border on the title header.

## QA guidance

Color contrast error on the accordion rows.  Not sure how we can override the uswds default, and googling isn't turning up any satisfying answers.  @haworku ?

How do _you_ expect VoiceOver to work here?  I'd like more guidance from VO about the fact that I'm on something like an accordion and can click down into the expanded content, but we're following the [guidance from USWDS](https://designsystem.digital.gov/components/accordion/).

Note that if you want to test this from scratch, you need to log in as a state user, submit, save the submission URL, then log in as a CMS user and unlock.