### PR TITLE
Test for document delete button with mock

### DIFF
--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -437,7 +437,7 @@ export function mockUnlockedHealthPlanPackage(
         revisions: [
             {
                 node: {
-                    id: 'revision2',
+                    id: 'revision3',
                     createdAt: new Date(),
                     unlockInfo: {
                         updatedAt: new Date(),
@@ -445,6 +445,23 @@ export function mockUnlockedHealthPlanPackage(
                         updatedReason: 'Test unlock reason',
                     },
                     submitInfo: null,
+                    formDataProto: b64,
+                },
+            },
+            {
+                node: {
+                    id: 'revision2',
+                    createdAt: new Date(),
+                    unlockInfo: {
+                        updatedAt: new Date(),
+                        updatedBy: 'bob@dmas.mn.gov',
+                        updatedReason: 'Test unlock reason',
+                    },
+                    submitInfo: {
+                        updatedAt: new Date(),
+                        updatedBy: 'bob@dmas.mn.gov',
+                        updatedReason: 'Second Submit',
+                    },
                     formDataProto: b64,
                 },
             },

--- a/services/app-web/src/testHelpers/jestHelpers.tsx
+++ b/services/app-web/src/testHelpers/jestHelpers.tsx
@@ -15,6 +15,7 @@ import { AuthProvider, AuthProviderProps } from '../contexts/AuthContext'
 import { PageProvider } from '../contexts/PageContext'
 import { S3Provider } from '../contexts/S3Context'
 import { testS3Client } from './s3Helpers'
+import { S3ClientT } from '../s3'
 
 /* Render */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -24,18 +25,22 @@ const renderWithProviders = (
         routerProvider?: { route?: string; routerProps?: RouterProps }
         apolloProvider?: MockedProviderProps
         authProvider?: Partial<AuthProviderProps>
+        s3Provider?: S3ClientT
     }
 ) => {
     const {
         routerProvider = {},
         apolloProvider = {},
         authProvider = {},
+        s3Provider = undefined,
     } = options || {}
 
     const { route, routerProps } = routerProvider
     const testHistory = routerProps?.history
         ? routerProps.history
         : createMemoryHistory()
+
+    const s3Client: S3ClientT = s3Provider ?? testS3Client()
 
     if (route) {
         testHistory.push(route)
@@ -44,7 +49,7 @@ const renderWithProviders = (
         <MockedProvider {...apolloProvider}>
             <Router history={testHistory}>
                 <AuthProvider authMode={'AWS_COGNITO'} {...authProvider}>
-                    <S3Provider client={testS3Client}>
+                    <S3Provider client={s3Client}>
                         <PageProvider>{ui}</PageProvider>
                     </S3Provider>
                 </AuthProvider>

--- a/services/app-web/src/testHelpers/s3Helpers.ts
+++ b/services/app-web/src/testHelpers/s3Helpers.ts
@@ -1,28 +1,33 @@
 import { S3ClientT } from '../s3'
 import { parseKey } from '../common-code/s3URLEncoding'
 
-export const testS3Client: S3ClientT = {
-    uploadFile: async (file: File): Promise<string> => {
-        return `${Date.now()}-${file.name}`
-    },
-    deleteFile: async (filename: string): Promise<void> => {
-        return
-    },
-    scanFile: async (filename: string): Promise<void> => {
-        return
-    },
-    getKey: (s3URL: string) => {
-        const key = parseKey(s3URL)
-        return key instanceof Error ? null : key
-    },
-    getS3URL: async (s3key: string, fileName: string): Promise<string> => {
-        return `fakes3://fake-bucket/${s3key}/${fileName}`
-    },
-    getURL: async (s3key: string): Promise<string> => {
-        return `https://fakes3.com/${s3key}?sekret=deadbeef`
-    },
-    getBulkDlURL: async (keys: string[], fileName: string): Promise<string> => {
-        const s3Key = keys[0]
-        return `https://fakes3.com/${s3Key}.zip`
-    },
+export const testS3Client: () => S3ClientT = () => {
+    return {
+        uploadFile: async (file: File): Promise<string> => {
+            return `${Date.now()}-${file.name}`
+        },
+        deleteFile: async (filename: string): Promise<void> => {
+            return
+        },
+        scanFile: async (filename: string): Promise<void> => {
+            return
+        },
+        getKey: (s3URL: string) => {
+            const key = parseKey(s3URL)
+            return key instanceof Error ? null : key
+        },
+        getS3URL: async (s3key: string, fileName: string): Promise<string> => {
+            return `fakes3://fake-bucket/${s3key}/${fileName}`
+        },
+        getURL: async (s3key: string): Promise<string> => {
+            return `https://fakes3.com/${s3key}?sekret=deadbeef`
+        },
+        getBulkDlURL: async (
+            keys: string[],
+            fileName: string
+        ): Promise<string> => {
+            const s3Key = keys[0]
+            return `https://fakes3.com/${s3Key}.zip`
+        },
+    }
 }


### PR DESCRIPTION
## Summary

This PR is not meant to be merged, but was a way to share some code with Jason.

This is a test that sets up a StateSubmissionForm.tsx with a HealthPlanPackage that has three different revisions, each one with different documents associated with it. The test then mocks the s3 Delete call and checks to see if delete is called when clicking the delete button for a file that exists in a previous revision. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
