### PR TITLE
MR-2082: Update dates on submission summary page and previous submission versions

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -91,7 +91,7 @@ describe('SubmissionTypeSummarySection', () => {
             screen.queryByRole('definition', { name: 'Submitted' })
         ).toBeInTheDocument()
     })
-    it('does not render Last Updated field', () => {
+    it('does not render Last Updated and Submitted at fields', () => {
         renderWithProviders(
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
@@ -101,6 +101,9 @@ describe('SubmissionTypeSummarySection', () => {
         )
         expect(
             screen.queryByRole('definition', { name: 'Last updated' })
+        ).not.toBeInTheDocument()
+        expect(
+            screen.queryByRole('definition', { name: 'Submitted' })
         ).not.toBeInTheDocument()
     })
     it('renders headerChildComponent component', () => {

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -85,13 +85,10 @@ describe('SubmissionTypeSummarySection', () => {
             screen.getByRole('definition', { name: 'Submission description' })
         ).toBeInTheDocument()
         expect(
-            screen.queryByRole('definition', { name: 'Last updated' })
-        ).toBeInTheDocument()
-        expect(
             screen.queryByRole('definition', { name: 'Submitted' })
         ).toBeInTheDocument()
     })
-    it('does not render Last Updated and Submitted at fields', () => {
+    it('does not render Submitted at field', () => {
         renderWithProviders(
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
@@ -99,9 +96,6 @@ describe('SubmissionTypeSummarySection', () => {
                 navigateTo="submission-type"
             />
         )
-        expect(
-            screen.queryByRole('definition', { name: 'Last updated' })
-        ).not.toBeInTheDocument()
         expect(
             screen.queryByRole('definition', { name: 'Submitted' })
         ).not.toBeInTheDocument()

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -15,6 +15,7 @@ export type SubmissionTypeSummarySectionProps = {
     statePrograms: ProgramT[]
     navigateTo?: string
     headerChildComponent?: React.ReactElement
+    intiallySubmittedAt?: Date
 }
 
 export const SubmissionTypeSummarySection = ({
@@ -22,6 +23,7 @@ export const SubmissionTypeSummarySection = ({
     statePrograms,
     navigateTo,
     headerChildComponent,
+    intiallySubmittedAt,
 }: SubmissionTypeSummarySectionProps): React.ReactElement => {
     const isPreviousSubmission = usePreviousSubmission()
     const programNames = statePrograms
@@ -46,7 +48,7 @@ export const SubmissionTypeSummarySection = ({
                             label="Submitted"
                             data={
                                 <span>
-                                    {dayjs(submission.submittedAt).format(
+                                    {dayjs(intiallySubmittedAt).format(
                                         'MM/DD/YY'
                                     )}
                                 </span>

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -54,17 +54,7 @@ export const SubmissionTypeSummarySection = ({
                                 </span>
                             }
                         />
-                        <DataDetail
-                            id="lastUpdated"
-                            label="Last updated"
-                            data={
-                                <span>
-                                    {dayjs(submission.updatedAt).format(
-                                        'MM/DD/YY'
-                                    )}
-                                </span>
-                            }
-                        />
+                        <></>
                     </DoubleColumnGrid>
                 )}
                 <DoubleColumnGrid>

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -39,7 +39,7 @@ export const SubmissionTypeSummarySection = ({
             </SectionHeader>
 
             <dl>
-                {isStateSubmission(submission) && (
+                {isStateSubmission(submission) && !isPreviousSubmission && (
                     <DoubleColumnGrid>
                         <DataDetail
                             id="submitted"
@@ -52,21 +52,17 @@ export const SubmissionTypeSummarySection = ({
                                 </span>
                             }
                         />
-                        {!isPreviousSubmission ? (
-                            <DataDetail
-                                id="lastUpdated"
-                                label="Last updated"
-                                data={
-                                    <span>
-                                        {dayjs(submission.updatedAt).format(
-                                            'MM/DD/YY'
-                                        )}
-                                    </span>
-                                }
-                            />
-                        ) : (
-                            <></>
-                        )}
+                        <DataDetail
+                            id="lastUpdated"
+                            label="Last updated"
+                            data={
+                                <span>
+                                    {dayjs(submission.updatedAt).format(
+                                        'MM/DD/YY'
+                                    )}
+                                </span>
+                            }
+                        />
                     </DoubleColumnGrid>
                 )}
                 <DoubleColumnGrid>

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -403,6 +403,9 @@ export const SubmissionSummary = (): React.ReactElement => {
                         ) : undefined
                     }
                     statePrograms={statePrograms}
+                    intiallySubmittedAt={
+                        submissionAndRevisions.intiallySubmittedAt
+                    }
                 />
                 <ContractDetailsSummarySection
                     submission={submission}

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -82,7 +82,6 @@ describe('dashboard', () => {
                 name: `Minnesota ${submissionName}`,
             }).should('exist')
             cy.findByText('Submitted').should('exist')
-            cy.findByText('Last updated').should('exist')
             cy.findByText('Rate details').should('exist')
             cy.findByText('New rate certification').should('exist')
             cy.findByText('02/29/2024 to 02/28/2025').should('exist')

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -17,10 +17,7 @@ describe('review and submit', () => {
             // Navigate to review and submit page
             cy.visit(`/submissions/${draftSubmissionId}/review-and-submit`)
 
-            // Submitted and Last updated dates should not appear
-            // (should only appear on Submission Summary)
             cy.findByText('Submitted').should('not.exist')
-            cy.findByText('Last updated').should('not.exist')
             cy.findByText('Download all contract documents').should('not.exist')
 
             // Navigate to dashboard page by clicking save as draft


### PR DESCRIPTION
## Summary
[MR-2082](https://qmacbis.atlassian.net/browse/MR-2082)
Update dates on submission summary page and previous submission versions
- Remove `Submitted` field from previous submission page
- Changes `Submitted` field to display initial submission date
- Remove `Last Updated` field from submission summary

#### Related issues

#### Screenshots
<img src="https://user-images.githubusercontent.com/98117700/162327834-9f204fc3-fd1c-4ec6-9ef7-c380a863904e.png" width="400" />

<img src="https://user-images.githubusercontent.com/98117700/162327840-5a697be6-92d8-4f62-844c-82df8c1a0fbb.png" width="400" />

#### Test cases covered
- Removed tests for `Last Updated` field.

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
