### PR TITLE
[MR-2147] Speculative fix for app-api test timeouts

### DIFF
--- a/services/app-api/src/resolvers/submitHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/submitHealthPlanPackage.test.ts
@@ -26,8 +26,11 @@ describe('submitHealthPlanPackage', () => {
         const draft = latestFormData(initialPkg)
         const draftID = draft.id
 
-        // submit
+        // We delay here to enable checking that updatedAt changes
+        jest.setTimeout(20000)
         await new Promise((resolve) => setTimeout(resolve, 2000))
+
+        // submit
         const submitResult = await server.executeOperation({
             query: SUBMIT_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -206,7 +209,6 @@ describe('submitHealthPlanPackage', () => {
         const draft = await createAndUpdateTestHealthPlanPackage(server, {})
         const draftID = draft.id
 
-        await new Promise((resolve) => setTimeout(resolve, 2000)) // TODO: why is this here in other tests??
         const submitResult = await server.executeOperation({
             query: SUBMIT_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -230,7 +232,6 @@ describe('submitHealthPlanPackage', () => {
         const draft = await createAndUpdateTestHealthPlanPackage(server, {})
         const draftID = draft.id
 
-        await new Promise((resolve) => setTimeout(resolve, 2000)) // TODO: why is this here in other tests??
         const submitResult = await server.executeOperation({
             query: SUBMIT_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -276,7 +277,6 @@ describe('submitHealthPlanPackage', () => {
         const draft = await createAndUpdateTestHealthPlanPackage(server, {})
         const draftID = draft.id
 
-        await new Promise((resolve) => setTimeout(resolve, 2000)) // TODO: why is this here in other tests??
         const submitResult = await server.executeOperation({
             query: SUBMIT_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -318,7 +318,6 @@ describe('submitHealthPlanPackage', () => {
         const draft = await createAndUpdateTestHealthPlanPackage(server, {})
         const draftID = draft.id
 
-        await new Promise((resolve) => setTimeout(resolve, 2000)) // TODO: why is this here in other tests??
         const submitResult = await server.executeOperation({
             query: SUBMIT_HEALTH_PLAN_PACKAGE,
             variables: {

--- a/services/app-api/src/resolvers/unlockHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/unlockHealthPlanPackage.test.ts
@@ -36,7 +36,6 @@ describe('unlockHealthPlanPackage', () => {
         })
 
         // Unlock
-        await new Promise((resolve) => setTimeout(resolve, 2000))
         const unlockResult = await cmsServer.executeOperation({
             query: UNLOCK_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -106,7 +105,6 @@ describe('unlockHealthPlanPackage', () => {
         })
 
         // Unlock
-        await new Promise((resolve) => setTimeout(resolve, 2000))
         const unlockResult = await cmsServer.executeOperation({
             query: UNLOCK_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -238,7 +236,6 @@ describe('unlockHealthPlanPackage', () => {
         )
 
         // Unlock
-        await new Promise((resolve) => setTimeout(resolve, 2000))
         const unlockResult = await stateServer.executeOperation({
             query: UNLOCK_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -336,7 +333,6 @@ describe('unlockHealthPlanPackage', () => {
         // const stateSubmission = await createAndSubmitTestHealthPlanPackage(stateServer)
 
         // Unlock
-        await new Promise((resolve) => setTimeout(resolve, 2000))
         const unlockResult = await cmsServer.executeOperation({
             query: UNLOCK_HEALTH_PLAN_PACKAGE,
             variables: {
@@ -369,7 +365,6 @@ describe('unlockHealthPlanPackage', () => {
         })
 
         // Unlock
-        await new Promise((resolve) => setTimeout(resolve, 2000))
         const unlockResult = await cmsServer.executeOperation({
             query: UNLOCK_HEALTH_PLAN_PACKAGE,
             variables: {


### PR DESCRIPTION
## Summary

We’ve had a number of timeouts in the app-api tests.

Both of the cases I could find from recently were for tests that had a 2 second delay built in to the test themselves. That was introduced to check that updatedAt was changing on the submit action. Several other tests ended up with that line copied into them even though they didn’t need a 2 second delay. I’ve deleted the unnessecary delays and added a longer timeout for the test that is still waiting 2 seconds. 

#### Related issues

https://qmacbis.atlassian.net/browse/MR-2147

## QA guidance

This has been an itermittant failure, often seen on promote only. So I think we’re going to have to merge this and then wait and see if we see that error again to know if it fixed anything. 