### PR TITLE
Update deployment-action GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           echo "${{steps.changed-services-action.outputs.changed-services}}"
 
-      - uses: chrnorm/deployment-action@releases/v2.0.3
+      - uses: chrnorm/deployment-action@releases/v2
         name: Create GitHub deployment
         id: ghdeployment
         with:
@@ -300,7 +300,7 @@ jobs:
 
       - name: Update deployment status (success)
         if: needs.deploy-app.result == 'success'
-        uses: chrnorm/deployment-status@releases/v2.0.3
+        uses: chrnorm/deployment-status@releases/v2
         with:
           token: '${{ github.token }}'
           environment-url: ${{ needs.finishing-prep.outputs.application-endpoint }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,14 +71,14 @@ jobs:
         run: |
           echo "${{steps.changed-services-action.outputs.changed-services}}"
 
-      - uses: chrnorm/deployment-action@releases/v1
+      - uses: chrnorm/deployment-action@releases/v2.0.3
         name: Create GitHub deployment
         id: ghdeployment
         with:
           token: '${{ github.token }}'
           environment: review-apps
           description: stack ${{ steps.branch-name.outputs.stage-name-for-branch}}
-          initial_status: in_progress
+          initial-status: in_progress
 
   web-unit-tests:
     name: test - web unit tests
@@ -300,12 +300,12 @@ jobs:
 
       - name: Update deployment status (success)
         if: needs.deploy-app.result == 'success'
-        uses: chrnorm/deployment-status@releases/v1
+        uses: chrnorm/deployment-status@releases/v2.0.3
         with:
           token: '${{ github.token }}'
-          environment_url: ${{ needs.finishing-prep.outputs.application-endpoint }}
+          environment-url: ${{ needs.finishing-prep.outputs.application-endpoint }}
           state: 'success'
-          deployment_id: ${{ needs.begin-deployment.outputs.deploy-id }}
+          deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}
 
   cypress:
     name: cypress-run


### PR DESCRIPTION
## Summary

Our CI started failing due to not being able to find the appropriate tag on the `deployment-action` action. This upgrades us to the latest release.

