### PR TITLE
don't use @prisma/engine in layer

### DIFF
--- a/services/app-api/scripts/prepare-prisma-layer.sh
+++ b/services/app-api/scripts/prepare-prisma-layer.sh
@@ -33,8 +33,6 @@ function preparePrismaLayer() {
     rsync -av ../../node_modules/@prisma/client/ lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/client
     rsync -av ../../node_modules/prisma/ lambda-layers-prisma-client-engine/nodejs/node_modules/prisma
     rsync -av ../../node_modules/.prisma/ lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma
-    cp ../../node_modules/@prisma/engines/libquery_engine-rhel-openssl-1.0.x.so.node lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/engines/
-    cp ../../node_modules/@prisma/engines/package.json lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/engines/package.json
     rsync -av ../../node_modules/@prisma/engines/dist/ lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/engines/dist
 
     echo "Copy migration files to layer..."


### PR DESCRIPTION
## Summary

This removes an extra prisma `libquery_engine` from our layer. It wasn't showing up in earlier PR branches, but came up during the CRA/webpack 5 upgrade merge.
