### PR TITLE
[MR-858] Add updateHealthPlanFormData mutation to API

### DIFF
--- a/services/app-api/.eslintrc
+++ b/services/app-api/.eslintrc
@@ -21,7 +21,9 @@
         "no-throw-literal": "error",
         "jest/no-focused-tests": "error",
         "jest/no-identical-title": "error",
-        "@typescript-eslint/no-floating-promises": "error"
+        "@typescript-eslint/no-floating-promises": "error",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_*" }]
     },
     "overrides": []
 }

--- a/services/app-api/postgres/insertDraftSubmission.test.ts
+++ b/services/app-api/postgres/insertDraftSubmission.test.ts
@@ -1,4 +1,5 @@
-import { DraftSubmissionType } from '../../app-web/src/common-code/domain-models'
+import { Submission2Type } from '../../app-web/src/common-code/domain-models'
+import { toDomain } from '../../app-web/src/common-code/proto/stateSubmission'
 import { sharedTestPrismaClient } from '../testHelpers/storeHelpers'
 import { insertDraftSubmission } from './insertDraftSubmission'
 import { isStoreError } from './storeError'
@@ -32,11 +33,19 @@ describe('insertDraftSubmissionPostgres', () => {
 
         // Because we are erroring above if _any_ of our results are a store error
         // we can tell the type system that all of our results are DraftSubmissionType
-        const drafts = results as DraftSubmissionType[]
+        const drafts = results as Submission2Type[]
+
+        const formDatum = drafts.map((d) => {
+            const formDataResult = toDomain(d.revisions[0].submissionFormProto)
+            if (formDataResult instanceof Error) {
+                throw formDataResult
+            }
+            return formDataResult
+        })
 
         // Quick way to see if there are any duplicates, throw the state numbers into
         // a set and check that the set and the array have the same number of elements
-        const stateNumbers = drafts.map((draft) => draft.stateNumber)
+        const stateNumbers = formDatum.map((d) => d.stateNumber)
         const stateNumberSet = new Set(stateNumbers)
 
         if (stateNumbers.length !== stateNumberSet.size) {

--- a/services/app-api/postgres/postgresStore.ts
+++ b/services/app-api/postgres/postgresStore.ts
@@ -19,6 +19,7 @@ import {
 import { insertSubmissionRevision } from './insertSubmissionRevision'
 import { StoreError } from './storeError'
 import { updateDraftSubmission } from './updateDraftSubmission'
+import { updateFormData } from './updateFormData'
 import { updateStateSubmission } from './updateStateSubmission'
 
 type Store = {
@@ -58,6 +59,12 @@ type Store = {
         draft: DraftSubmissionType
     ) => Promise<Submission2Type | StoreError>
 
+    updateFormData: (
+        submissionID: string,
+        revisionID: string,
+        formData: DraftSubmissionType
+    ) => Promise<Submission2Type | StoreError>
+
     findPrograms: (
         stateCode: string,
         programIDs: Array<string>
@@ -90,6 +97,8 @@ function NewPostgresStore(client: PrismaClient): Store {
         },
         updateDraftSubmission: (draftSubmission) =>
             updateDraftSubmission(client, draftSubmission),
+        updateFormData: (submissionID, revisionID, formData) =>
+            updateFormData(client, submissionID, revisionID, formData),
         updateStateSubmission: (submission, submitInfo) =>
             updateStateSubmission(client, submission, submitInfo),
         findStateSubmission: (submissionID) =>

--- a/services/app-api/postgres/postgresStore.ts
+++ b/services/app-api/postgres/postgresStore.ts
@@ -4,7 +4,7 @@ import {
     ProgramT,
     StateSubmissionType,
     Submission2Type,
-    UpdateInfoType
+    UpdateInfoType,
 } from '../../app-web/src/common-code/domain-models'
 import { findPrograms } from '../postgres'
 import { findAllSubmissions } from './findAllSubmissions'
@@ -14,7 +14,7 @@ import { findStateSubmission } from './findStateSubmission'
 import { findSubmissionWithRevisions } from './findSubmissionWithRevisions'
 import {
     insertDraftSubmission,
-    InsertDraftSubmissionArgsType
+    InsertDraftSubmissionArgsType,
 } from './insertDraftSubmission'
 import { insertSubmissionRevision } from './insertSubmissionRevision'
 import { StoreError } from './storeError'
@@ -24,7 +24,7 @@ import { updateStateSubmission } from './updateStateSubmission'
 type Store = {
     insertDraftSubmission: (
         args: InsertDraftSubmissionArgsType
-    ) => Promise<DraftSubmissionType | StoreError>
+    ) => Promise<Submission2Type | StoreError>
 
     findAllSubmissions: (
         stateCode: string
@@ -70,7 +70,7 @@ type Store = {
 
     findAllSubmissionsWithRevisions: (
         stateCode: string
-    ) => Promise<(Submission2Type)[] | StoreError>
+    ) => Promise<Submission2Type[] | StoreError>
 }
 
 function NewPostgresStore(client: PrismaClient): Store {
@@ -82,7 +82,7 @@ function NewPostgresStore(client: PrismaClient): Store {
             findDraftSubmission(client, draftUUID),
         findSubmissionWithRevisions: (id) =>
             findSubmissionWithRevisions(client, id),
-        findAllSubmissionsWithRevisions: (stateCode) => 
+        findAllSubmissionsWithRevisions: (stateCode) =>
             findAllSubmissionsWithRevisions(client, stateCode),
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         findDraftSubmissionByStateNumber: (_stateCode, _stateNumber) => {
@@ -95,7 +95,11 @@ function NewPostgresStore(client: PrismaClient): Store {
         findStateSubmission: (submissionID) =>
             findStateSubmission(client, submissionID),
         insertNewRevision: (submissionID, unlockInfo, draft) =>
-            insertSubmissionRevision(client, {submissionID, unlockInfo, draft}),
+            insertSubmissionRevision(client, {
+                submissionID,
+                unlockInfo,
+                draft,
+            }),
         findPrograms: findPrograms,
     }
 }

--- a/services/app-api/postgres/updateFormData.ts
+++ b/services/app-api/postgres/updateFormData.ts
@@ -1,0 +1,78 @@
+import { PrismaClient } from '@prisma/client'
+import {
+    DraftSubmissionType,
+    Submission2Type,
+} from '../../app-web/src/common-code/domain-models'
+import { toProtoBuffer } from '../../app-web/src/common-code/proto/stateSubmission'
+import {
+    convertPrismaErrorToStoreError,
+    isStoreError,
+    StoreError,
+} from './storeError'
+import {
+    convertToSubmission2Type,
+    StateSubmissionWithRevisions,
+} from './submissionWithRevisionsHelpers'
+
+export async function updateRevisionWrapper(
+    client: PrismaClient,
+    submissionID: string,
+    revisionID: string,
+    proto: Buffer
+): Promise<StateSubmissionWithRevisions | StoreError> {
+    try {
+        const updateResult = await client.stateSubmission.update({
+            where: {
+                id: submissionID,
+            },
+            data: {
+                revisions: {
+                    update: {
+                        where: {
+                            id: revisionID,
+                        },
+                        data: {
+                            submissionFormProto: proto,
+                        },
+                    },
+                },
+            },
+            include: {
+                revisions: {
+                    orderBy: {
+                        createdAt: 'desc', // We expect our revisions most-recent-first
+                    },
+                },
+            },
+        })
+
+        return updateResult
+    } catch (updateError) {
+        return convertPrismaErrorToStoreError(updateError)
+    }
+}
+
+export async function updateFormData(
+    client: PrismaClient,
+    submissionID: string,
+    revisionID: string,
+    formData: DraftSubmissionType
+): Promise<Submission2Type | StoreError> {
+    formData.updatedAt = new Date()
+
+    const proto = toProtoBuffer(formData)
+    const buffer = Buffer.from(proto)
+
+    const updateResult = await updateRevisionWrapper(
+        client,
+        submissionID,
+        revisionID,
+        buffer
+    )
+
+    if (isStoreError(updateResult)) {
+        return updateResult
+    }
+
+    return convertToSubmission2Type(updateResult)
+}

--- a/services/app-api/resolvers/configureResolvers.ts
+++ b/services/app-api/resolvers/configureResolvers.ts
@@ -3,6 +3,7 @@ import type { Emailer } from '../emailer'
 import { Resolvers } from '../gen/gqlServer'
 import type { Store } from '../postgres'
 import { createDraftSubmissionResolver } from './createDraftSubmission'
+import { createSubmission2Resolver } from './createSubmission2'
 import { draftSubmissionResolver } from './draftSubmissionResolver'
 import { fetchCurrentUserResolver } from './fetchCurrentUser'
 import { fetchDraftSubmissionResolver } from './fetchDraftSubmission'
@@ -27,16 +28,20 @@ export function configureResolvers(store: Store, emailer: Emailer): Resolvers {
             fetchStateSubmission: fetchStateSubmissionResolver(store),
             fetchSubmission2: fetchSubmission2Resolver(store),
             indexSubmissions: indexSubmissionsResolver(store),
-            indexSubmissions2: indexSubmissions2Resolver(store)
+            indexSubmissions2: indexSubmissions2Resolver(store),
         },
         Mutation: {
             createDraftSubmission: createDraftSubmissionResolver(store),
+            createSubmission2: createSubmission2Resolver(store),
             updateDraftSubmission: updateDraftSubmissionResolver(store),
             submitDraftSubmission: submitDraftSubmissionResolver(
                 store,
                 emailer
             ),
-            unlockStateSubmission: unlockStateSubmissionResolver(store, emailer),
+            unlockStateSubmission: unlockStateSubmissionResolver(
+                store,
+                emailer
+            ),
         },
         Submission: {
             // resolveType is required to differentiate Unions

--- a/services/app-api/resolvers/configureResolvers.ts
+++ b/services/app-api/resolvers/configureResolvers.ts
@@ -16,6 +16,7 @@ import { submission2Resolver } from './submission2Resolver'
 import { submitDraftSubmissionResolver } from './submitDraftSubmission'
 import { unlockStateSubmissionResolver } from './unlockStateSubmission'
 import { updateDraftSubmissionResolver } from './updateDraftSubmission'
+import { updateHealthPlanFormDataResolver } from './updateHealthPlanFormData'
 import { stateUserResolver } from './userResolver'
 
 export function configureResolvers(store: Store, emailer: Emailer): Resolvers {
@@ -42,6 +43,7 @@ export function configureResolvers(store: Store, emailer: Emailer): Resolvers {
                 store,
                 emailer
             ),
+            updateHealthPlanFormData: updateHealthPlanFormDataResolver(store),
         },
         Submission: {
             // resolveType is required to differentiate Unions

--- a/services/app-api/resolvers/createSubmission2.test.ts
+++ b/services/app-api/resolvers/createSubmission2.test.ts
@@ -1,0 +1,58 @@
+import { CreateSubmission2Input } from '../gen/gqlServer'
+import CREATE_SUBMISSION_2 from '../../app-graphql/src/mutations/createSubmission2.graphql'
+import { constructTestPostgresServer } from '../testHelpers/gqlHelpers'
+import { latestFormData } from '../testHelpers/healthPlanPackageHelpers'
+
+describe('createSubmission2', () => {
+    it('returns draft submission payload with a draft submission', async () => {
+        const server = await constructTestPostgresServer()
+
+        const input: CreateSubmission2Input = {
+            programIDs: [
+                '5c10fe9f-bec9-416f-a20c-718b152ad633',
+                '037af66b-81eb-4472-8b80-01edf17d12d9',
+            ],
+            submissionType: 'CONTRACT_ONLY',
+            submissionDescription: 'A real submission',
+        }
+        const res = await server.executeOperation({
+            query: CREATE_SUBMISSION_2,
+            variables: { input },
+        })
+
+        expect(res.errors).toBeUndefined()
+
+        const pkg = res.data?.createSubmission2.submission
+        const draft = latestFormData(pkg)
+
+        expect(draft.submissionDescription).toBe('A real submission')
+        expect(draft.submissionType).toBe('CONTRACT_ONLY')
+        expect(draft.programIDs).toEqual([
+            '5c10fe9f-bec9-416f-a20c-718b152ad633',
+            '037af66b-81eb-4472-8b80-01edf17d12d9',
+        ])
+        expect(draft.documents).toHaveLength(0)
+        expect(draft.managedCareEntities).toHaveLength(0)
+        expect(draft.federalAuthorities).toHaveLength(0)
+        expect(draft.contractDateStart).toBeUndefined()
+        expect(draft.contractDateEnd).toBeUndefined()
+    })
+
+    it('returns an error if the program id is not in valid', async () => {
+        const server = await constructTestPostgresServer()
+        const input: CreateSubmission2Input = {
+            programIDs: ['xyz123'],
+            submissionType: 'CONTRACT_ONLY',
+            submissionDescription: 'A real submission',
+        }
+        const res = await server.executeOperation({
+            query: CREATE_SUBMISSION_2,
+            variables: { input },
+        })
+
+        expect(res.errors).toBeDefined()
+        expect(res.errors && res.errors[0].message).toBe(
+            'The program id xyz123 does not exist in state FL'
+        )
+    })
+})

--- a/services/app-api/resolvers/createSubmission2.test.ts
+++ b/services/app-api/resolvers/createSubmission2.test.ts
@@ -55,4 +55,31 @@ describe('createSubmission2', () => {
             'The program id xyz123 does not exist in state FL'
         )
     })
+
+    it('returns an error if a CMS user attempts to create', async () => {
+        const server = await constructTestPostgresServer({
+            context: {
+                user: {
+                    name: 'Zuko',
+                    role: 'CMS_USER',
+                    email: 'aang@va.gov',
+                },
+            },
+        })
+
+        const input: CreateSubmission2Input = {
+            programIDs: ['xyz123'],
+            submissionType: 'CONTRACT_ONLY',
+            submissionDescription: 'A real submission',
+        }
+        const res = await server.executeOperation({
+            query: CREATE_SUBMISSION_2,
+            variables: { input },
+        })
+
+        expect(res.errors).toBeDefined()
+        expect(res.errors && res.errors[0].message).toBe(
+            'user not authorized to create state data'
+        )
+    })
 })

--- a/services/app-api/resolvers/createSubmission2.ts
+++ b/services/app-api/resolvers/createSubmission2.ts
@@ -9,12 +9,12 @@ import {
     setErrorAttributesOnActiveSpan,
     setSuccessAttributesOnActiveSpan,
 } from './attributeHelper'
-import { toDomain } from '../../app-web/src/common-code/proto/stateSubmission'
 
-export function createDraftSubmissionResolver(
+export function createSubmission2Resolver(
     store: Store
-): MutationResolvers['createDraftSubmission'] {
+): MutationResolvers['createSubmission2'] {
     return async (_parent, { input }, context) => {
+        console.log('IN SUBMI T2')
         const { user, span } = context
         setResolverDetailsOnActiveSpan('createDraftSubmission', user, span)
 
@@ -76,28 +76,8 @@ export function createDraftSubmissionResolver(
         logSuccess('createDraftSubmission')
         setSuccessAttributesOnActiveSpan(span)
 
-        const revision = pkgResult.revisions[0]
-        const formDataResult = toDomain(revision.submissionFormProto)
-        if (formDataResult instanceof Error) {
-            const errMessage =
-                'Failed to deserialize form data after create' +
-                formDataResult.message
-            logError('createDraftSubmission', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw formDataResult
-        }
-
-        if (formDataResult.status === 'SUBMITTED') {
-            const errMessage =
-                'managed to get a submitted package after creation: ' +
-                formDataResult.id
-            logError('createDraftSubmission', errMessage)
-            setErrorAttributesOnActiveSpan(errMessage, span)
-            throw formDataResult
-        }
-
         return {
-            draftSubmission: formDataResult,
+            submission: pkgResult,
         }
     }
 }

--- a/services/app-api/resolvers/createSubmission2.ts
+++ b/services/app-api/resolvers/createSubmission2.ts
@@ -14,7 +14,6 @@ export function createSubmission2Resolver(
     store: Store
 ): MutationResolvers['createSubmission2'] {
     return async (_parent, { input }, context) => {
-        console.log('IN SUBMI T2')
         const { user, span } = context
         setResolverDetailsOnActiveSpan('createDraftSubmission', user, span)
 

--- a/services/app-api/resolvers/updateHealthPlanFormData.test.ts
+++ b/services/app-api/resolvers/updateHealthPlanFormData.test.ts
@@ -1,0 +1,287 @@
+import {
+    constructTestPostgresServer,
+    createTestSubmission2,
+} from '../testHelpers/gqlHelpers'
+import UPDATE_HEALTH_PLAN_FORM_DATA from '../../app-graphql/src/mutations/updateHealthPlanFormData.graphql'
+import { domainToBase64 } from '../../app-web/src/common-code/proto/stateSubmission'
+import { latestFormData } from '../testHelpers/healthPlanPackageHelpers'
+import { basicStateSubmission } from '../../app-web/src/common-code/domain-mocks'
+import { v4 as uuidv4 } from 'uuid'
+
+describe('updateHealthPlanFormData', () => {
+    it('updates valid fields in the formData', async () => {
+        const server = await constructTestPostgresServer()
+
+        const createdDraft = await createTestSubmission2(server)
+
+        const formData = latestFormData(createdDraft)
+
+        // update that draft.
+        formData.submissionDescription = 'UPDATED BY REVISION'
+
+        // convert to base64 proto
+        const updatedB64 = domainToBase64(formData)
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: updatedB64,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeUndefined()
+
+        const healthPlanPackage =
+            updateResult.data?.updateHealthPlanFormData.submission
+
+        const updatedFormData = latestFormData(healthPlanPackage)
+        expect(updatedFormData.submissionDescription).toBe(
+            'UPDATED BY REVISION'
+        )
+    })
+
+    it('errors if a CMS user calls it', async () => {
+        const server = await constructTestPostgresServer()
+
+        const createdDraft = await createTestSubmission2(server)
+
+        const formData = latestFormData(createdDraft)
+
+        // update that draft.
+        formData.submissionDescription = 'UPDATED BY REVISION'
+
+        // convert to base64 proto
+        const updatedB64 = domainToBase64(formData)
+
+        const cmsUserServer = await constructTestPostgresServer({
+            context: {
+                user: {
+                    name: 'Zuko',
+                    role: 'CMS_USER',
+                    email: 'aang@va.gov',
+                },
+            },
+        })
+
+        const updateResult = await cmsUserServer.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: updatedB64,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
+        expect(updateResult.errors[0].message).toBe(
+            'user not authorized to modify state data'
+        )
+    })
+
+    it('errors if a state user from a different state calls it', async () => {
+        const server = await constructTestPostgresServer()
+        const createdDraft = await createTestSubmission2(server)
+        const formData = latestFormData(createdDraft)
+
+        // update that draft.
+        formData.submissionDescription = 'UPDATED BY REVISION'
+
+        // convert to base64 proto
+        const updatedB64 = domainToBase64(formData)
+
+        // setup a server with a different user
+        const otherUserServer = await constructTestPostgresServer({
+            context: {
+                user: {
+                    name: 'Aang',
+                    state_code: 'VA',
+                    role: 'STATE_USER',
+                    email: 'aang@va.gov',
+                },
+            },
+        })
+
+        const updateResult = await otherUserServer.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: updatedB64,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('FORBIDDEN')
+        expect(updateResult.errors[0].message).toBe(
+            'user not authorized to fetch data from a different state'
+        )
+    })
+
+    it('errors if the payload isnt valid', async () => {
+        const server = await constructTestPostgresServer()
+
+        const createdDraft = await createTestSubmission2(server)
+
+        const formData = 'not-valid-proto'
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: formData,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
+        expect(updateResult.errors[0].message).toContain(
+            'Failed to parse out form data in request'
+        )
+    })
+
+    it('errors if the payload is submitted', async () => {
+        const server = await constructTestPostgresServer()
+
+        const createdDraft = await createTestSubmission2(server)
+
+        const stateSubmission = basicStateSubmission()
+
+        const formData = domainToBase64(stateSubmission)
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: formData,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
+        expect(updateResult.errors[0].message).toContain(
+            'Attempted to update with a StateSubmission'
+        )
+    })
+
+    it('errors if the payload is already submitted', async () => {
+        const server = await constructTestPostgresServer()
+        const createdDraft = await createTestSubmission2(server)
+        const stateSubmission = basicStateSubmission()
+        const formData = domainToBase64(stateSubmission)
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: formData,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
+        expect(updateResult.errors[0].message).toContain(
+            'Attempted to update with a StateSubmission'
+        )
+    })
+
+    it('errors if the id doesnt match the db', async () => {
+        // id is wrong
+        // createdAt is wrong? or just overwrite
+        //
+
+        const server = await constructTestPostgresServer()
+        const createdDraft = await createTestSubmission2(server)
+
+        const formData = latestFormData(createdDraft)
+
+        formData.id = uuidv4()
+
+        const b64 = domainToBase64(formData)
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: b64,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
+        expect(updateResult.errors[0].message).toBe(
+            'Attempted to modify un-modifiable field(s): id'
+        )
+    })
+
+    it('errors if the other payload values dont match the db', async () => {
+        const server = await constructTestPostgresServer()
+        const createdDraft = await createTestSubmission2(server)
+
+        const formData = latestFormData(createdDraft)
+
+        formData.stateCode = 'CA'
+        formData.stateNumber = 9999999
+        formData.createdAt = new Date(2021)
+        formData.updatedAt = new Date(2021)
+
+        const b64 = domainToBase64(formData)
+
+        const updateResult = await server.executeOperation({
+            query: UPDATE_HEALTH_PLAN_FORM_DATA,
+            variables: {
+                input: {
+                    submissionID: createdDraft.id,
+                    healthPlanFormData: b64,
+                },
+            },
+        })
+
+        expect(updateResult.errors).toBeDefined()
+        if (updateResult.errors === undefined) {
+            throw new Error('type narrow')
+        }
+
+        expect(updateResult.errors[0].extensions?.code).toBe('BAD_USER_INPUT')
+        expect(updateResult.errors[0].message).toBe(
+            'Attempted to modify un-modifiable field(s): stateCode,stateNumber,createdAt,updatedAt'
+        )
+    })
+})

--- a/services/app-api/resolvers/updateHealthPlanFormData.ts
+++ b/services/app-api/resolvers/updateHealthPlanFormData.ts
@@ -1,0 +1,213 @@
+import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
+import {
+    DraftSubmissionType,
+    isStateUser,
+    Submission2Type,
+    submissionStatus,
+} from '../../app-web/src/common-code/domain-models'
+import {
+    base64ToDomain,
+    toDomain,
+} from '../../app-web/src/common-code/proto/stateSubmission'
+import { MutationResolvers } from '../gen/gqlServer'
+import { logError, logSuccess } from '../logger'
+import { isStoreError, Store } from '../postgres'
+import {
+    setErrorAttributesOnActiveSpan,
+    setResolverDetailsOnActiveSpan,
+    setSuccessAttributesOnActiveSpan,
+} from './attributeHelper'
+
+export function updateHealthPlanFormDataResolver(
+    store: Store
+): MutationResolvers['updateHealthPlanFormData'] {
+    return async (_parent, { input }, context) => {
+        const { user, span } = context
+        setResolverDetailsOnActiveSpan('updateHealthPlanFormData', user, span)
+
+        // This resolver is only callable by state users
+        if (!isStateUser(context.user)) {
+            logError(
+                'updateHealthPlanFormData',
+                'user not authorized to modify state data'
+            )
+            setErrorAttributesOnActiveSpan(
+                'user not authorized to modify state data',
+                span
+            )
+            throw new ForbiddenError('user not authorized to modify state data')
+        }
+
+        const formDataResult = base64ToDomain(input.healthPlanFormData)
+        if (formDataResult instanceof Error) {
+            const errMessage =
+                `Failed to parse out form data in request: ${input.submissionID}  ` +
+                formDataResult.message
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'healthPlanFormData',
+            })
+        }
+
+        // don't send a StateSubmission to the update endpoint
+        if (formDataResult.status === 'SUBMITTED') {
+            const errMessage = `Attempted to update with a StateSubmission: ${input.submissionID}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'healthPlanFormData',
+            })
+        }
+
+        const unlockedFormData: DraftSubmissionType = formDataResult
+        const result = await store.findSubmissionWithRevisions(
+            input.submissionID
+        )
+
+        if (isStoreError(result)) {
+            console.log('Error finding a submission', result)
+            const errMessage = `Issue finding a draft submission of type ${result.code}. Message: ${result.message}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new Error(errMessage)
+        }
+
+        if (result === undefined) {
+            const errMessage = `No submission found to update with that ID: ${input.submissionID}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'submissionID',
+            })
+        }
+
+        const planPackage: Submission2Type = result
+
+        // Authorize the update
+        const stateFromCurrentUser = context.user.state_code
+        if (planPackage.stateCode !== stateFromCurrentUser) {
+            logError(
+                'updateHealthPlanFormData',
+                'user not authorized to fetch data from a different state'
+            )
+            setErrorAttributesOnActiveSpan(
+                'user not authorized to fetch data from a different state',
+                span
+            )
+            throw new ForbiddenError(
+                'user not authorized to fetch data from a different state'
+            )
+        }
+
+        // Check the package is in an updateable state
+        const planPackageStatus = submissionStatus(planPackage)
+        if (planPackageStatus instanceof Error) {
+            const errMessage = `No revisions found on submission: ${input.submissionID}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new Error(errMessage)
+        }
+
+        // Can't update a submission that is locked or resubmitted
+        if (!['DRAFT', 'UNLOCKED'].includes(planPackageStatus)) {
+            const errMessage = `Submission is not in editable state: ${input.submissionID} status: ${submissionStatus}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'submissionID',
+            })
+        }
+
+        // Validate input against the db.
+        // Having to crack this open to check on this is probably an indication that some of this info
+        // really belongs on the Submission2 itself instead of being inside form data, but this is where we are now.
+
+        const previousFormDataResult = toDomain(
+            planPackage.revisions[0].submissionFormProto
+        )
+        if (previousFormDataResult instanceof Error) {
+            const errMessage = `Issue deserializing old formData ${previousFormDataResult.message}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new Error(errMessage)
+        }
+
+        // Sanity check, Can't update a submission that is locked or resubmitted in the form data either
+        if (previousFormDataResult.status === 'SUBMITTED') {
+            const errMessage = `Submission form data is not in editable state: ${input.submissionID}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: 'submissionID',
+            })
+        }
+
+        const previousFormData: DraftSubmissionType = previousFormDataResult
+
+        // Validate that none of these protected fields have been modified.
+        // These fields should only be modified by the server, never by an update.
+        const fixedFields: (keyof DraftSubmissionType)[] = [
+            'id',
+            'stateCode',
+            'stateNumber',
+            'createdAt',
+            'updatedAt',
+        ]
+        const unfixedFields = []
+        for (const fixedField of fixedFields) {
+            console.log(
+                `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
+            )
+            const prevVal = previousFormData[fixedField]
+            const newVal = unlockedFormData[fixedField]
+
+            if (prevVal instanceof Date && newVal instanceof Date) {
+                if (prevVal.getTime() !== newVal.getTime()) {
+                    unfixedFields.push(fixedField)
+                }
+            } else {
+                if (
+                    previousFormData[fixedField] !==
+                    unlockedFormData[fixedField]
+                ) {
+                    unfixedFields.push(fixedField)
+                }
+            }
+        }
+
+        if (unfixedFields.length !== 0) {
+            const errMessage = `Attempted to modify un-modifiable field(s): ${unfixedFields.join(
+                ','
+            )}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new UserInputError(errMessage, {
+                argumentName: unfixedFields.join(','),
+            })
+        }
+
+        const editableRevision = planPackage.revisions[0]
+
+        // save the new form data to the db
+        const updateResult = await store.updateFormData(
+            planPackage.id,
+            editableRevision.id,
+            unlockedFormData
+        )
+
+        if (isStoreError(updateResult)) {
+            const errMessage = `Error updating form data: ${input.submissionID}:: ${updateResult.code}: ${updateResult.message}`
+            logError('updateHealthPlanFormData', errMessage)
+            setErrorAttributesOnActiveSpan(errMessage, span)
+            throw new Error(errMessage)
+        }
+
+        logSuccess('updateHealthPlanFormData')
+        setSuccessAttributesOnActiveSpan(span)
+
+        return {
+            submission: updateResult,
+        }
+    }
+}

--- a/services/app-api/resolvers/updateHealthPlanFormData.ts
+++ b/services/app-api/resolvers/updateHealthPlanFormData.ts
@@ -111,7 +111,7 @@ export function updateHealthPlanFormDataResolver(
 
         // Can't update a submission that is locked or resubmitted
         if (!['DRAFT', 'UNLOCKED'].includes(planPackageStatus)) {
-            const errMessage = `Submission is not in editable state: ${input.submissionID} status: ${submissionStatus}`
+            const errMessage = `Submission is not in editable state: ${input.submissionID} status: ${planPackageStatus}`
             logError('updateHealthPlanFormData', errMessage)
             setErrorAttributesOnActiveSpan(errMessage, span)
             throw new UserInputError(errMessage, {

--- a/services/app-api/testHelpers/healthPlanPackageHelpers.ts
+++ b/services/app-api/testHelpers/healthPlanPackageHelpers.ts
@@ -1,0 +1,18 @@
+import { SubmissionUnionType } from '../../app-web/src/common-code/domain-models'
+import { base64ToDomain } from '../../app-web/src/common-code/proto/stateSubmission'
+import { Submission2 } from '../gen/gqlServer'
+// returns the latest form data for this submission, will throw an error if unwrapping fails
+// hence, this function is meant for making clean tests, not for business logic.
+export function latestFormData(pkg: Submission2): SubmissionUnionType {
+    const latestRevision = pkg.revisions[0].revision
+    if (!latestRevision) {
+        throw new Error('no revisions found for package' + pkg.id)
+    }
+
+    const unwrapResult = base64ToDomain(latestRevision.submissionData)
+    if (unwrapResult instanceof Error) {
+        throw unwrapResult
+    }
+
+    return unwrapResult
+}

--- a/services/app-api/testHelpers/storeHelpers.ts
+++ b/services/app-api/testHelpers/storeHelpers.ts
@@ -34,39 +34,42 @@ async function sharedTestPrismaClient(): Promise<PrismaClient> {
 function mockStoreThatErrors(): Store {
     const genericStoreError: StoreError = {
         code: 'UNEXPECTED_EXCEPTION',
-        message: 'this error came from the generic store with errors mock'
+        message: 'this error came from the generic store with errors mock',
     }
 
     return {
-        findAllSubmissions: async (stateCode) => {
+        findAllSubmissions: async (_stateCode) => {
             return genericStoreError
         },
-        findAllSubmissionsWithRevisions: async (stateCode) => {
+        findAllSubmissionsWithRevisions: async (_stateCode) => {
             return genericStoreError
         },
-        insertDraftSubmission: async (args) => {
+        insertDraftSubmission: async (_args) => {
             return genericStoreError
         },
-        findDraftSubmission: async (draftUUID) => {
+        findDraftSubmission: async (_draftUUID) => {
             return genericStoreError
         },
-        findSubmissionWithRevisions: async (draftUUID) => {
+        findSubmissionWithRevisions: async (_draftUUID) => {
             return genericStoreError
         },
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         findDraftSubmissionByStateNumber: async (_stateCode, _stateNumber) => {
             throw new Error('UNIMPLEMENTED')
         },
-        updateDraftSubmission: async (draftSubmission) => {
+        updateDraftSubmission: async (_draftSubmission) => {
             return genericStoreError
         },
-        updateStateSubmission: async (submission) => {
+        updateStateSubmission: async (_submission) => {
             return genericStoreError
         },
-        findStateSubmission: async (submissionID) => {
+        findStateSubmission: async (_submissionID) => {
             return genericStoreError
         },
-        insertNewRevision: async (submissionID, draft) => {
+        insertNewRevision: async (_submissionID, _draft) => {
+            return genericStoreError
+        },
+        updateFormData: async (_submissionID, _formData) => {
             return genericStoreError
         },
         findPrograms: () => {

--- a/services/app-graphql/src/mutations/createSubmission2.graphql
+++ b/services/app-graphql/src/mutations/createSubmission2.graphql
@@ -1,0 +1,35 @@
+mutation createSubmission2($input: CreateSubmission2Input!) {
+    createSubmission2(input: $input) {
+        submission {
+            id
+            stateCode
+            state {
+                code
+                name
+                programs {
+                    id
+                    name
+                }
+            }
+            status
+            intiallySubmittedAt
+            revisions {
+                revision {
+                    id
+                    unlockInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    submitInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    createdAt
+                    submissionData
+                }
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/mutations/updateHealthPlanFormData.graphql
+++ b/services/app-graphql/src/mutations/updateHealthPlanFormData.graphql
@@ -1,0 +1,35 @@
+mutation updateHealthPlanFormData($input: UpdateHealthPlanFormDataInput!) {
+    updateHealthPlanFormData(input: $input) {
+        submission {
+            id
+            stateCode
+            state {
+                code
+                name
+                programs {
+                    id
+                    name
+                }
+            }
+            status
+            intiallySubmittedAt
+            revisions {
+                revision {
+                    id
+                    unlockInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    submitInfo {
+                        updatedAt
+                        updatedBy
+                        updatedReason
+                    }
+                    createdAt
+                    submissionData
+                }
+            }
+        }
+    }
+}

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -32,6 +32,11 @@ type Mutation {
     unlockStateSubmission(
         input: UnlockStateSubmissionInput!
     ): UnlockStateSubmissionPayload!
+
+    # new API
+    createSubmission2(
+        input: CreateSubmission2Input!
+    ): CreateSubmission2Payload!
 }
 
 input CreateDraftSubmissionInput {
@@ -42,6 +47,16 @@ input CreateDraftSubmissionInput {
 
 type CreateDraftSubmissionPayload {
     draftSubmission: DraftSubmission!
+}
+
+input CreateSubmission2Input {
+    programIDs: [ID!]!
+    submissionType: SubmissionType!
+    submissionDescription: String!
+}
+
+type CreateSubmission2Payload {
+    submission: Submission2!
 }
 
 input FetchDraftSubmissionInput {

--- a/services/app-graphql/src/schema.graphql
+++ b/services/app-graphql/src/schema.graphql
@@ -37,6 +37,9 @@ type Mutation {
     createSubmission2(
         input: CreateSubmission2Input!
     ): CreateSubmission2Payload!
+    updateHealthPlanFormData(
+        input: UpdateHealthPlanFormDataInput!
+    ): UpdateHealthPlanFormDataPayload!
 }
 
 input CreateDraftSubmissionInput {
@@ -124,6 +127,15 @@ input UnlockStateSubmissionInput {
 }
 
 type UnlockStateSubmissionPayload {
+    submission: Submission2!
+}
+
+input UpdateHealthPlanFormDataInput {
+    submissionID: ID!
+    healthPlanFormData: String!
+}
+
+type UpdateHealthPlanFormDataPayload {
     submission: Submission2!
 }
 

--- a/services/app-web/.eslintrc
+++ b/services/app-web/.eslintrc
@@ -25,7 +25,9 @@
         "no-throw-literal": "error",
         "jest/no-focused-tests": "error",
         "jest/no-identical-title": "error",
-        "@typescript-eslint/no-floating-promises": "error"
+        "@typescript-eslint/no-floating-promises": "error",
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_*" }]
     },
     "overrides": [
         {

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -172,36 +172,5 @@ describe('Header', () => {
             await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
             await waitFor(() => expect(mockAlert).toHaveBeenCalled())
         })
-
-        it('shows signin link when logout is successful', async () => {
-            const spy = jest
-                .spyOn(CognitoAuthApi, 'signOut')
-                .mockResolvedValue(null)
-
-            renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({ statusCode: 200 }),
-                        fetchCurrentUserMock({ statusCode: 403 }),
-                    ],
-                },
-            })
-
-            await waitFor(() => {
-                const signOutButton = screen.getByRole('button', {
-                    name: /Sign out/i,
-                })
-
-                expect(signOutButton).toBeInTheDocument()
-                userEvent.click(signOutButton)
-            })
-
-            await waitFor(() => {
-                expect(spy).toHaveBeenCalledTimes(1)
-                expect(
-                    screen.getByRole('link', { name: /Sign In/i })
-                ).toBeVisible()
-            })
-        })
     })
 })

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -36,22 +36,18 @@ export const Header = ({
             return
         }
 
-        logout()
-            .then(() => {
-                history.push('/')
-            })
-            .catch((e) => {
-                console.log('Error with logout: ', e)
-                setAlert &&
-                    setAlert(
-                        <Alert
-                            data-testid="Error400"
-                            style={{ width: '600px', marginBottom: '5px' }}
-                            type="error"
-                            heading="Oops! Something went wrong"
-                        />
-                    )
-            })
+        logout().catch((e) => {
+            console.log('Error with logout: ', e)
+            setAlert &&
+                setAlert(
+                    <Alert
+                        data-testid="Error400"
+                        style={{ width: '600px', marginBottom: '5px' }}
+                        type="error"
+                        heading="Oops! Something went wrong"
+                    />
+                )
+        })
     }
 
     return (

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -11,9 +11,6 @@ import styles from './Header.module.scss'
 import { PageHeadingRow } from './PageHeadingRow/PageHeadingRow'
 import { UserLoginInfo } from './UserLoginInfo/UserLoginInfo'
 
-
-
-
 export type HeaderProps = {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
@@ -39,19 +36,22 @@ export const Header = ({
             return
         }
 
-        logout().catch((e) => {
-            console.log('Error with logout: ', e)
-            setAlert &&
-                setAlert(
-                    <Alert
-                        data-testid="Error400"
-                        style={{ width: '600px', marginBottom: '5px' }}
-                        type="error"
-                        heading="Oops! Something went wrong"
-                    />
-                )
-        })
-        history.push('/')
+        logout()
+            .then(() => {
+                history.push('/')
+            })
+            .catch((e) => {
+                console.log('Error with logout: ', e)
+                setAlert &&
+                    setAlert(
+                        <Alert
+                            data-testid="Error400"
+                            style={{ width: '600px', marginBottom: '5px' }}
+                            type="error"
+                            heading="Oops! Something went wrong"
+                        />
+                    )
+            })
     }
 
     return (

--- a/services/app-web/src/contexts/AuthContext.tsx
+++ b/services/app-web/src/contexts/AuthContext.tsx
@@ -4,7 +4,6 @@ import { useFetchCurrentUserQuery, User as UserType } from '../gen/gqlClient'
 import { logoutLocalUser } from '../localAuth'
 import { signOut as cognitoSignOut } from '../pages/Auth/cognitoAuth'
 
-
 type LogoutFn = () => Promise<null>
 
 export type LoginStatusType = 'LOADING' | 'LOGGED_OUT' | 'LOGGED_IN'
@@ -98,23 +97,12 @@ function AuthProvider({
         loggedInUser === undefined
             ? undefined
             : () => {
-                  return new Promise<void>((resolve, reject) => {
+                  return new Promise<void>((_resolve, reject) => {
                       realLogout()
                           .then(() => {
-                              refetch()
-                                  .then(() => {
-                                      // this would actually be unexpected.
-                                      console.log("Error: We fetched CurrentUser after logout")
-                                      reject(
-                                          new Error(
-                                              "Logout somehow didn't trigger a 403"
-                                          )
-                                      )
-                                  })
-                                  .catch(() => {
-                                      // we expect this to 403, but that's all the logout caller is waiting on
-                                      resolve()
-                                  })
+                              // Hard navigate back to /
+                              // this is more like how things work with IDM anyway.
+                              window.location.href = '/'
                           })
                           .catch((e) => {
                               console.log('Logout Failed.', e)

--- a/services/app-web/src/pages/StateSubmission/New/NewStateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/New/NewStateSubmissionForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { screen } from '@testing-library/react'
 
 import { fetchCurrentUserMock } from '../../../testHelpers/apolloHelpers'
@@ -16,10 +15,9 @@ describe('NewStateSubmissionForm', () => {
             },
             routerProvider: { route: '/submissions/new' },
         })
-  
+
         expect(
             screen.getByRole('form', { name: 'New Submission Form' })
         ).toBeInTheDocument()
-
     })
 })

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -269,6 +269,10 @@ export const StateSubmissionForm = (): React.ReactElement => {
     }
 
     if ((updateError || updateFormDataError) && !showPageErrorMessage) {
+        // This triggers if Apollo sets the error from our useQuery invocation
+        // we should already be setting this in our try {} block in the actual update handler, I think
+        // so this might be worth looking into.
+        console.log('Apollo Error reported: ', updateError, updateFormDataError)
         setShowPageErrorMessage(true)
     }
 

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -34,6 +34,8 @@ import {
     useUpdateDraftSubmissionMutation,
     useFetchSubmission2Query,
     User,
+    useUpdateHealthPlanFormDataMutation,
+    Submission2,
 } from '../../gen/gqlClient'
 import { SubmissionUnlockedBanner } from '../../components/Banner'
 import { UpdateInfoType } from '../../common-code/domain-models/Submission2Type'
@@ -43,10 +45,7 @@ import {
     DraftSubmissionType,
     submissionName,
 } from '../../common-code/domain-models'
-import {
-    cleanDraftSubmission,
-    updatesFromSubmission,
-} from './updateSubmissionTransform'
+import { domainToBase64 } from '../../common-code/proto/stateSubmission'
 
 const FormAlert = ({ message }: { message?: string }): React.ReactElement => {
     return message ? (
@@ -137,6 +136,8 @@ export const StateSubmissionForm = (): React.ReactElement => {
     const submissionAndRevisions = fetchData?.fetchSubmission2?.submission
     const [updateDraftSubmission, { error: updateError }] =
         useUpdateDraftSubmissionMutation()
+    const [updateFormData, { error: updateFormDataError }] =
+        useUpdateHealthPlanFormDataMutation()
 
     const updateDraft = async (
         input: UpdateDraftSubmissionInput
@@ -167,23 +168,16 @@ export const StateSubmissionForm = (): React.ReactElement => {
     // When the new API is done, we'll call the new API here
     const updateDraftSubmission2 = async (
         input: DraftSubmissionType
-    ): Promise<undefined | Error> => {
-        // convert to GQL DraftSubmissionUpdates type
-
-        const draft = convertDomainModelFormDataToGQLSubmission(
-            input,
-            statePrograms
-        ) as DraftSubmission
-        const updatedDraft = updatesFromSubmission(draft)
-        const cleanSubmission = cleanDraftSubmission(updatedDraft)
+    ): Promise<Submission2 | Error> => {
+        const base64Draft = domainToBase64(input)
 
         setShowPageErrorMessage(false)
         try {
-            const updateResult = await updateDraftSubmission({
+            const updateResult = await updateFormData({
                 variables: {
                     input: {
                         submissionID: input.id,
-                        draftSubmissionUpdates: cleanSubmission,
+                        healthPlanFormData: base64Draft,
                     },
                 },
                 update(cache) {
@@ -191,12 +185,15 @@ export const StateSubmissionForm = (): React.ReactElement => {
                     cache.gc()
                 },
             })
-            const updatedSubmission: DraftSubmission | undefined =
-                updateResult?.data?.updateDraftSubmission.draftSubmission
+            const updatedSubmission: Submission2 | undefined =
+                updateResult?.data?.updateHealthPlanFormData.submission
 
-            if (!updatedSubmission) setShowPageErrorMessage(true)
+            if (!updatedSubmission) {
+                setShowPageErrorMessage(true)
+                return new Error('Failed to update form data')
+            }
 
-            return undefined
+            return updatedSubmission
         } catch (serverError) {
             setShowPageErrorMessage(true)
             return serverError
@@ -271,7 +268,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
         )
     }
 
-    if (updateError && !showPageErrorMessage) {
+    if ((updateError || updateFormDataError) && !showPageErrorMessage) {
         setShowPageErrorMessage(true)
     }
 

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -20,10 +20,10 @@ import { SubmissionTypeRecord } from '../../../constants/submissions'
 import { useAuth } from '../../../contexts/AuthContext'
 import {
     CreateDraftSubmissionInput,
-    DraftSubmission,
     Program,
+    Submission2,
     SubmissionType as SubmissionTypeT,
-    useCreateDraftSubmissionMutation,
+    useCreateSubmission2Mutation,
 } from '../../../gen/gqlClient'
 import { PageActions } from '../PageActions'
 import styles from '../StateSubmissionForm.module.scss'
@@ -47,7 +47,7 @@ export interface SubmissionTypeFormValues {
 type SubmissionTypeProps = {
     showValidations?: boolean
     draftSubmission?: DraftSubmissionType
-    updateDraft?: (input: DraftSubmissionType) => Promise<undefined | Error>
+    updateDraft?: (input: DraftSubmissionType) => Promise<Submission2 | Error>
     formAlert?: React.ReactElement
 }
 
@@ -93,23 +93,21 @@ export const SubmissionType = ({
         return msg
     }
 
-    const [createDraftSubmission, { error }] = useCreateDraftSubmissionMutation(
-        {
-            // An alternative to messing with the cache like we do with create, just zero it out.
-            update(cache, { data }) {
-                if (data) {
-                    cache.modify({
-                        id: 'ROOT_QUERY',
-                        fields: {
-                            indexSubmissions2(_index, { DELETE }) {
-                                return DELETE
-                            },
+    const [createDraftSubmission, { error }] = useCreateSubmission2Mutation({
+        // An alternative to messing with the cache like we do with create, just zero it out.
+        update(cache, { data }) {
+            if (data) {
+                cache.modify({
+                    id: 'ROOT_QUERY',
+                    fields: {
+                        indexSubmissions2(_index, { DELETE }) {
+                            return DELETE
                         },
-                    })
-                }
-            },
-        }
-    )
+                    },
+                })
+            }
+        },
+    })
 
     useEffect(() => {
         // Focus the error summary heading only if we are displaying
@@ -162,8 +160,8 @@ export const SubmissionType = ({
                     variables: { input },
                 })
 
-                const draftSubmission: DraftSubmission | undefined =
-                    result?.data?.createDraftSubmission.draftSubmission
+                const draftSubmission: Submission2 | undefined =
+                    result?.data?.createSubmission2.submission
 
                 if (draftSubmission) {
                     history.push(
@@ -251,7 +249,7 @@ export const SubmissionType = ({
                                 <Field name="programIDs">
                                     {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                                     {/* @ts-ignore */}
-                                    {({ _field, form }) => (
+                                    {({ form }) => (
                                         <Select
                                             defaultValue={values.programIDs.map(
                                                 (programID) => {

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -73,7 +73,7 @@ describe('dashboard', () => {
                 cy.logInAsStateUser()
 
                 // State user sees unlocked submission - check tag then submission link
-                cy.findByText('Dashboard').should('exist')
+                cy.findByText('Submissions').should('exist')
                 cy.get('table')
                     .should('exist')
                     .findByText(submissionName)

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -19,7 +19,7 @@ describe('submission type', () => {
             cy.visit(`/submissions/${draftSubmissionId}/type`)
 
             // Navigate to contract details page by clicking continue for contract only submission
-            cy.navigateForm('CONTINUE')
+            cy.navigateForm('CONTINUE_WITH_NEW_UPDATE')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
         })
     })
@@ -38,7 +38,7 @@ describe('submission type', () => {
             cy.findByText('Contract action and rate certification').click()
 
             // Navigate to contract details page by clicking continue for contract and rates submission
-            cy.navigateForm('CONTINUE')
+            cy.navigateForm('CONTINUE_WITH_NEW_UPDATE')
             cy.findByRole('heading', { level: 2, name: /Contract details/ })
 
             // Navigate to type page

--- a/tests/cypress/support/index.ts
+++ b/tests/cypress/support/index.ts
@@ -14,7 +14,7 @@ import './commands'
 import './loginCommands'
 import './stateSubmissionFormCommands'
 import './submissionCommands'
-type FormButtonKey = 'CONTINUE_FROM_START_NEW' | 'CONTINUE' | 'SAVE_DRAFT' | 'BACK' 
+type FormButtonKey = 'CONTINUE_FROM_START_NEW' | 'CONTINUE_WITH_NEW_UPDATE' | 'CONTINUE' | 'SAVE_DRAFT' | 'BACK' 
 
 declare global {
     namespace Cypress {

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -220,10 +220,11 @@ Cypress.Commands.add('submitStateSubmissionForm', (success = true, resubmission 
     }
 })
 
-type FormButtonKey =  'CONTINUE_FROM_START_NEW'| 'CONTINUE' | 'SAVE_DRAFT' | 'BACK'
+type FormButtonKey =  'CONTINUE_FROM_START_NEW' | 'CONTINUE_WITH_NEW_UPDATE' | 'CONTINUE' | 'SAVE_DRAFT' | 'BACK'
 type FormButtons = { [key in FormButtonKey]: string }
 const buttonsWithLabels: FormButtons = {
     CONTINUE: 'Continue',
+    CONTINUE_WITH_NEW_UPDATE: 'Continue',
     CONTINUE_FROM_START_NEW: 'Continue',
     SAVE_DRAFT: 'Save as draft',
     BACK: 'Back',
@@ -236,6 +237,7 @@ Cypress.Commands.add(
             aliasQuery(req, 'indexSubmissions2')
             aliasQuery(req, 'fetchSubmission2')
             aliasMutation(req, 'createSubmission2')
+            aliasMutation(req, 'updateDraftSubmission')
             aliasMutation(req, 'updateHealthPlanFormData')
         })
 
@@ -256,6 +258,12 @@ Cypress.Commands.add(
                 'exist'
             ) 
         } else if (buttonKey === 'CONTINUE'){
+            if (waitForLoad){
+                cy.wait('@updateDraftSubmissionMutation')
+                cy.wait('@fetchSubmission2Query')
+            }
+            cy.findByTestId('state-submission-form-page').should('exist')
+        } else if (buttonKey === 'CONTINUE_WITH_NEW_UPDATE'){
             if (waitForLoad){
                 cy.wait('@updateHealthPlanFormDataMutation')
                 cy.wait('@fetchSubmission2Query')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -236,7 +236,7 @@ Cypress.Commands.add(
             aliasQuery(req, 'indexSubmissions2')
             aliasQuery(req, 'fetchSubmission2')
             aliasMutation(req, 'createSubmission2')
-            aliasMutation(req, 'updateDraftSubmission')
+            aliasMutation(req, 'updateHealthPlanFormData')
         })
 
         cy.findByRole('button', {
@@ -257,7 +257,7 @@ Cypress.Commands.add(
             ) 
         } else if (buttonKey === 'CONTINUE'){
             if (waitForLoad){
-                cy.wait('@updateDraftSubmissionMutation')
+                cy.wait('@updateHealthPlanFormDataMutation')
                 cy.wait('@fetchSubmission2Query')
             }
             cy.findByTestId('state-submission-form-page').should('exist')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -235,7 +235,7 @@ Cypress.Commands.add(
         cy.intercept('POST', '*/graphql', (req) => {
             aliasQuery(req, 'indexSubmissions2')
             aliasQuery(req, 'fetchSubmission2')
-            aliasMutation(req, 'createDraftSubmission')
+            aliasMutation(req, 'createSubmission2')
             aliasMutation(req, 'updateDraftSubmission')
         })
 
@@ -249,7 +249,7 @@ Cypress.Commands.add(
 
         } else if (buttonKey === 'CONTINUE_FROM_START_NEW') {
                  if (waitForLoad){
-                    cy.wait('@createDraftSubmissionMutation', { timeout: 50000 })
+                    cy.wait('@createSubmission2Mutation', { timeout: 50000 })
                     cy.wait('@fetchSubmission2Query')
                  }
             cy.findByTestId('state-submission-form-page').should(


### PR DESCRIPTION
## Summary
This is the api side of the work for moving away from the updateDraftSubmission endpoint

#### Related issues
https://qmacbis.atlassian.net/browse/MR-858
https://qmacbis.atlassian.net/browse/MR-856

#### Test cases covered

I added tests for all the errors we can see in the API, I think. 

## QA guidance

I haven’t touched the frontend code yet, I am worried I broke something. 
