### PR TITLE
Fix apollo cache usage

### DIFF
--- a/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
+++ b/services/app-web/src/components/ChangeHistory/ChangeHistory.test.tsx
@@ -30,7 +30,7 @@ const submissionData: HealthPlanPackage = {
                     __typename: 'UpdateInformation',
                 },
                 createdAt: '2022-03-25T01:18:44.665Z',
-                submissionData: 'qpoiuenad',
+                formDataProto: 'qpoiuenad',
                 __typename: 'HealthPlanRevision',
             },
             __typename: 'HealthPlanRevisionEdge',
@@ -51,7 +51,7 @@ const submissionData: HealthPlanPackage = {
                     __typename: 'UpdateInformation',
                 },
                 createdAt: '2022-03-24T01:18:44.665Z',
-                submissionData: 'qpoiuenad',
+                formDataProto: 'qpoiuenad',
                 __typename: 'HealthPlanRevision',
             },
             __typename: 'HealthPlanRevisionEdge',
@@ -67,7 +67,7 @@ const submissionData: HealthPlanPackage = {
                     __typename: 'UpdateInformation',
                 },
                 createdAt: '2022-03-23T02:08:14.241Z',
-                submissionData: 'nmzxcv;lasf',
+                formDataProto: 'nmzxcv;lasf',
                 __typename: 'HealthPlanRevision',
             },
             __typename: 'HealthPlanRevisionEdge',
@@ -76,7 +76,7 @@ const submissionData: HealthPlanPackage = {
     __typename: 'HealthPlanPackage',
 }
 
