### PR TITLE
MR-226: User sees banner message that a submission has been updated

### DIFF
--- a/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
+++ b/services/app-web/src/components/Banner/PreviousSubmissionBanner/PreviousSubmissionBanner.tsx
@@ -20,7 +20,7 @@ export const PreviousSubmissionBanner = ({
                 data-testid="previous-submission-banner"
             >
                 <span>This is a past version of this submission.&nbsp;</span>
-                <Link href={link}>
+                <Link href={link} data-testid="currentSubmissionLink">
                     View most recent version of this submission
                 </Link>
             </p>

--- a/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.test.tsx
+++ b/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import { SubmissionUnlockedBanner } from './SubmissionUnlockedBanner';
-import { dayjs } from '../../../dateHelpers';
+import { SubmissionUnlockedBanner } from './SubmissionUnlockedBanner'
+import { dayjs } from '../../../dateHelpers'
 
 describe('SubmissionUnlockBanner', () => {
     it('renders without errors and correct background color for CMS User', () => {
@@ -15,8 +15,19 @@ describe('SubmissionUnlockBanner', () => {
         )
         expect(screen.getByRole('alert')).toHaveClass('usa-alert--warning')
         expect(screen.getByText('Loremipsum@email.com')).toBeInTheDocument()
-        expect(screen.getByText(dayjs(testDate).format('MM/DD/YYYY hh:mma z'))).toBeInTheDocument()
-        expect(screen.getByText('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ut justo non nisl congue efficitur. Praesent porta condimentum imperdiet. Curabitur.')).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                `${dayjs
+                    .utc(testDate)
+                    .tz('America/New_York')
+                    .format('MM/DD/YY h:mma')} ET`
+            )
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ut justo non nisl congue efficitur. Praesent porta condimentum imperdiet. Curabitur.'
+            )
+        ).toBeInTheDocument()
     })
 
     it('renders without errors and correct background color for State user', () => {
@@ -31,7 +42,18 @@ describe('SubmissionUnlockBanner', () => {
         )
         expect(screen.getByRole('alert')).toHaveClass('usa-alert--info')
         expect(screen.getByText('Loremipsum@email.com')).toBeInTheDocument()
-        expect(screen.getByText(dayjs(testDate).format('MM/DD/YYYY hh:mma z'))).toBeInTheDocument()
-        expect(screen.getByText('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ut justo non nisl congue efficitur. Praesent porta condimentum imperdiet. Curabitur.')).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                `${dayjs
+                    .utc(testDate)
+                    .tz('America/New_York')
+                    .format('MM/DD/YY h:mma')} ET`
+            )
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi ut justo non nisl congue efficitur. Praesent porta condimentum imperdiet. Curabitur.'
+            )
+        ).toBeInTheDocument()
     })
 })

