### PR TITLE
Add update function for DraftSubmissionType, decoupling the rest of the update work

### DIFF
--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -1,15 +1,12 @@
-import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryHistory } from 'history'
 import { screen, waitFor } from '@testing-library/react'
 import selectEvent from 'react-select-event'
-import {
-    fetchCurrentUserMock,
-    mockDraft,
-} from '../../../testHelpers/apolloHelpers'
+import { fetchCurrentUserMock } from '../../../testHelpers/apolloHelpers'
 import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { SubmissionType, SubmissionTypeFormValues } from './'
 import { Formik } from 'formik'
+import { contractOnly } from '../../../common-code/domain-mocks'
 
 describe('SubmissionType', () => {
     const SubmissionTypeInitialValues: SubmissionTypeFormValues = {
@@ -62,11 +59,14 @@ describe('SubmissionType', () => {
     })
 
     it('displays with draft submission when expected', async () => {
-        renderWithProviders(<SubmissionType draftSubmission={mockDraft()} />, {
-            apolloProvider: {
-                mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-            },
-        })
+        renderWithProviders(
+            <SubmissionType draftSubmission={contractOnly()} />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
 
         await waitFor(() =>
             expect(
@@ -166,7 +166,7 @@ describe('SubmissionType', () => {
         const combobox = await screen.findByRole('combobox')
 
         await waitFor(async () => {
-            await selectEvent.openMenu(combobox)
+            selectEvent.openMenu(combobox)
         })
 
         await waitFor(() => {


### PR DESCRIPTION
## Summary

This is part of the ticket for adding the updateSubmission2 endpoint. This decouples all of the subtasks on that ticket so that they can be done independently. With this separate update function, we can update each of the pages of the form to operate on DraftSubmissionType (soon to be HealthPlanFormData) instead of the GQL types. And the new API can be written that accepts a revision, paving the way for us to get rid of the form data types from GQL.

#### Related issues
- can’t find it right now b/c JIRA is being changed

#### Screenshots

#### Test cases covered
* I got all tests passing, surprisingly little just for the SubmissionType component. I suspect the other form pages will require more changes. 

## QA guidance

* The only page that was changed was the submissionType page, and specifically I changed updating it, no creating a new submission. 