-const submissionDataInitialSubmission: HealthPlanPackage = {
+const formDataProtoInitialSubmission: HealthPlanPackage = {
     id: '440d6a53-bb0a-49ae-9a9c-da7c5352789f',
     stateCode: 'MN',
     state: {
@@ -98,7 +98,7 @@ const submissionDataInitialSubmission: HealthPlanPackage = {
                     __typename: 'UpdateInformation',
                 },
                 createdAt: '2022-03-23T02:08:14.241Z',
-                submissionData: 'nmzxcv;lasf',
+                formDataProto: 'nmzxcv;lasf',
                 __typename: 'HealthPlanRevision',
             },
             __typename: 'HealthPlanRevisionEdge',
@@ -204,7 +204,7 @@ describe('Change History', () => {
         ).toHaveTextContent('View past submission version')
     })
     it('should not list links for initial submission without revisions', () => {
-        render(<ChangeHistory submission={submissionDataInitialSubmission} />)
+        render(<ChangeHistory submission={formDataProtoInitialSubmission} />)
         //Initial submission should not have a link
         expect(
             screen.getByTestId('accordionItem_2022-03-23T02:08:52.259Z')

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -50,21 +50,7 @@ export const ReviewSubmit = ({
             loggedInUser.state.programs) ||
         []
 
-    const [submitDraftSubmission] = useSubmitHealthPlanPackageMutation({
-        // An alternative to messing with the cache like we do with create, just zero it out.
-        update(cache, { data }) {
-            if (data) {
-                cache.modify({
-                    id: 'ROOT_QUERY',
-                    fields: {
-                        indexHealthPlanPackages(_index, { DELETE }) {
-                            return DELETE
-                        },
-                    },
-                })
-            }
-        },
-    })
+    const [submitDraftSubmission] = useSubmitHealthPlanPackageMutation()
 
     const showError = (error: string) => {
         setUserVisibleError(error)

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -148,45 +148,15 @@ export const StateSubmissionForm = (): React.ReactElement => {
                         healthPlanFormData: base64Draft,
                     },
                 },
-                update(cache) {
-                    cache.evict({ id: `HealthPlanPackage:${id}` })
-                    cache.gc()
-                },
             })
             const updatedSubmission: HealthPlanPackage | undefined =
                 updateResult?.data?.updateHealthPlanFormData.pkg
 
             if (!updatedSubmission) {
                 setShowPageErrorMessage(true)
+                console.log('Failed to update form data', updateResult)
                 return new Error('Failed to update form data')
             }
-            // Apollo is letting us load new pages without having finished re-fetching the new data
-            // and isn't updating the cache the way I expected here, so for now, we set our current
-            // revision manually when update returns.
-            const protoResult =
-                getCurrentRevisionFromHealthPlanPackage(updatedSubmission)
-            if (protoResult instanceof Error) {
-                console.log(
-                    'Proto returned by update mutation is invalid',
-                    protoResult
-                )
-                setFormDataError('MALFORMATTED_DATA')
-                return protoResult
-            }
-            const planFormData = protoResult[1]
-
-            if (planFormData.status !== 'DRAFT') {
-                console.log(
-                    'Proto returned by update mutation is wrong state',
-                    protoResult
-                )
-                setFormDataError('WRONG_SUBMISSION_STATUS')
-                return new Error(
-                    'Proto returned by update mutation is wrong state'
-                )
-            }
-
-            setFormDataFromLatestRevision(planFormData)
 
             return updatedSubmission
         } catch (serverError) {

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -199,7 +199,6 @@ Cypress.Commands.add('verifyDocumentsHaveNoErrors', () => {
 Cypress.Commands.add('submitStateSubmissionForm', (success = true, resubmission = false) => {
       cy.intercept('POST', '*/graphql', (req) => {
           aliasMutation(req, 'submitHealthPlanPackage')
-          aliasQuery(req, 'indexHealthPlanPackages')
       })
     cy.findByRole('heading', { level: 2, name: /Review and submit/ })
     cy.findByRole('button', {
@@ -215,9 +214,6 @@ Cypress.Commands.add('submitStateSubmissionForm', (success = true, resubmission 
             cy.findByTestId('review-and-submit-modal-submit').click()
         })
     cy.wait('@submitHealthPlanPackageMutation', { timeout: 50000 })
-    if (success) {
-        cy.wait('@indexHealthPlanPackagesQuery', { timeout: 50000 })
-    }
 })
 
 type FormButtonKey =  'CONTINUE_FROM_START_NEW' | 'CONTINUE' | 'SAVE_DRAFT' | 'BACK'
@@ -244,7 +240,6 @@ Cypress.Commands.add(
         }).safeClick()
 
         if (buttonKey === 'SAVE_DRAFT') {
-            if (waitForLoad) cy.wait('@indexHealthPlanPackagesQuery', { timeout: 20000 })
             cy.findByTestId('dashboard-page').should('exist')
 
         } else if (buttonKey === 'CONTINUE_FROM_START_NEW') {
@@ -258,7 +253,6 @@ Cypress.Commands.add(
         } else if (buttonKey === 'CONTINUE'){
             if (waitForLoad){
                 cy.wait('@updateHealthPlanFormDataMutation')
-                cy.wait('@fetchHealthPlanPackageQuery')
             }
             cy.findByTestId('state-submission-form-page').should('exist')
         } else {


### PR DESCRIPTION
## Summary

After renaming everything, I have cleaned up some of our apollo cache usage to be consistent.

Apollo uses its cache by default to respond to requests if there is data in the cache that matches the query. So, for instance, in our app, moving between different pages of the app doesn’t cause new requests to fetch the HealthPlanPackage every time because useFetchHPPQuery() knows that it is asking for a single record with the given ID and that already exists in the cache. 

That’s quite straightforward for queries, if we’ve queried it before its in the cache and won’t be re-queried, but mutations can modify the actual state of things, so how does that work?

By default, if your mutation return all of the mutated objects, they are inserted into the cache automatically. So, now, with our update, submit, and unlock mutations, we don’t need to configure the calls at all for the cache. those endpoints return the object they modify in full so Apollo puts the new data in the cache. 

The only part that doesn’t work automatically for us is updating the indexHPPQuery. When we create a new package, that individual package is correctly inserted into the cache (though even so, we do re-fetch when the app navigates to the ContractDetails page, I suspect since that query itself hasn’t happened before it always fetches but I don’t know). But even though that single object is in the cache, apollo doesn’t try to be clever enough to update other queries that might reference that new object, so we have to explicitly update the cached indexHPPQuery to include the newly create package. 