### PR TITLE
[MR-2083] Drop pre-pilot data

### DIFF
--- a/services/app-api/prisma/migrations/20220425194642_drop_pre_pilot_data/migration.sql
+++ b/services/app-api/prisma/migrations/20220425194642_drop_pre_pilot_data/migration.sql
@@ -1,0 +1,2 @@
+-- This migration drops all data entered up to now. 
+TRUNCATE "HealthPlanRevisionTable", "HealthPlanPackageTable"


### PR DESCRIPTION
## Summary

We have a lot of data in the db that is out of date, especially protos that no longer decode, we decided to wipe the whole db and start over. 

#### Related issues

https://qmacbis.atlassian.net/browse/MR-2083

## QA guidance

Make sure the review app still works, it should lose the first run of Cypress data that was in there. 