### PR TITLE
Move ref back to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,7 +219,7 @@ jobs:
       always() &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
 
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@hw-upgrade-react-scripts
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
       app_version: ${{ needs.begin-deployment.outputs.app-version }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -107,6 +107,11 @@ jobs:
           name: lambda-layers-prisma-client-migration
           path: ./services/app-api/lambda-layers-prisma-client-migration
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lambda-layers-prisma-client-engine
+          path: ./services/app-api/lambda-layers-prisma-client-engine
+
   promote-infra-dev:
     needs: [build-prisma-client-lambda-layer, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main


### PR DESCRIPTION
## Summary

This moves the ref on `deploy-app` back to main. 

It also fixes an issue with the upload artifact not being run on promote.
