### PR TITLE
Add more dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 6
     ignore:
       - dependency-name: '@types/node'
         versions: ['>14.999'] # I think this is how we don't ever go above 14?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 6
+      interval: 'daily'
+    open-pull-requests-limit: 4
     ignore:
       - dependency-name: '@types/node'
         versions: ['>14.999'] # I think this is how we don't ever go above 14?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,3 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         versions: ['>14.999'] # I think this is how we don't ever go above 14?
-
-  - package-ecosystem: 'npm'
-    directory: '/tests/nightwatch'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary

Back when our CI was slower and we weren't using lerna with yarn workspaces, dependabot was causing a lot of noise for us. We decided to limit how often dependabot was checking for updates and limited it to 4 open slots in our PRs. 

We're in a better place now, so this has dependabot checking daily. We can tweak it again if it becomes too noisy.
