### PR TITLE
Update error copy on unlock and resubmit modals and fix tests

### DIFF
--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.test.tsx
@@ -447,7 +447,7 @@ describe('Resubmitting plan packages', () => {
         screen.getByTestId('review-and-submit-modal-submit').click()
 
         expect(
-            await screen.findByText('Summary for submission is required')
+            await screen.findByText('You must provide a summary of changes')
         ).toBeInTheDocument()
     })
 
@@ -486,7 +486,7 @@ describe('Resubmitting plan packages', () => {
         userClickByTestId(screen, 'review-and-submit-modal-submit')
 
         expect(
-            await screen.findByText('Summary for submission is required')
+            await screen.findByText('You must provide a summary of changes')
         ).toBeInTheDocument()
 
         // check focus after error

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -64,7 +64,7 @@ export const ReviewSubmit = ({
         initialValues: modalFormInitialValues,
         validationSchema: Yup.object().shape({
             submittedReason: Yup.string().defined(
-                'Summary for submission is required'
+                'You must provide a summary of changes'
             ),
         }),
         onSubmit: (values) => onModalSubmit(values),

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -441,7 +441,7 @@ describe('SubmissionSummary', () => {
 
             expect(
                 await screen.findByText(
-                    'Reason for unlocking submission is required'
+                    'You must provide a reason for unlocking this submission'
                 )
             ).toBeInTheDocument()
         })
@@ -491,7 +491,7 @@ describe('SubmissionSummary', () => {
 
             expect(
                 await screen.findByText(
-                    'Reason for unlocking submission is required'
+                    'You must provide a reason for unlocking this submission'
                 )
             ).toBeInTheDocument()
 

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -144,7 +144,7 @@ export const SubmissionSummary = (): React.ReactElement => {
         initialValues: modalFormInitialValues,
         validationSchema: Yup.object().shape({
             unlockReason: Yup.string().defined(
-                'Reason for unlocking submission is required'
+                'You must provide a reason for unlocking this submission'
             ),
         }),
         onSubmit: (values) => onModalSubmit(values),


### PR DESCRIPTION
## Summary
Error message on the unlock modal have been updated to: "You must provide a reason for unlocking this submission"
Error message on the resubmit modal have been updated to:  "You must provide a summary of changes"

Tests have been updated to mach copy changes.