### PR TITLE
Add env var for LD client 

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -26,6 +26,7 @@ export EMAILER_MODE='LOCAL'
 export SES_SOURCE_EMAIL_ADDRESS='dev@localhost'
 export SES_REVIEW_TEAM_EMAIL_ADDRESSES='mc-review-qa@truss.works'
 export REACT_APP_OTEL_COLLECTOR_URL='http://localhost:4318/v1/traces'
+export REACT_APP_LD_CLIENT_ID='this-value-can-be-set-in-local-if-desired'
 
 # Sources a local overrides file. You can export any variables you
 # need for your local setup there. Any that match variables set here


### PR DESCRIPTION
## Summary

If a developer doesn't have the appropriate environment variable set in their `.envrc.local` for the Launch Darkly `app-web` setup, the web application will not start up. This has caused a bit of confusion.

This PR adds a dummy var to `.envrc` itself so the application will start (it just won't have feature flags running in local dev). If a developer wants to add a live key they can do so by entering our client side key from our LD account into `.envrc.local`.
