### PR TITLE
[MR-2235] Add test environment banner to val and dev environments

### DIFF
--- a/services/app-web/src/pages/App/App.tsx
+++ b/services/app-web/src/pages/App/App.tsx
@@ -15,7 +15,6 @@ import TraceProvider from '../../contexts/TraceContext'
 import { GenericErrorPage } from '../Errors/GenericErrorPage'
 import { AuthModeType } from '../../common-code/config'
 import { S3Provider } from '../../contexts/S3Context'
-import { useScript } from '../../hooks/useScript'
 import type { S3ClientT } from '../../s3'
 
 function ErrorFallback({
@@ -42,13 +41,6 @@ function App({
     useEffect(() => {
         logEvent('on_load', { success: true })
     }, [])
-
-    // This is a hacky way to fake feature flags before we have feature flags.
-    // please avoid reading env vars outside of index.tsx in general.
-    const environmentName = process.env.REACT_APP_STAGE_NAME || ''
-    const isProdEnvironment = ['prod', 'val'].includes(environmentName)
-    const jiraTicketCollectorURL = `https://meghantest.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/-9zew5j/b/7/c95134bc67d3a521bb3f4331beb9b804/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=e59b8faf`
-    useScript(jiraTicketCollectorURL, !isProdEnvironment)
 
     return (
         <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/services/app-web/src/pages/App/AppBody.module.scss
+++ b/services/app-web/src/pages/App/AppBody.module.scss
@@ -14,3 +14,11 @@
     flex-direction: column;
     background-color: color('base-lightest');
 }
+
+.testEnvironmentBanner {
+    background-color: $cms-color-gold-darker;
+    font-weight: bold;
+    text-align: center;
+    font-size: 1rem;
+    padding: .5rem;
+}

--- a/services/app-web/src/pages/App/AppBody.test.tsx
+++ b/services/app-web/src/pages/App/AppBody.test.tsx
@@ -30,6 +30,49 @@ describe('App Body and routes', () => {
         expect(mainElement).toBeInTheDocument()
     })
 
+    describe('Environment specific banner', () => {
+        const OLD_ENV = process.env
+
+        beforeEach(() => {
+            jest.resetModules() // Most important - it clears the cache
+            process.env = { ...OLD_ENV } // Make a copy
+        })
+
+        afterAll(() => {
+            process.env = OLD_ENV // Restore old environment
+        })
+
+        it('shows test environment banner in val', () => {
+            process.env.REACT_APP_STAGE_NAME = 'val'
+            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({ statusCode: 200 }),
+                        indexHealthPlanPackagesMockSuccess(),
+                    ],
+                },
+            })
+
+            expect(
+                screen.getByText('THIS IS A TEST ENVIRONMENT')
+            ).toBeInTheDocument()
+        })
+
+        it('does not show test environment banner in prod', () => {
+            process.env.REACT_APP_STAGE_NAME = 'prod'
+            renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({ statusCode: 200 }),
+                        indexHealthPlanPackagesMockSuccess(),
+                    ],
+                },
+            })
+
+            expect(screen.queryByText('THIS IS A TEST ENVIRONMENT')).toBeNull()
+        })
+    })
+
     describe('/', () => {
         it('display dashboard when logged in', async () => {
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {

--- a/services/app-web/src/pages/App/AppBody.test.tsx
+++ b/services/app-web/src/pages/App/AppBody.test.tsx
@@ -34,7 +34,7 @@ describe('App Body and routes', () => {
         const OLD_ENV = process.env
 
         beforeEach(() => {
-            jest.resetModules() // Most important - it clears the cache
+            jest.resetModules() // Most important - clears the cache
             process.env = { ...OLD_ENV } // Make a copy
         })
 

--- a/services/app-web/src/pages/App/AppBody.tsx
+++ b/services/app-web/src/pages/App/AppBody.tsx
@@ -15,9 +15,11 @@ export function AppBody({
 }: {
     authMode: AuthModeType
 }): React.ReactElement {
-    const [alert, setAlert] = React.useState<React.ReactElement | undefined>(
-        undefined
-    )
+    const [globalAlert, setGlobalAlert] = React.useState<
+        React.ReactElement | undefined
+    >(undefined)
+    const environmentName = process.env.REACT_APP_STAGE_NAME || ''
+    const isLowerEnvironment = environmentName !== 'prod'
     const { loginStatus } = useAuth()
 
     return (
@@ -26,14 +28,19 @@ export function AppBody({
                 Skip to main content
             </a>
             <GovBanner aria-label="Official government website" />
+            {isLowerEnvironment && (
+                <div className={styles.testEnvironmentBanner}>
+                    THIS IS A TEST ENVIRONMENT
+                </div>
+            )}
 
-            <Header authMode={authMode} setAlert={setAlert} />
+            <Header authMode={authMode} setAlert={setGlobalAlert} />
             <main id="main-content" className={styles.mainContent} role="main">
-                {alert && alert}
+                {globalAlert && globalAlert}
                 {loginStatus === 'LOADING' ? (
                     <Loading />
                 ) : (
-                    <AppRoutes authMode={authMode} setAlert={setAlert} />
+                    <AppRoutes authMode={authMode} setAlert={setGlobalAlert} />
                 )}
             </main>
 


### PR DESCRIPTION
## Summary
Add banner.

Bonus:  strip out the jira collector from the frontend (cc: @MegMurphy, my understanding is this is no longer needed )
#### Related issues
https://qmacbis.atlassian.net/browse/MR-2235

#### Screenshots
![Screen Shot 2022-05-31 at 5 16 17 PM](https://user-images.githubusercontent.com/10750442/171293213-7ef67bfd-9aec-49ae-8aeb-5df88bd1d5f2.png)

#### Test cases covered
- shows test environment banner in val
- does not show test environment banner in prod 
<!---These are the tests written in this PR and the cases they cover -->
