### PR TITLE
MR-392: Add a NEW tag to newly uploaded documents

### DIFF
--- a/services/app-web/src/common-code/data-helpers/makeDocumentDateLookupTable.test.ts
+++ b/services/app-web/src/common-code/data-helpers/makeDocumentDateLookupTable.test.ts
@@ -18,6 +18,7 @@ describe('makeDateTable', () => {
                 '2022-03-25T21:14:43.057Z'
             ),
             'lifeofgalileo.pdf': new Date('2022-03-28T17:56:32.953Z'),
+            previousSubmissionDate: new Date('2022-03-25T21:14:43.057Z'),
         })
     })
 })

--- a/services/app-web/src/common-code/data-helpers/makeDocumentDateLookupTable.ts
+++ b/services/app-web/src/common-code/data-helpers/makeDocumentDateLookupTable.ts
@@ -11,15 +11,20 @@ export const makeDateTable = (
     ] as const
     const lookupTable = {} as DocumentDateLookupTable
     if (submissions) {
-        submissions.revisions.forEach((revision) => {
+        submissions.revisions.forEach((revision, index) => {
             const revisionData = base64ToDomain(
                 revision.revision.submissionData
             )
+
             if (revisionData instanceof Error) {
                 console.error(
                     'failed to read submission data; unable to display document dates'
                 )
                 return
+            }
+            if (index === 1) {
+                // second most recent revision
+                lookupTable['previousSubmissionDate'] = revisionData.updatedAt
             }
             docBuckets.forEach((bucket) => {
                 revisionData[bucket].forEach((doc) => {

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -23,6 +23,7 @@ export type ContractDetailsSummarySectionProps = {
     submission: DraftSubmission | StateSubmission
     navigateTo?: string
     documentDateLookupTable?: DocumentDateLookupTable
+    isCMSUser?: boolean
 }
 
 const createCheckboxList = ({
@@ -55,6 +56,7 @@ export const ContractDetailsSummarySection = ({
     submission,
     navigateTo,
     documentDateLookupTable,
+    isCMSUser,
 }: ContractDetailsSummarySectionProps): React.ReactElement => {
     //Checks if submission is a previous submission
     const isPreviousSubmission = usePreviousSubmission()
@@ -236,12 +238,14 @@ export const ContractDetailsSummarySection = ({
             <UploadedDocumentsTable
                 documents={submission.contractDocuments}
                 documentDateLookupTable={documentDateLookupTable}
+                isCMSUser={isCMSUser}
                 caption="Contract"
                 documentCategory="Contract"
             />
             <UploadedDocumentsTable
                 documents={contractSupportingDocuments}
                 documentDateLookupTable={documentDateLookupTable}
+                isCMSUser={isCMSUser}
                 caption="Contract supporting documents"
                 documentCategory="Contract-supporting"
                 isSupportingDocuments

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -15,12 +15,14 @@ export type RateDetailsSummarySectionProps = {
     submission: DraftSubmission | StateSubmission
     navigateTo?: string
     documentDateLookupTable?: DocumentDateLookupTable
+    isCMSUser?: boolean
 }
 
 export const RateDetailsSummarySection = ({
     submission,
     navigateTo,
     documentDateLookupTable,
+    isCMSUser,
 }: RateDetailsSummarySectionProps): React.ReactElement => {
     const isSubmitted = submission.__typename === 'StateSubmission'
     const isEditing = !isSubmitted && navigateTo !== undefined
@@ -119,12 +121,14 @@ export const RateDetailsSummarySection = ({
             <UploadedDocumentsTable
                 documents={submission.rateDocuments}
                 documentDateLookupTable={documentDateLookupTable}
+                isCMSUser={isCMSUser}
                 caption="Rate certification"
                 documentCategory="Rate certification"
             />
             <UploadedDocumentsTable
                 documents={rateSupportingDocuments}
                 documentDateLookupTable={documentDateLookupTable}
+                isCMSUser={isCMSUser}
                 caption="Rate supporting documents"
                 documentCategory="Rate-supporting"
                 isSupportingDocuments

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
@@ -38,3 +38,14 @@
     display: flex;
     justify-content: space-between;
 }
+
+.newDocTag {
+    background-color: #009ec1;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: 2px;
+    height: 18px;
+    margin-right: 5px !important;
+}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
@@ -40,7 +40,7 @@
 }
 
 .newDocTag {
-    background-color: #009ec1;
+    background-color: $theme-color-info-dark;
     display: inline-flex;
     flex-direction: row;
     align-items: center;

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.test.tsx
@@ -155,6 +155,8 @@ describe('UploadedDocumentsTable', () => {
                 'Sat Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
             'supporting docs test 3':
                 'Sun Mar 27 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            previousSubmissionDate:
+                'Sun Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
         }
         renderWithProviders(
             <UploadedDocumentsTable
@@ -163,6 +165,7 @@ describe('UploadedDocumentsTable', () => {
                 documentCategory="Contract-supporting"
                 isSupportingDocuments
                 documentDateLookupTable={dateLookupTable}
+                isCMSUser={true}
             />
         )
         await waitFor(() => {
@@ -172,6 +175,96 @@ describe('UploadedDocumentsTable', () => {
             expect(rows[1]).toHaveTextContent('3/25/22')
             expect(rows[2]).toHaveTextContent('3/26/22')
             expect(rows[3]).toHaveTextContent('3/27/22')
+        })
+    })
+    it('shows the NEW tag when a document is submitted after the last submission', async () => {
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                documentCategories: ['CONTRACT_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+        ]
+        const dateLookupTable = {
+            'supporting docs test 1':
+                'Fri Mar 25 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            'supporting docs test 2':
+                'Sat Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            'supporting docs test 3':
+                'Sun Mar 27 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            previousSubmissionDate:
+                'Sun Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+        }
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Contract supporting"
+                documentCategory="Contract-supporting"
+                isSupportingDocuments
+                documentDateLookupTable={dateLookupTable}
+                isCMSUser={true}
+            />
+        )
+        await waitFor(() => {
+            expect(screen.getByTestId('tag')).toHaveTextContent('NEW')
+        })
+    })
+    it('does not show the NEW tag if the user is not a CMS user', async () => {
+        const testDocuments = [
+            {
+                s3URL: 's3://foo/bar/test-1',
+                name: 'supporting docs test 1',
+                documentCategories: ['CONTRACT_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-2',
+                name: 'supporting docs test 2',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+            {
+                s3URL: 's3://foo/bar/test-3',
+                name: 'supporting docs test 3',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+        ]
+        const dateLookupTable = {
+            'supporting docs test 1':
+                'Fri Mar 25 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            'supporting docs test 2':
+                'Sat Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            'supporting docs test 3':
+                'Sun Mar 27 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+            previousSubmissionDate:
+                'Sun Mar 26 2022 16:13:20 GMT-0500 (Central Daylight Time)',
+        }
+        renderWithProviders(
+            <UploadedDocumentsTable
+                documents={testDocuments}
+                caption="Contract supporting"
+                documentCategory="Contract-supporting"
+                isSupportingDocuments
+                documentDateLookupTable={dateLookupTable}
+                isCMSUser={false}
+            />
+        )
+        await waitFor(() => {
+            expect(screen.queryByTestId('tag')).not.toBeInTheDocument()
         })
     })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@trussworks/react-uswds'
+import { Link, Tag } from '@trussworks/react-uswds'
 import { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import dayjs from 'dayjs'
@@ -14,6 +14,7 @@ export type UploadedDocumentsTableProps = {
     documentDateLookupTable?: DocumentDateLookupTable
     isSupportingDocuments?: boolean
     isEditing?: boolean
+    isCMSUser?: boolean
 }
 
 type DocumentWithLink = { url: string | null } & Document
@@ -29,6 +30,7 @@ export const UploadedDocumentsTable = ({
     documentDateLookupTable,
     isSupportingDocuments = false,
     isEditing = false,
+    isCMSUser,
 }: UploadedDocumentsTableProps): React.ReactElement => {
     const { getURL, getKey } = useS3()
     const [refreshedDocs, setRefreshedDocs] = useState<DocumentWithLink[]>([])
@@ -36,6 +38,14 @@ export const UploadedDocumentsTable = ({
     const shouldShowAsteriskExplainer = refreshedDocs.some((doc) =>
         isBothContractAndRateSupporting(doc)
     )
+    const shouldHaveNewTag = (doc: DocumentWithLink) => {
+        return (
+            isCMSUser &&
+            documentDateLookupTable &&
+            documentDateLookupTable[doc.name] >
+                documentDateLookupTable.previousSubmissionDate
+        )
+    }
     const borderTopGradientStyles = `borderTopLinearGradient ${styles.uploadedDocumentsTable}`
     const supportingDocsTopMarginStyles = isSupportingDocuments
         ? styles.withMarginTop
@@ -121,6 +131,11 @@ export const UploadedDocumentsTable = ({
                         <tr key={doc.name}>
                             {doc.url ? (
                                 <td>
+                                    {shouldHaveNewTag(doc) ? (
+                                        <Tag className={styles.newDocTag}>
+                                            NEW
+                                        </Tag>
+                                    ) : null}
                                     <Link
                                         aria-label={`${doc.name} (opens in new window)`}
                                         href={doc.url}
@@ -134,7 +149,14 @@ export const UploadedDocumentsTable = ({
                                     </Link>
                                 </td>
                             ) : (
-                                <td>{doc.name}</td>
+                                <td>
+                                    {shouldHaveNewTag(doc) ? (
+                                        <Tag className={styles.newDocTag}>
+                                            NEW
+                                        </Tag>
+                                    ) : null}{' '}
+                                    {doc.name}
+                                </td>
                             )}
                             <td>
                                 {documentDateLookupTable

--- a/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionRevisionSummary/SubmissionRevisionSummary.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import { Route } from 'react-router'
 import { RoutesRecord } from '../../constants/routes'
 import {
@@ -49,5 +49,39 @@ describe('SubmissionRevisionSummary', () => {
         expect(
             await screen.findByTestId('previous-submission-banner')
         ).toBeInTheDocument()
+    })
+    it('extracts the correct dates from the submission and displays them in tables', async () => {
+        renderWithProviders(
+            <Route
+                path={RoutesRecord.SUBMISSIONS_REVISION}
+                component={SubmissionRevisionSummary}
+            />,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateSubmission2MockSuccess({
+                            stateSubmission:
+                                mockSubmittedSubmission2WithRevisions(),
+                            id: '15',
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/revisions/2',
+                },
+            }
+        )
+        await waitFor(() => {
+            const rows = screen.getAllByRole('row')
+            expect(rows).toHaveLength(2)
+            expect(within(rows[0]).getByText('Date added')).toBeInTheDocument()
+            expect(
+                within(rows[1]).getByText(dayjs(new Date()).format('M/D/YY'))
+            ).toBeInTheDocument()
+        })
     })
 })

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -141,33 +141,6 @@ export const SubmissionSummary = (): React.ReactElement => {
         DocumentDateLookupTable | undefined
     >({})
 
-    // const makeDateTable = (submissions: Submission2) => {
-    //     const docBuckets = [
-    //         'contractDocuments',
-    //         'rateDocuments',
-    //         'documents',
-    //     ] as const
-    //     const lookupTable = {} as DocumentDateLookupTable
-    //     if (submissions) {
-    //         submissions.revisions.forEach((revision) => {
-    //             const revisionData = base64ToDomain(
-    //                 revision.revision.submissionData
-    //             )
-    //             if (revisionData instanceof Error) {
-    //                 console.error(
-    //                     'failed to read submission data; unable to display document dates'
-    //                 )
-    //                 return
-    //             }
-    //             docBuckets.forEach((bucket) => {
-    //                 revisionData[bucket].forEach((doc) => {
-    //                     lookupTable[doc.name] = revisionData.updatedAt
-    //                 })
-    //             })
-    //         })
-    //         setDocumentDates(lookupTable)
-    //     }
-    // }
     const formik = useFormik({
         initialValues: modalFormInitialValues,
         validationSchema: Yup.object().shape({
@@ -189,7 +162,7 @@ export const SubmissionSummary = (): React.ReactElement => {
     const [unlockStateSubmission] = useUnlockStateSubmissionMutation()
     const submissionAndRevisions = data?.fetchSubmission2.submission
 
-    const displayUnlockButton = loggedInUser?.role === 'CMS_USER'
+    const isCMSUser = loggedInUser?.role === 'CMS_USER'
 
     // Pull out the correct revision form api request, display errors for bad dad
     useEffect(() => {
@@ -397,7 +370,7 @@ export const SubmissionSummary = (): React.ReactElement => {
                 <SubmissionTypeSummarySection
                     submission={submission}
                     headerChildComponent={
-                        displayUnlockButton ? (
+                        isCMSUser ? (
                             <UnlockModalButton
                                 modalRef={modalRef}
                                 disabled={disableUnlockButton}
@@ -409,12 +382,14 @@ export const SubmissionSummary = (): React.ReactElement => {
                 <ContractDetailsSummarySection
                     submission={submission}
                     documentDateLookupTable={documentDates}
+                    isCMSUser={isCMSUser}
                 />
 
                 {isContractActionAndRateCertification && (
                     <RateDetailsSummarySection
                         submission={submission}
                         documentDateLookupTable={documentDates}
+                        isCMSUser={isCMSUser}
                     />
                 )}
 

--- a/services/app-web/src/styles/theme/_color.scss
+++ b/services/app-web/src/styles/theme/_color.scss
@@ -105,7 +105,7 @@ $theme-color-success-darker: $cms-color-success-darker;
 // $theme-color-info-lighter: 'cyan-5';
 // $theme-color-info-light: 'cyan-20';
 // $theme-color-info: 'cyan-30v';
-// $theme-color-info-dark: 'cyan-40v';
+$theme-color-info-dark: #009ec1;
 // $theme-color-info-darker: 'blue-cool-60';
 
 // // Disabled colors


### PR DESCRIPTION
## Summary

Closes[392](https://qmacbis.atlassian.net/browse/MR-392)

Adds a NEW tag to newly uploaded docs, provided the user is a CMS user.

#### Screenshots

<img width="827" alt="image" src="https://user-images.githubusercontent.com/8964335/161362423-6d6f7c98-3c7a-4c08-b168-b99809188aaa.png">

#### Test cases covered

Should see NEW when a doc is newer than the second submission (the first submission is the current one; the doc will be part of the current submission).
Should NOT see NEW if it's not a CMS user.
Updated the lookup table, which now has the date of the second submission.

## QA guidance

Not much.  Should see that tag if you're logged in as a CMS user and a doc has been uploaded since the last submission, and not if not.
