### PR TITLE
 Fix delay when modal closes to redirect when resubmitting

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
@@ -6,14 +6,20 @@ import {
     submitDraftSubmissionMockError,
     submitDraftSubmissionMockSuccess,
 } from '../../../testHelpers/apolloHelpers'
-import { renderWithProviders, userClickByTestId } from '../../../testHelpers/jestHelpers'
+import {
+    renderWithProviders,
+    userClickByTestId,
+} from '../../../testHelpers/jestHelpers'
 import { ReviewSubmit } from './ReviewSubmit'
 import userEvent from '@testing-library/user-event'
 
 describe('ReviewSubmit', () => {
     it('renders without errors', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -27,7 +33,10 @@ describe('ReviewSubmit', () => {
 
     it('displays edit buttons for every section', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -50,7 +59,10 @@ describe('ReviewSubmit', () => {
 
     it('does not display zip download buttons', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false} />,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -62,13 +74,16 @@ describe('ReviewSubmit', () => {
             const bulkDownloadButtons = screen.queryAllByRole('button', {
                 name: /documents/,
             })
-            expect(bulkDownloadButtons.length).toBe(0)
+            expect(bulkDownloadButtons).toHaveLength(0)
         })
     })
 
     it('renders info from a DraftSubmission', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false} />,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -103,7 +118,10 @@ describe('ReviewSubmit', () => {
 
     it('displays back and save as draft buttons', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -129,7 +147,10 @@ describe('ReviewSubmit', () => {
 
     it('displays submit button', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -144,7 +165,10 @@ describe('ReviewSubmit', () => {
 
     it('submit button opens confirmation modal', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -158,7 +182,9 @@ describe('ReviewSubmit', () => {
         submitButton.click()
 
         await waitFor(() => {
-            const confirmSubmit = screen.getByTestId('review-and-submit-modal-submit')
+            const confirmSubmit = screen.getByTestId(
+                'review-and-submit-modal-submit'
+            )
             expect(confirmSubmit).toBeInTheDocument()
             expect(screen.getByText('Ready to submit?')).toBeInTheDocument()
             expect(
@@ -173,7 +199,10 @@ describe('ReviewSubmit', () => {
         const history = createMemoryHistory()
 
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [
@@ -198,14 +227,16 @@ describe('ReviewSubmit', () => {
         submit.click()
 
         await waitFor(() => {
-            const confirmSubmit = screen.getByTestId('review-and-submit-modal-submit')
+            const confirmSubmit = screen.getByTestId(
+                'review-and-submit-modal-submit'
+            )
             expect(confirmSubmit).toBeInTheDocument()
             confirmSubmit.click()
         })
 
         await waitFor(() => {
-            expect(history.location.pathname).toEqual(`/dashboard`)
-            expect(history.location.search).toEqual(
+            expect(history.location.pathname).toBe(`/dashboard`)
+            expect(history.location.search).toBe(
                 `?justSubmitted=${mockCompleteDraft().name}`
             )
         })
@@ -213,7 +244,10 @@ describe('ReviewSubmit', () => {
 
     it('displays an error if submission fails', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={false}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={false}
+            />,
             {
                 apolloProvider: {
                     mocks: [
@@ -230,7 +264,9 @@ describe('ReviewSubmit', () => {
 
         submitButton.click()
 
-        const confirmSubmit = screen.getByTestId('review-and-submit-modal-submit')
+        const confirmSubmit = screen.getByTestId(
+            'review-and-submit-modal-submit'
+        )
         expect(confirmSubmit).toBeInTheDocument()
         confirmSubmit.click()
 
@@ -245,7 +281,10 @@ describe('ReviewSubmit', () => {
 describe('Resubmitting plan packages', () => {
     it('opens submission modal with summary input when submit button is clicked on unlocked plan package', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
@@ -260,7 +299,9 @@ describe('Resubmitting plan packages', () => {
         screen.getByTestId('form-submit').click()
 
         await waitFor(() => {
-            expect(screen.getByTestId('review-and-submit-modal-submit')).toBeInTheDocument()
+            expect(
+                screen.getByTestId('review-and-submit-modal-submit')
+            ).toBeInTheDocument()
             expect(screen.getByText('Summarize changes')).toBeInTheDocument()
             expect(
                 screen.getByText(
@@ -273,7 +314,9 @@ describe('Resubmitting plan packages', () => {
                 )
             ).toBeInTheDocument()
             expect(screen.getByTestId('submittedReason')).toBeInTheDocument()
-            expect(screen.getByTestId('review-and-submit-modal-submit')).toHaveTextContent('Resubmit')
+            expect(
+                screen.getByTestId('review-and-submit-modal-submit')
+            ).toHaveTextContent('Resubmit')
         })
     })
 
@@ -281,14 +324,17 @@ describe('Resubmitting plan packages', () => {
         const history = createMemoryHistory()
 
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({ statusCode: 200 }),
                         submitDraftSubmissionMockSuccess({
                             id: mockCompleteDraft().id,
-                            submittedReason: 'Test submission summary'
+                            submittedReason: 'Test submission summary',
                         }),
                     ],
                 },
@@ -317,8 +363,8 @@ describe('Resubmitting plan packages', () => {
         })
 
         await waitFor(() => {
-            expect(history.location.pathname).toEqual(`/dashboard`)
-            expect(history.location.search).toEqual(
+            expect(history.location.pathname).toBe(`/dashboard`)
+            expect(history.location.search).toBe(
                 `?justSubmitted=${mockCompleteDraft().name}`
             )
         })
@@ -326,7 +372,10 @@ describe('Resubmitting plan packages', () => {
 
     it('displays an error if submission fails on unlocked plan package', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
@@ -351,21 +400,26 @@ describe('Resubmitting plan packages', () => {
             expect(screen.getByRole('dialog')).toHaveClass('is-hidden')
         })
 
-        expect(await screen.findByText(
-            'Error attempting to submit. Please try again.'
-        )).toBeInTheDocument()
+        expect(
+            await screen.findByText(
+                'Error attempting to submit. Please try again.'
+            )
+        ).toBeInTheDocument()
     })
 
     it('displays form validation error when summary for submission is over 300 characters', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({ statusCode: 200 }),
                         submitDraftSubmissionMockSuccess({
                             id: mockCompleteDraft().id,
-                            submittedReason: 'Test submission summary'
+                            submittedReason: 'Test submission summary',
                         }),
                     ],
                 },
@@ -387,22 +441,23 @@ describe('Resubmitting plan packages', () => {
         screen.getByTestId('review-and-submit-modal-submit').click()
 
         expect(
-            await screen.findByText(
-                'Summary for submission is too long'
-            )
+            await screen.findByText('Summary for submission is too long')
         ).toBeInTheDocument()
     })
 
     it('displays form validation error when submitting without an submission summary', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({ statusCode: 200 }),
                         submitDraftSubmissionMockSuccess({
                             id: mockCompleteDraft().id,
-                            submittedReason: 'Test submission summary'
+                            submittedReason: 'Test submission summary',
                         }),
                     ],
                 },
@@ -418,21 +473,22 @@ describe('Resubmitting plan packages', () => {
         screen.getByTestId('review-and-submit-modal-submit').click()
 
         expect(
-            await screen.findByText(
-                'Summary for submission is required'
-            )
+            await screen.findByText('Summary for submission is required')
         ).toBeInTheDocument()
     })
 
     it('draws focus to submitted summary textarea when form validation errors exist', async () => {
         renderWithProviders(
-            <ReviewSubmit draftSubmission={mockCompleteDraft()} unlocked={true}/>,
+            <ReviewSubmit
+                draftSubmission={mockCompleteDraft()}
+                unlocked={true}
+            />,
             {
                 apolloProvider: {
                     mocks: [
                         fetchCurrentUserMock({ statusCode: 200 }),
                         submitDraftSubmissionMockSuccess({
-                            id: mockCompleteDraft().id
+                            id: mockCompleteDraft().id,
                         }),
                     ],
                 },
@@ -441,7 +497,11 @@ describe('Resubmitting plan packages', () => {
         userClickByTestId(screen, 'form-submit')
 
         // the popup dialog should be visible now
-        await waitFor(() =>  screen.getByText('Provide summary of all changes made to this submission'))
+        await waitFor(() =>
+            screen.getByText(
+                'Provide summary of all changes made to this submission'
+            )
+        )
 
         // Using findBy because it seems like the timeout in findBy gives it enough time to find the textarea?
         const textbox = await screen.findByTestId('submittedReason')
@@ -451,9 +511,7 @@ describe('Resubmitting plan packages', () => {
         userClickByTestId(screen, 'review-and-submit-modal-submit')
 
         expect(
-            await screen.findByText(
-                'Summary for submission is required'
-            )
+            await screen.findByText('Summary for submission is required')
         ).toBeInTheDocument()
 
         // check focus after error

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -122,6 +122,7 @@ export const ReviewSubmit = ({
             }
 
             if (data.data?.submitDraftSubmission) {
+                modalRef.current?.toggleModal(undefined, false)
                 history.push(`/dashboard?justSubmitted=${draftSubmission.name}`)
             } else {
                 console.error('Got nothing back from submit')

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -1,6 +1,11 @@
 import {
-    Alert, Button, CharacterCount, FormGroup,
-    GridContainer, ModalRef, ModalToggleButton
+    Alert,
+    Button,
+    CharacterCount,
+    FormGroup,
+    GridContainer,
+    ModalRef,
+    ModalToggleButton,
 } from '@trussworks/react-uswds'
 import React, { useEffect, useRef, useState } from 'react'
 import { useHistory } from 'react-router-dom'
@@ -9,26 +14,25 @@ import {
     ContractDetailsSummarySection,
     RateDetailsSummarySection,
     SubmissionTypeSummarySection,
-    SupportingDocumentsSummarySection
+    SupportingDocumentsSummarySection,
 } from '../../../components/SubmissionSummarySection'
 import { useAuth } from '../../../contexts/AuthContext'
 import {
     DraftSubmission,
-    useSubmitDraftSubmissionMutation
+    useSubmitDraftSubmissionMutation,
 } from '../../../gen/gqlClient'
 import { PageActionsContainer } from '../PageActions'
 import { Modal } from '../../../components/Modal'
 import styles from './ReviewSubmit.module.scss'
-import { PoliteErrorMessage } from '../../../components';
-import { useFormik } from 'formik';
-import * as Yup from 'yup';
-
+import { PoliteErrorMessage } from '../../../components'
+import { useFormik } from 'formik'
+import * as Yup from 'yup'
 
 export const ReviewSubmit = ({
     draftSubmission,
-    unlocked
+    unlocked,
 }: {
-    draftSubmission: DraftSubmission,
+    draftSubmission: DraftSubmission
     unlocked: boolean
 }): React.ReactElement => {
     const [userVisibleError, setUserVisibleError] = useState<
@@ -40,7 +44,11 @@ export const ReviewSubmit = ({
     const { loggedInUser } = useAuth()
 
     // pull the programs off the user
-    const statePrograms = (loggedInUser && ('state' in loggedInUser) && loggedInUser.state.programs) || []
+    const statePrograms =
+        (loggedInUser &&
+            'state' in loggedInUser &&
+            loggedInUser.state.programs) ||
+        []
 
     const [submitDraftSubmission] = useSubmitDraftSubmissionMutation({
         // An alternative to messing with the cache like we do with create, just zero it out.
@@ -68,17 +76,15 @@ export const ReviewSubmit = ({
 
     const formik = useFormik({
         initialValues: modalFormInitialValues,
-        validationSchema: Yup.object().shape(
-            {
-                submittedReason: Yup.string()
-                    .max(300, 'Summary for submission is too long')
-                    .defined('Summary for submission is required')
-            }
-        ),
+        validationSchema: Yup.object().shape({
+            submittedReason: Yup.string()
+                .max(300, 'Summary for submission is too long')
+                .defined('Summary for submission is required'),
+        }),
         onSubmit: (values) => onModalSubmit(values),
     })
 
-    const submitHandler = async() => {
+    const submitHandler = async () => {
         setFocusErrorsInModal(true)
         if (unlocked) {
             formik.handleSubmit()
@@ -89,24 +95,25 @@ export const ReviewSubmit = ({
 
     const onModalSubmit = async (values: typeof modalFormInitialValues) => {
         const { submittedReason } = values
-        modalRef.current?.toggleModal(undefined, false)
         await onSubmit(submittedReason)
     }
 
-    const onSubmit = async (submittedReason: string | undefined): Promise<void> => {
+    const onSubmit = async (
+        submittedReason: string | undefined
+    ): Promise<void> => {
         const input = { submissionID: draftSubmission.id }
 
         if (unlocked) {
             Object.assign(input, {
-                submittedReason: submittedReason
+                submittedReason: submittedReason,
             })
         }
 
         try {
             const data = await submitDraftSubmission({
                 variables: {
-                    input: input
-                }
+                    input: input,
+                },
             })
 
             if (data.errors) {
@@ -132,10 +139,7 @@ export const ReviewSubmit = ({
 
     // Focus submittedReason field in submission modal on Resubmit click when errors exist
     useEffect(() => {
-        if (
-            focusErrorsInModal &&
-            formik.errors.submittedReason
-        ) {
+        if (focusErrorsInModal && formik.errors.submittedReason) {
             const fieldElement: HTMLElement | null = document.querySelector(
                 `[name="submittedReason"]`
             )
@@ -216,7 +220,9 @@ export const ReviewSubmit = ({
             <Modal
                 modalRef={modalRef}
                 id="review-and-submit"
-                modalHeading={unlocked ? 'Summarize changes' : 'Ready to submit?'}
+                modalHeading={
+                    unlocked ? 'Summarize changes' : 'Ready to submit?'
+                }
                 submitButtonProps={{ className: styles.submitButton }}
                 onSubmitText={unlocked ? 'Resubmit' : undefined}
                 onSubmit={submitHandler}
@@ -224,22 +230,21 @@ export const ReviewSubmit = ({
                 {unlocked ? (
                     <form>
                         <p>
-                            Once you submit, this package will be sent to CMS for review and you will no longer be
-                            able to make changes.
+                            Once you submit, this package will be sent to CMS
+                            for review and you will no longer be able to make
+                            changes.
                         </p>
-                        <FormGroup error={Boolean(formik.errors.submittedReason)}>
+                        <FormGroup
+                            error={Boolean(formik.errors.submittedReason)}
+                        >
                             {formik.errors.submittedReason && (
-                                <PoliteErrorMessage
-                                    role="alert"
-                                >
+                                <PoliteErrorMessage role="alert">
                                     {formik.errors.submittedReason}
                                 </PoliteErrorMessage>
                             )}
-                            <span
-                                id="submittedReason-hint"
-                                role="note"
-                            >
-                                Provide summary of all changes made to this submission
+                            <span id="submittedReason-hint" role="note">
+                                Provide summary of all changes made to this
+                                submission
                             </span>
                             <CharacterCount
                                 id="submittedReasonCharacterCount"
@@ -258,11 +263,10 @@ export const ReviewSubmit = ({
                     </form>
                 ) : (
                     <p>
-                        Submitting this package will send it to CMS to begin their
-                        review.
+                        Submitting this package will send it to CMS to begin
+                        their review.
                     </p>
-                    )
-                }
+                )}
             </Modal>
         </GridContainer>
     )

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -40,7 +40,10 @@ import {
     useFetchSubmission2Query,
     useUnlockStateSubmissionMutation,
 } from '../../gen/gqlClient'
-import { convertDomainModelFormDataToGQLSubmission, isGraphQLErrors } from '../../gqlHelpers'
+import {
+    convertDomainModelFormDataToGQLSubmission,
+    isGraphQLErrors,
+} from '../../gqlHelpers'
 import { Error404 } from '../Errors/Error404'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import styles from './SubmissionSummary.module.scss'
@@ -148,9 +151,7 @@ export const SubmissionSummary = (): React.ReactElement => {
     const [unlockStateSubmission] = useUnlockStateSubmissionMutation()
     const submissionAndRevisions = data?.fetchSubmission2.submission
 
-
-    const displayUnlockButton =
-        loggedInUser?.role === 'CMS_USER'
+    const displayUnlockButton = loggedInUser?.role === 'CMS_USER'
 
     // Pull out the correct revision form api request, display errors for bad dad
     useEffect(() => {
@@ -255,7 +256,6 @@ export const SubmissionSummary = (): React.ReactElement => {
 
     const onModalSubmit = async (values: typeof modalFormInitialValues) => {
         const { unlockReason } = values
-        modalRef.current?.toggleModal(undefined, false)
         await onUnlock(unlockReason)
     }
 
@@ -272,6 +272,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                 result
             )
             setPageLevelAlert('Error attempting to unlock. Please try again.')
+            modalRef.current?.toggleModal(undefined, false)
         } else if (isGraphQLErrors(result)) {
             console.error('ERROR: got a GraphQL error response', result)
             if (result[0].extensions.code === 'BAD_USER_INPUT') {
@@ -283,20 +284,27 @@ export const SubmissionSummary = (): React.ReactElement => {
                     'Error attempting to unlock. Please try again.'
                 )
             }
+            modalRef.current?.toggleModal(undefined, false)
         } else {
             const unlockedSub: Submission2 = result
+            modalRef.current?.toggleModal(undefined, false)
             console.log('Submission Unlocked', unlockedSub)
         }
     }
 
     const statePrograms = submissionAndRevisions.state.programs
 
-    // temporary kludge while the display data is expecting the wrong format. 
+    // temporary kludge while the display data is expecting the wrong format.
     // This is turning our domain model into the GraphQL model which is what
-    // all our frontend stuff expects right now. 
-    const submission = convertDomainModelFormDataToGQLSubmission(packageData, statePrograms)
+    // all our frontend stuff expects right now.
+    const submission = convertDomainModelFormDataToGQLSubmission(
+        packageData,
+        statePrograms
+    )
 
-    const disableUnlockButton = ['DRAFT', 'UNLOCKED'].includes(submissionAndRevisions.status)
+    const disableUnlockButton = ['DRAFT', 'UNLOCKED'].includes(
+        submissionAndRevisions.status
+    )
 
     const isContractActionAndRateCertification =
         submission.submissionType === 'CONTRACT_AND_RATES'
@@ -356,7 +364,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                             />
                         ) : undefined
                     }
-					statePrograms={statePrograms}
+                    statePrograms={statePrograms}
                 />
                 <ContractDetailsSummarySection submission={submission} />
 


### PR DESCRIPTION
## Summary
Fix to address delay after modal closes and redirect when resubmitting a submission. 

**Note: **Also add code to close Unlock Modal on error. Does not seem to make sense to keep modal open and not see the error banner, but let me know otherwise.

#### Related issues
[OY2-12183](https://qmacbis.atlassian.net/browse/OY2-12183?focusedCommentId=108213)

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
