### PR TITLE
[MR-2217] Capitation rates specification on review/submit and summary pages displaying incorrect data

### DIFF
--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -276,4 +276,44 @@ describe('RateDetailsSummarySection', () => {
             })
         ).toBeNull()
     })
+    it('renders rate cell capitation type', () => {
+        renderWithProviders(
+            <RateDetailsSummarySection
+                submission={draftSubmission}
+                navigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+            />
+        )
+        expect(
+            screen.getByRole('definition', {
+                name: 'Does the actuary certify capitation rates specific to each rate cell or a rate range?',
+            })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Certification of capitation rates specific to each rate cell'
+            )
+        ).toBeInTheDocument()
+    })
+    it('renders rate range capitation type', () => {
+        const draftSubmission = mockContractAndRatesDraft()
+        draftSubmission.rateCapitationType = 'RATE_RANGE'
+        renderWithProviders(
+            <RateDetailsSummarySection
+                submission={draftSubmission}
+                navigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+            />
+        )
+        expect(
+            screen.getByRole('definition', {
+                name: 'Does the actuary certify capitation rates specific to each rate cell or a rate range?',
+            })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByText(
+                'Certification of rate ranges of capitation rates per rate cell'
+            )
+        ).toBeInTheDocument()
+    })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -40,6 +40,12 @@ export const RateDetailsSummarySection = ({
 
     const rateName = generateRateName(submission, submissionName)
 
+    const rateCapitationType = submission.rateCapitationType
+        ? submission.rateCapitationType === 'RATE_CELL'
+            ? 'Certification of capitation rates specific to each rate cell'
+            : 'Certification of rate ranges of capitation rates per rate cell'
+        : ''
+
     useEffect(() => {
         // get all the keys for the documents we want to zip
         async function fetchZipUrl() {
@@ -106,11 +112,7 @@ export const RateDetailsSummarySection = ({
                     <DataDetail
                         id="rateCapitationType"
                         label="Does the actuary certify capitation rates specific to each rate cell or a rate range?"
-                        data={
-                            submission.rateAmendmentInfo
-                                ? 'Certification of rate ranges of capitation rates per rate cell'
-                                : 'Certification of capitation rates specific to each rate cell'
-                        }
+                        data={rateCapitationType}
                     />
                     <DataDetail
                         id="ratingPeriod"


### PR DESCRIPTION
## Summary
[MR-2217](https://qmacbis.atlassian.net/browse/MR-2217)

`Does the actuary certify capitation rates specific to each rate cell or a rate range?` on review/submit and summary pages displayed incorrect data.

#### Related issues

#### Screenshots

#### Test cases covered

- `RateDetailsSummarySection.test.tsx`
   - `renders rate cell capitation type`
   - `renders rate range capitation type`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
