### PR TITLE
MR-2094: Date missing from documents table on unlocked review and submit page

### DIFF
--- a/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
+++ b/services/app-web/src/documentHelpers/makeDocumentDateLookupTable.test.ts
@@ -1,5 +1,11 @@
 import { makeDateTable } from './makeDocumentDateLookupTable'
 import { mockSubmittedHealthPlanPackageWithRevision } from '../testHelpers/apolloHelpers'
+import {
+    basicHealthPlanFormData,
+    basicLockedHealthPlanFormData,
+} from '../common-code/healthPlanFormDataMocks'
+import { SubmissionDocument } from '../common-code/healthPlanFormDataType'
+import { domainToBase64 } from '../common-code/proto/healthPlanFormDataProto'
 
 describe('makeDateTable', () => {
     it('should make a proper lookup table', () => {
@@ -19,6 +25,42 @@ describe('makeDateTable', () => {
             ),
             'lifeofgalileo.pdf': new Date('2022-03-28T17:56:32.953Z'),
             previousSubmissionDate: new Date('2022-03-25T21:14:43.057Z'),
+        })
+    })
+    it('should use earliest document added date', () => {
+        const submissions = mockSubmittedHealthPlanPackageWithRevision()
+        const docs: SubmissionDocument[] = [
+            {
+                s3URL: 's3://bucketname/testDateDoc/testDateDoc.png',
+                name: 'Test Date Doc',
+                documentCategories: ['CONTRACT_RELATED'],
+            },
+        ]
+        const baseFormData = basicLockedHealthPlanFormData()
+        baseFormData.documents = docs
+
+        const unlockedData = basicHealthPlanFormData()
+        unlockedData.documents = docs
+
+        baseFormData.updatedAt = new Date('2022-01-10T00:00:00.000Z')
+        const initialSubmission = domainToBase64(baseFormData)
+
+        baseFormData.updatedAt = new Date('2022-02-10T00:00:00.000Z')
+        const secondSubmission = domainToBase64(baseFormData)
+
+        baseFormData.updatedAt = new Date('2022-03-10T00:00:00.000Z')
+        const currentSubmission = domainToBase64(baseFormData)
+
+        submissions.revisions[2].node.formDataProto = initialSubmission
+        submissions.revisions[1].node.formDataProto = secondSubmission
+        submissions.revisions[0].node.formDataProto = currentSubmission
+
+        const lookupTable = makeDateTable(submissions)
+
+        expect(lookupTable).toEqual({
+            'contract doc': new Date('2022-01-10T00:00:00.000Z'),
+            'Test Date Doc': new Date('2022-01-10T00:00:00.000Z'),
+            previousSubmissionDate: new Date('2022-02-10T00:00:00.000Z'),
         })
     })
 })

--- a/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
+++ b/services/app-web/src/pages/StateSubmission/ReviewSubmit/ReviewSubmit.tsx
@@ -25,13 +25,16 @@ import { PoliteErrorMessage } from '../../../components'
 import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import { UnlockedHealthPlanFormDataType } from '../../../common-code/healthPlanFormDataType'
+import { DocumentDateLookupTable } from '../../SubmissionSummary/SubmissionSummary'
 
 export const ReviewSubmit = ({
     draftSubmission,
+    documentDateLookupTable,
     unlocked,
     submissionName,
 }: {
     draftSubmission: UnlockedHealthPlanFormDataType
+    documentDateLookupTable?: DocumentDateLookupTable
     unlocked: boolean
     submissionName: string
 }): React.ReactElement => {
@@ -159,6 +162,7 @@ export const ReviewSubmit = ({
                 submission={draftSubmission}
                 navigateTo="contract-details"
                 submissionName={submissionName}
+                documentDateLookupTable={documentDateLookupTable}
             />
 
             {isContractActionAndRateCertification && (
@@ -166,6 +170,7 @@ export const ReviewSubmit = ({
                     submission={draftSubmission}
                     navigateTo="rate-details"
                     submissionName={submissionName}
+                    documentDateLookupTable={documentDateLookupTable}
                 />
             )}
 

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -41,6 +41,8 @@ import {
 } from '../../common-code/healthPlanFormDataType'
 import { domainToBase64 } from '../../common-code/proto/healthPlanFormDataProto'
 import { makeDocumentList } from '../../documentHelpers/makeDocumentKeyLookupList'
+import { makeDateTable } from '../../documentHelpers/makeDocumentDateLookupTable'
+import { DocumentDateLookupTable } from '../SubmissionSummary/SubmissionSummary'
 
 const FormAlert = ({ message }: { message?: string }): React.ReactElement => {
     return message ? (
@@ -117,6 +119,11 @@ export const StateSubmissionForm = (): React.ReactElement => {
     const [computedSubmissionName, setComputedSubmissionName] =
         useState<string>('')
     const [previousDocuments, setPreviousDocuments] = useState<string[]>([])
+
+    // document date lookup state
+    const [documentDates, setDocumentDates] = useState<
+        DocumentDateLookupTable | undefined
+    >({})
 
     // Set up graphql calls
     const {
@@ -203,6 +210,9 @@ export const StateSubmissionForm = (): React.ReactElement => {
 
             //set previous submitted files
             const documentList = makeDocumentList(submissionAndRevisions)
+            //set document dates
+            const documentDates = makeDateTable(submissionAndRevisions)
+            setDocumentDates(documentDates)
             if (documentList instanceof Error) {
                 //Maybe a different error message here.
                 setFormDataError('MALFORMATTED_DATA')
@@ -337,6 +347,7 @@ export const StateSubmissionForm = (): React.ReactElement => {
                             draftSubmission={formDataFromLatestRevision}
                             unlocked={!!unlockedInfo}
                             submissionName={computedSubmissionName}
+                            documentDateLookupTable={documentDates}
                         />
                     </Route>
                 </Switch>


### PR DESCRIPTION
## Summary
[MR-2094](https://qmacbis.atlassian.net/browse/MR-2094)

Date missing from documents from Review/Submit page. 

Repeated the code from `SubmissionSummary` that generates the document dates in `StateSubmissionForm`. This is passed to `ReviewSubmit` which is then passed to `ContractDetailsSummarySection` and `RateDetailsSummarySection`. 

#### Related issues

#### Screenshots

#### Test cases covered
- makeDocumentDateLookupTable.test
   - should use earliest document added date

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