--- a/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.tsx
+++ b/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.tsx
@@ -4,10 +4,10 @@ import { Alert } from '@trussworks/react-uswds'
 import { dayjs } from '../../../dateHelpers'
 
 export type UnlockedProps = {
-    userType: 'STATE_USER' | 'CMS_USER';
-    unlockedBy: string,
-    unlockedOn: Date,
-    reason: string,
+    userType: 'STATE_USER' | 'CMS_USER'
+    unlockedBy: string
+    unlockedOn: Date
+    reason: string
 }
 
 export const SubmissionUnlockedBanner = ({
@@ -17,11 +17,30 @@ export const SubmissionUnlockedBanner = ({
     reason,
 }: UnlockedProps): React.ReactElement => {
     return (
-        <Alert role="alert" type={userType === "CMS_USER" ? "warning" : "info"} heading="Submission unlocked" validation={true} data-testid="unlockedBanner">
+        <Alert
+            role="alert"
+            type={userType === 'CMS_USER' ? 'warning' : 'info'}
+            heading="Submission unlocked"
+            validation={true}
+            data-testid="unlockedBanner"
+        >
             <div className={styles.bannerBodyText}>
-                <p className="usa-alert__text"><b>Unlocked by:&nbsp;</b>{unlockedBy}</p>
-                <p className="usa-alert__text"><b>Unlocked on:&nbsp;</b>{dayjs(unlockedOn).format('MM/DD/YYYY hh:mma z')}</p>
-                <p className="usa-alert__text"><b>Reason for unlock:&nbsp;</b>{reason}</p>
+                <p className="usa-alert__text">
+                    <b>Unlocked by:&nbsp;</b>
+                    {unlockedBy}
+                </p>
+                <p className="usa-alert__text">
+                    <b>Unlocked on:&nbsp;</b>
+                    {dayjs
+                        .utc(unlockedOn)
+                        .tz('America/New_York')
+                        .format('MM/DD/YY h:mma')}
+                    &nbsp;ET
+                </p>
+                <p className="usa-alert__text">
+                    <b>Reason for unlock:&nbsp;</b>
+                    {reason}
+                </p>
             </div>
         </Alert>
     )

--- a/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.tsx
+++ b/services/app-web/src/components/Banner/SubmissionUnlockedBanner/SubmissionUnlockedBanner.tsx
@@ -15,7 +15,10 @@ export const SubmissionUnlockedBanner = ({
     unlockedBy,
     unlockedOn,
     reason,
-}: UnlockedProps): React.ReactElement => {
+    className,
+    ...props
+}: UnlockedProps &
+    React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
     return (
         <Alert
             role="alert"
@@ -23,6 +26,8 @@ export const SubmissionUnlockedBanner = ({
             heading="Submission unlocked"
             validation={true}
             data-testid="unlockedBanner"
+            className={className}
+            {...props}
         >
             <div className={styles.bannerBodyText}>
                 <p className="usa-alert__text">

--- a/services/app-web/src/components/Banner/SubmissionUpdatedBanner/SubmissionUpdatedBanner.tsx
+++ b/services/app-web/src/components/Banner/SubmissionUpdatedBanner/SubmissionUpdatedBanner.tsx
@@ -13,7 +13,9 @@ export const SubmissionUpdatedBanner = ({
     submittedBy,
     updatedOn,
     changesMade,
-}: UpdatedProps): React.ReactElement => {
+    className,
+    ...props
+}: UpdatedProps & React.HTMLAttributes<HTMLDivElement>): React.ReactElement => {
     return (
         <Alert
             role="alert"
@@ -21,6 +23,8 @@ export const SubmissionUpdatedBanner = ({
             heading="Submission updated"
             validation={true}
             data-testid="updatedSubmissionBanner"
+            className={className}
+            {...props}
         >
             <div className={styles.bannerBodyText}>
                 <p className="usa-alert__text">

--- a/services/app-web/src/components/Banner/SubmissionUpdatedBanner/SubmissionUpdatedBanner.tsx
+++ b/services/app-web/src/components/Banner/SubmissionUpdatedBanner/SubmissionUpdatedBanner.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import styles from '../Banner.module.scss'
+import { Alert } from '@trussworks/react-uswds'
+import { dayjs } from '../../../dateHelpers'
+
+export type UpdatedProps = {
+    submittedBy: string
+    updatedOn: Date
+    changesMade: string
+}
+
+export const SubmissionUpdatedBanner = ({
+    submittedBy,
+    updatedOn,
+    changesMade,
+}: UpdatedProps): React.ReactElement => {
+    return (
+        <Alert
+            role="alert"
+            type="info"
+            heading="Submission updated"
+            validation={true}
+            data-testid="updatedSubmissionBanner"
+        >
+            <div className={styles.bannerBodyText}>
+                <p className="usa-alert__text">
+                    <b>Submitted by:&nbsp;</b>
+                    {submittedBy}
+                </p>
+                <p className="usa-alert__text">
+                    <b>Updated on:&nbsp;</b>
+                    {dayjs
+                        .utc(updatedOn)
+                        .tz('America/New_York')
+                        .format('MM/DD/YY h:mma')}
+                    &nbsp;ET
+                </p>
+                <p className="usa-alert__text">
+                    <b>Changes made:&nbsp;</b>
+                    {changesMade}
+                </p>
+            </div>
+        </Alert>
+    )
+}

--- a/services/app-web/src/components/Banner/index.ts
+++ b/services/app-web/src/components/Banner/index.ts
@@ -1,2 +1,3 @@
 export { SubmissionUnlockedBanner } from './SubmissionUnlockedBanner/SubmissionUnlockedBanner'
 export { PreviousSubmissionBanner } from './PreviousSubmissionBanner/PreviousSubmissionBanner'
+export { SubmissionUpdatedBanner } from './SubmissionUpdatedBanner/SubmissionUpdatedBanner'

--- a/services/app-web/src/components/index.ts
+++ b/services/app-web/src/components/index.ts
@@ -42,6 +42,10 @@ export { SubmissionCard } from './SubmissionCard'
 
 export { Tabs, TabPanel } from './Tabs'
 
-export { SubmissionUnlockedBanner, PreviousSubmissionBanner } from './Banner'
+export {
+    SubmissionUnlockedBanner,
+    PreviousSubmissionBanner,
+    SubmissionUpdatedBanner,
+} from './Banner'
 
 export { Modal } from './Modal'

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.module.scss
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.module.scss
@@ -14,3 +14,7 @@
 .unlockReasonTextarea {
     max-width: 100%;
 }
+
+.banner {
+    margin: units(2) auto;
+}

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -84,7 +84,9 @@ describe('SubmissionSummary', () => {
             /Updated on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET/i
         )
         banner.toHaveTextContent('Submitted by: aang@example.com')
-        banner.toHaveTextContent('Changes made: Should be latest resubmission')
+        banner.toHaveTextContent(
+            'Changes made: Placeholder resubmission reason'
+        )
     })
 
     describe('Submission package data display', () => {

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -367,7 +367,11 @@ export const SubmissionSummary = (): React.ReactElement => {
                 className={styles.container}
             >
                 {pageLevelAlert && (
-                    <Alert type="error" heading="Unlock Error">
+                    <Alert
+                        type="error"
+                        heading="Unlock Error"
+                        className={styles.banner}
+                    >
                         {pageLevelAlert}
                     </Alert>
                 )}
@@ -382,6 +386,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                         unlockedBy={updateInfo.updatedBy}
                         unlockedOn={updateInfo.updatedAt}
                         reason={updateInfo.updatedReason}
+                        className={styles.banner}
                     />
                 )}
 
@@ -390,6 +395,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                         submittedBy={updateInfo.updatedBy}
                         updatedOn={updateInfo.updatedAt}
                         changesMade={updateInfo.updatedReason}
+                        className={styles.banner}
                     />
                 )}
 

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -31,6 +31,7 @@ import {
     SubmissionUnlockedBanner,
     Modal,
     PoliteErrorMessage,
+    SubmissionUpdatedBanner,
 } from '../../components'
 import { useAuth } from '../../contexts/AuthContext'
 import { usePage } from '../../contexts/PageContext'
@@ -39,6 +40,7 @@ import {
     UnlockStateSubmissionMutationFn,
     useFetchSubmission2Query,
     useUnlockStateSubmissionMutation,
+    Submission2Status,
 } from '../../gen/gqlClient'
 import {
     convertDomainModelFormDataToGQLSubmission,
@@ -120,9 +122,9 @@ export const SubmissionSummary = (): React.ReactElement => {
     const [packageData, setPackageData] = useState<
         SubmissionUnionType | undefined
     >(undefined)
-    const [unlockedInfo, setUnlockedInfo] = useState<UpdateInfoType | null>(
-        null
-    )
+    const [updateInfo, setUpdateInfo] = useState<UpdateInfoType | null>(null)
+    const [submissionStatus, setSubmissionStatus] =
+        useState<Submission2Status | null>(null)
 
     // Unlock modal state
     const [focusErrorsInModal, setFocusErrorsInModal] = useState(true)
@@ -190,25 +192,34 @@ export const SubmissionSummary = (): React.ReactElement => {
                 return
             }
 
-            if (submissionAndRevisions.status === 'UNLOCKED') {
-                const unlockedRevision = submissionAndRevisions.revisions.find(
-                    (rev) => rev.revision.unlockInfo
-                )
-                const unlockInfo = unlockedRevision?.revision.unlockInfo
+            const submissionStatus = submissionAndRevisions.status
+            if (
+                submissionStatus === 'UNLOCKED' ||
+                submissionStatus === 'RESUBMITTED'
+            ) {
+                const updateInfo =
+                    submissionStatus === 'UNLOCKED'
+                        ? submissionAndRevisions.revisions.find(
+                              (rev) => rev.revision.unlockInfo
+                          )?.revision.unlockInfo
+                        : currentRevision.revision.submitInfo
 
-                if (unlockInfo) {
-                    setUnlockedInfo({
-                        updatedBy: unlockInfo.updatedBy,
-                        updatedAt: unlockInfo.updatedAt,
-                        updatedReason: unlockInfo.updatedReason,
+                if (updateInfo) {
+                    setSubmissionStatus(submissionStatus)
+                    setUpdateInfo({
+                        ...updateInfo,
                     })
                 } else {
+                    const info =
+                        submissionStatus === 'UNLOCKED'
+                            ? 'unlock information'
+                            : 'resubmission information'
                     console.error(
-                        'ERROR: submission in summary has no revision with unlocked information',
+                        `ERROR: Encountered error when fetching ${info}`,
                         submissionAndRevisions.revisions
                     )
                     setPageLevelAlert(
-                        'Error fetching the unlocked information. Please try again.'
+                        `Error fetching ${info}. Please try again.`
                     )
                 }
             }
@@ -321,16 +332,24 @@ export const SubmissionSummary = (): React.ReactElement => {
                     </Alert>
                 )}
 
-                {unlockedInfo && (
+                {submissionStatus === 'UNLOCKED' && updateInfo && (
                     <SubmissionUnlockedBanner
                         userType={
                             loggedInUser?.role === 'CMS_USER'
                                 ? 'CMS_USER'
                                 : 'STATE_USER'
                         }
-                        unlockedBy={unlockedInfo.updatedBy}
-                        unlockedOn={unlockedInfo.updatedAt}
-                        reason={unlockedInfo.updatedReason}
+                        unlockedBy={updateInfo.updatedBy}
+                        unlockedOn={updateInfo.updatedAt}
+                        reason={updateInfo.updatedReason}
+                    />
+                )}
+
+                {submissionStatus === 'RESUBMITTED' && updateInfo && (
+                    <SubmissionUpdatedBanner
+                        submittedBy={updateInfo.updatedBy}
+                        updatedOn={updateInfo.updatedAt}
+                        changesMade={updateInfo.updatedReason}
                     />
                 )}
 

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -390,7 +390,7 @@ export function mockSubmittedSubmission2WithRevisions(): Submission2 {
 
     return {
         id: 'test-id-123',
-        status: 'SUBMITTED',
+        status: 'RESUBMITTED',
         intiallySubmittedAt: '2022-01-01',
         stateCode: 'MN',
         state: mockMNState(),

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -390,7 +390,7 @@ export function mockSubmittedSubmission2WithRevisions(): Submission2 {
 
     return {
         id: 'test-id-123',
-        status: 'SUBMITTED',
+        status: 'RESUBMITTED',
         intiallySubmittedAt: '2022-01-01',
         stateCode: 'MN',
         state: mockMNState(),
@@ -626,7 +626,7 @@ const fetchStateSubmission2MockSuccess = ({
     stateSubmission = mockSubmittedSubmission2(),
     id, // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }: fetchStateSubmission2MockSuccessProps): MockedResponse<
-    Record<string, any>
+    Record<string, unknown>
 > => {
     // override the ID of the returned draft to match the queried id.
     const mergedStateSubmission = Object.assign({}, stateSubmission, { id })

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -131,6 +131,9 @@ describe('dashboard', () => {
 
                 // Login as CMS User
                 cy.findByRole('button', { name: 'Sign out' }).click()
+
+                cy.wait(2000)
+
                 cy.findByText(
                     'Medicaid and CHIP Managed Care Reporting and Review System'
                 )

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -126,11 +126,12 @@ describe('dashboard', () => {
                 cy.get('table')
                     .findByText(submissionName)
                     .click()
-                cy.wait('@fetchSubmission2Query')
+                cy.wait('@fetchSubmission2Query', { timeout: 50000 })
                 cy.findByTestId('updatedSubmissionBanner').should('exist')
 
                 // Login as CMS User
                 cy.findByRole('button', { name: 'Sign out' }).click()
+                cy.wait('@indexSubmissions2Query', { timeout: 50000 })
                 cy.findByText(
                     'Medicaid and CHIP Managed Care Reporting and Review System'
                 )
@@ -171,8 +172,6 @@ describe('dashboard', () => {
                     .should('not.exist')
                 cy.findByTestId('revision-version')
                     .should('not.exist')
-
-                cy.findByRole('button', { name: 'Sign out' }).click()
             })
         })
     })

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -54,7 +54,7 @@ describe('dashboard', () => {
                 .should('exist')
                 .and('contain.text', 'zuko@example.com')
                 .and('contain.text', 'Unlock submission reason.')
-                .contains(/Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+\s[a-zA-Z]+/i)
+                .contains(/Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET/i)
                 .should('exist')
 
             cy.wait(2000)
@@ -102,7 +102,7 @@ describe('dashboard', () => {
                     .and('contain.text', 'zuko@example.com')
                     .and('contain.text', 'Unlock submission reason.')
                     .contains(
-                        /Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+\s[a-zA-Z]+/i
+                        /Unlocked on: (0?[1-9]|[12][0-9]|3[01])\/[0-9]+\/[0-9]+\s[0-9]+:[0-9]+[a-zA-Z]+ ET+/i
                     )
                     .should('exist')
 
@@ -122,6 +122,13 @@ describe('dashboard', () => {
                     .should('have.attr', 'href')
                     .and('not.include', 'review-and-submit')
 
+                //Navigate to resubmitted submission and check for submission updated banner
+                cy.get('table')
+                    .findByText(submissionName)
+                    .click()
+                cy.wait('@fetchSubmission2Query')
+                cy.findByTestId('updatedSubmissionBanner').should('exist')
+
                 // Login as CMS User
                 cy.findByRole('button', { name: 'Sign out' }).click()
                 cy.findByText(
@@ -134,7 +141,9 @@ describe('dashboard', () => {
                     'not.be.disabled'
                 )
 
+                //CSM user should not see unlock banner and should see updated submission banner
                 cy.findByTestId('unlockedBanner').should('not.exist')
+                cy.findByTestId('updatedSubmissionBanner').should('exist')
 
                 //Open all change history accordion items
                 cy.findByTestId('accordion')
@@ -144,8 +153,8 @@ describe('dashboard', () => {
                     .each( button => {
                         button.trigger('click')
                     })
-                //Click on link in the initial accordion item
-                cy.navigateToSubmissionRevision('revision-link-1')
+                //Check for view previous submission link in the initial accordion item to exist
+                cy.navigateToSubmissionByUserInteraction('revision-link-1')
                 //Making sure we are on SubmissionRevisionSummary page and contains version text
                 cy.findByTestId('revision-version')
                     .should('exist')
@@ -156,12 +165,14 @@ describe('dashboard', () => {
                 cy.findByTestId('previous-submission-banner')
                     .should('exist')
                 //Navigate back to current submission using link inside banner.
-                cy.navigateBackToCurrentSubmission()
+                cy.navigateToSubmissionByUserInteraction('currentSubmissionLink')
                 //MAke sure banner and revision version text are gone.
                 cy.findByTestId('previous-submission-banner')
                     .should('not.exist')
                 cy.findByTestId('revision-version')
                     .should('not.exist')
+
+                cy.findByRole('button', { name: 'Sign out' }).click()
             })
         })
     })

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -131,7 +131,6 @@ describe('dashboard', () => {
 
                 // Login as CMS User
                 cy.findByRole('button', { name: 'Sign out' }).click()
-                cy.wait('@indexSubmissions2Query', { timeout: 50000 })
                 cy.findByText(
                     'Medicaid and CHIP Managed Care Reporting and Review System'
                 )

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -7,7 +7,6 @@ describe('new submission', () => {
 
         // Navigate to dashboard page by clicking cancel
         cy.findByRole('button', { name: /Cancel/ }).click()
-        cy.wait('@fetchSubmission2Query')
         cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
         // Navigate to new page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -7,6 +7,7 @@ describe('new submission', () => {
 
         // Navigate to dashboard page by clicking cancel
         cy.findByRole('button', { name: /Cancel/ }).click()
+        cy.wait('@fetchSubmission2Query')
         cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
         // Navigate to new page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/newSubmission.spec.ts
@@ -7,6 +7,7 @@ describe('new submission', () => {
 
         // Navigate to dashboard page by clicking cancel
         cy.findByRole('button', { name: /Cancel/ }).click()
+        cy.wait('@indexSubmissions2Query', { timeout: 50000 })
         cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
         // Navigate to new page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -12,6 +12,7 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/ }).click()
+            cy.wait('@indexSubmissions2Query', { timeout: 50000 })
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to type page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -12,7 +12,6 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/ }).click()
-            cy.wait('@fetchSubmission2Query')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to type page

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -12,6 +12,7 @@ describe('submission type', () => {
 
             // Navigate to dashboard page by clicking cancel
             cy.findByRole('button', { name: /Cancel/ }).click()
+            cy.wait('@fetchSubmission2Query')
             cy.findByRole('heading', { level: 1, name: /Dashboard/ })
 
             // Navigate to type page

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -43,8 +43,7 @@ declare global {
             verifyDocumentsHaveNoErrors(): void
             submitStateSubmissionForm(success?: boolean, resubmission?: boolean): void
             navigateForm(buttonName: FormButtonKey, waitForLoad?: boolean): void
-            navigateBackToCurrentSubmission(): void
-            navigateToSubmissionRevision(linkTestId: string): void
+            navigateToSubmissionByUserInteraction(testId: string): void
         }
     }
 }

--- a/tests/cypress/support/submissionCommands.ts
+++ b/tests/cypress/support/submissionCommands.ts
@@ -1,26 +1,12 @@
 import { aliasQuery } from '../utils/graphql-test-utils'
 
 Cypress.Commands.add(
-    'navigateBackToCurrentSubmission',
-    () => {
+    'navigateToSubmissionByUserInteraction',
+    (testId: string) => {
         cy.intercept('POST', '*/graphql', (req) => {
             aliasQuery(req, 'fetchSubmission2')
         })
-        cy.findByText('View most recent version of this submission').click()
-        cy.wait('@fetchSubmission2Query', { timeout: 20000 })
-    }
-)
-
-Cypress.Commands.add(
-    'navigateToSubmissionRevision',
-    (linkTestId: string) => {
-        cy.intercept('POST', '*/graphql', (req) => {
-            aliasQuery(req, 'fetchSubmission2')
-        })
-
-        cy.findByTestId(linkTestId)
-            .should('exist')
-            .click()
+        cy.findByTestId(testId).should('exist').click()
         cy.wait('@fetchSubmission2Query', { timeout: 20000 })
     }
 )


### PR DESCRIPTION
## Summary
[MR-226](https://qmacbis.atlassian.net/browse/MR-226)
Display banner to users indicating the submission has been updated.

**NOTE: ** 
- Also updated unlocked banner timezone to default to ET.
- <strike>Also testing a fix for flaky test when clicking `Cancel` button on state submission form.</strike>

#### Related issues

####
<img width="904" alt="Screen Shot 2022-04-01 at 5 29 08 PM" src="https://user-images.githubusercontent.com/98117700/161343706-511f4a94-37ba-414e-9e24-b284e3553114.png">
 Screenshots

#### Test cases covered
- SubmissionSummary.test.tsx
   - renders submission updated banner
   
- unlockResubmit.spec.ts
   - Navigate to resubmitted submission and check for submission updated banner after resubmission

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
