### PR TITLE
Fix spacing in unlock emails

### DIFF
--- a/services/app-api/emailer/templates.ts
+++ b/services/app-api/emailer/templates.ts
@@ -171,9 +171,10 @@ const unlockPackageCMSEmail = (
     const bodyHTML = `
         ${testEmailAlert}
         <br /><br />
-        Submission ${unlockData.submissionName} was unlocked<br /><br />
-        <b>Unlocked by:</b> ${unlockData.updatedBy}<br /><br />
-        <b>Unlocked on:</b> ${formatCalendarDate(unlockData.updatedAt)}<br /><br />
+        Submission ${unlockData.submissionName} was unlocked<br />
+        <br />
+        <b>Unlocked by:</b> ${unlockData.updatedBy}<br />
+        <b>Unlocked on:</b> ${formatCalendarDate(unlockData.updatedAt)}<br />
         <b>Reason for unlock:</b> ${unlockData.updatedReason}<br /><br />
         You will receive another notification when the state resubmits.
     `
@@ -201,9 +202,10 @@ const unlockPackageStateEmail = (
     const bodyHTML = `
         ${testEmailAlert}
         <br /><br />
-        Submission ${unlockData.submissionName} was unlocked by CMS<br /><br /> 
-        <b>Unlocked by:</b> ${unlockData.updatedBy}<br /><br />
-        <b>Unlocked on:</b> ${formatCalendarDate(unlockData.updatedAt)}<br /><br />
+        Submission ${unlockData.submissionName} was unlocked by CMS<br />
+        <br />
+        <b>Unlocked by:</b> ${unlockData.updatedBy}<br />
+        <b>Unlocked on:</b> ${formatCalendarDate(unlockData.updatedAt)}<br />
         <b>Reason for unlock:</b> ${unlockData.updatedReason}<br /><br />
         <a href="${submissionURL}">Open the submission in MC-Review to make edits.</a>
     `


### PR DESCRIPTION
Fix spacing in unlock emails.

**Before**
<img width="975" alt="Screen Shot 2022-04-11 at 11 11 36 AM" src="https://user-images.githubusercontent.com/4196834/162770465-3da9d3bc-3a17-4f81-b1ad-74f057f124b5.png">


**After**
<img width="999" alt="Screen Shot 2022-04-11 at 11 11 04 AM" src="https://user-images.githubusercontent.com/4196834/162770330-b2752a3e-0e11-4fc5-b3d4-4a060da8d1c7.png">

