### PR TITLE
Encrypt s3 buckets

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -115,6 +115,10 @@ resources:
           BlockPublicPolicy: true
           IgnorePublicAcls: true
           RestrictPublicBuckets: true
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
 
     FirehoseStreamToNewRelic:
       Type: AWS::KinesisFirehose::DeliveryStream

--- a/services/storybook/serverless.yml
+++ b/services/storybook/serverless.yml
@@ -50,7 +50,10 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html
-      DeletionPolicy: Delete
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -50,7 +50,10 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html
-      DeletionPolicy: Delete
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
       Properties:


### PR DESCRIPTION
## Summary

The CMS cloud support team flagged some buckets in our environment that didn't have s3 encryption turned on, as it is a requirement everywhere. Specifically, we're to encrypt the serverless buckets that get created automatically by Serverless to do the infra deploys.

#### Related issues

https://qmacbis.atlassian.net/browse/MR-2066
