### PR TITLE
Add more encryption policies

### DIFF
--- a/services/storybook/serverless.yml
+++ b/services/storybook/serverless.yml
@@ -68,6 +68,16 @@ resources:
                   Fn::GetAtt:
                     - CloudFrontOriginAccessIdentity
                     - S3CanonicalUserId
+            - Effect: Deny
+              Action:
+                - 's3:GetObject'
+                - 's3:PutObject'
+              Principal: '*'
+              Condition:
+                Bool:
+                  'aws:SecureTransport': false
+              Resource: !Sub ${S3Bucket.Arn}/*
+              Sid: DenyUnencryptedConnections
         Bucket: !Ref S3Bucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -65,6 +65,16 @@ resources:
               Resource: !Sub arn:aws:s3:::${S3Bucket}/*
               Principal:
                 CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+            - Effect: Deny
+              Action:
+                - 's3:GetObject'
+                - 's3:PutObject'
+              Principal: '*'
+              Condition:
+                Bool:
+                  'aws:SecureTransport': false
+              Resource: !Sub ${S3Bucket.Arn}/*
+              Sid: DenyUnencryptedConnections
         Bucket: !Ref S3Bucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -166,6 +166,16 @@ resources:
                 - !Sub ${DocumentUploadsBucket.Arn}/*.xls
                 - !Sub ${DocumentUploadsBucket.Arn}/*.xlsx
                 - !Sub ${DocumentUploadsBucket.Arn}/*.zip
+            - Effect: Deny
+              Action:
+                - 's3:GetObject'
+                - 's3:PutObject'
+              Principal: '*'
+              Condition:
+                Bool:
+                  'aws:SecureTransport': false
+              Resource: !Sub ${DocumentUploadsBucket.Arn}/*
+              Sid: DenyUnencryptedConnections
 
     LambdaInvokePermission:
       Type: AWS::Lambda::Permission
@@ -175,6 +185,7 @@ resources:
         Principal: s3.amazonaws.com
         SourceAccount: !Sub ${AWS::AccountId}
         SourceArn: !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-uploads-${AWS::AccountId}
+
     ClamDefsBucket:
       Type: AWS::S3::Bucket
       Properties:
@@ -184,6 +195,22 @@ resources:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
         AccessControl: Private
+    ClamsDefsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref ClamDefsBucket
+        PolicyDocument:
+          Statement:
+            - Effect: Deny
+              Action:
+                - 's3:GetObject'
+                - 's3:PutObject'
+              Principal: '*'
+              Condition:
+                Bool:
+                  'aws:SecureTransport': false
+              Resource: !Sub ${ClamDefsBucket.Arn}/*
+              Sid: DenyUnencryptedConnections
 
   Outputs:
     DocumentUploadsBucketName:


### PR DESCRIPTION
## Summary
This is a follow on for the s3 bucket security hub findings we have in our environment. This adds a rule that denies unencrypted traffic from our buckets (not that we have any anyways).

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2066
