### PR TITLE
[MR-2324] DMCP & OACT do not receive CHIP emails

### DIFF
--- a/services/app-api/src/emailer/templates.test.ts
+++ b/services/app-api/src/emailer/templates.test.ts
@@ -265,6 +265,46 @@ describe('Email templates', () => {
                 )
             })
         })
+        it('CHIP contract only submission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockContractOnlyFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = newPackageCMSEmail(
+                sub,
+                'some-title',
+                testEmailConfig
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
+        })
+        it('CHIP contract and rate submission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockContractAndRatesFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = newPackageCMSEmail(
+                sub,
+                'some-title',
+                testEmailConfig
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
+        })
         it('does not include rate name on contract only submission', () => {
             const sub = mockContractOnlyFormData()
             const template = newPackageCMSEmail(
@@ -600,6 +640,48 @@ describe('Email templates', () => {
                 )
             })
         })
+        it('CHIP contract only unlock email does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockUnlockedContractOnlyFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = unlockPackageCMSEmail(
+                sub,
+                unlockData,
+                testEmailConfig,
+                rateName
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
+        })
+        it('CHIP contract and rate unlock email does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockUnlockedContractAndRatesFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = unlockPackageCMSEmail(
+                sub,
+                unlockData,
+                testEmailConfig,
+                rateName
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
+        })
         it('does not include rate name on contract only submission unlock', () => {
             const sub = mockUnlockedContractOnlyFormData()
             const rateName = 'test-rate-name'
@@ -826,6 +908,26 @@ describe('Email templates', () => {
                 )
             })
         })
+        it('CHIP contract and rate resubmission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockContractAndRatesFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = resubmittedCMSEmail(
+                sub,
+                resubmitData,
+                testEmailConfig
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
+        })
     })
     describe('CMS resubmission email without rates', () => {
         const resubmitData = {
@@ -860,6 +962,27 @@ describe('Email templates', () => {
                     bodyText: expect.stringMatching(/Rate name:/),
                 })
             )
+        })
+
+        it('CHIP contract only resubmission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress', () => {
+            const sub = mockContractOnlyFormData()
+            sub.programIDs = ['36c54daf-7611-4a15-8c3b-cdeb3fd7e25a']
+            const template = resubmittedCMSEmail(
+                sub,
+                resubmitData,
+                testEmailConfig
+            )
+            const excludedEmails = [
+                ...testEmailConfig.ratesReviewSharedEmails,
+                testEmailConfig.cmsRateHelpEmailAddress,
+            ]
+            excludedEmails.forEach((emailAddress) => {
+                expect(template).toEqual(
+                    expect.objectContaining({
+                        toAddresses: expect.not.arrayContaining([emailAddress]),
+                    })
+                )
+            })
         })
     })
 })

--- a/services/app-api/src/emailer/templates.ts
+++ b/services/app-api/src/emailer/templates.ts
@@ -14,6 +14,12 @@ const SubmissionTypeRecord: Record<SubmissionType, string> = {
     CONTRACT_AND_RATES: 'Contract action and rate certification',
 }
 
+//This should reference UUIDS in the statePrograms.json in src/data/
+const CHIP_PROGRAMS_UUID = {
+    MS: '36c54daf-7611-4a15-8c3b-cdeb3fd7e25a',
+    AS: 'e112301b-72c7-4c8f-856a-2cf8c6a1465b',
+}
+
 // Clean out HTML tags from an HTML based template
 // this way we still have a text alternative for email client rendering html in plaintext
 // plaintext is also referenced for unit testing
@@ -32,18 +38,33 @@ const stripHTMLFromTemplate = (template: string) => {
     return formatted.replace(/(<([^>]+)>)/gi, '')
 }
 
+//Checks if at least one program is CHIP
+const includesChipPrograms = (programIDs: string[]): boolean => {
+    const chipProgramIds = Object.values(CHIP_PROGRAMS_UUID)
+    return programIDs.some((id: string) => chipProgramIds.includes(id))
+}
+
 const generateReviewerEmails = (
     config: EmailConfiguration,
     submission: LockedHealthPlanFormDataType | UnlockedHealthPlanFormDataType
 ): string[] => {
+    //chipReviewerEmails does not include OACT and DMCP emails
+    const chipReviewerEmails = config.cmsReviewSharedEmails.filter(
+        (email) => email !== config.cmsRateHelpEmailAddress
+    )
+    const contractAndRateReviewerEmails = [
+        ...config.cmsReviewSharedEmails,
+        ...config.ratesReviewSharedEmails,
+    ]
+
     if (
         submission.submissionType === 'CONTRACT_AND_RATES' &&
-        submission.stateCode !== 'PR'
+        submission.stateCode !== 'PR' &&
+        !includesChipPrograms(submission.programIDs)
     ) {
-        return [
-            ...config.cmsReviewSharedEmails,
-            ...config.ratesReviewSharedEmails,
-        ]
+        return contractAndRateReviewerEmails
+    } else if (includesChipPrograms(submission.programIDs)) {
+        return chipReviewerEmails
     }
     return config.cmsReviewSharedEmails
 }
@@ -386,4 +407,5 @@ export {
     resubmittedStateEmail,
     resubmittedCMSEmail,
     UpdatedEmailData,
+    CHIP_PROGRAMS_UUID,
 }

--- a/services/app-api/src/testHelpers/emailerHelpers.ts
+++ b/services/app-api/src/testHelpers/emailerHelpers.ts
@@ -20,7 +20,11 @@ const testEmailConfig: EmailConfiguration = {
     stage: 'LOCAL',
     baseUrl: 'http://localhost',
     emailSource: 'emailSource@example.com',
-    cmsReviewSharedEmails: ['cmsreview1@example.com', 'cmsreview2@example.com'],
+    cmsReviewSharedEmails: [
+        'cmsreview1@example.com',
+        'cmsreview2@example.com',
+        'rates@example.com',
+    ],
     cmsReviewHelpEmailAddress: 'mcog@example.com',
     cmsRateHelpEmailAddress: 'rates@example.com',
     cmsDevTeamHelpEmailAddress: 'mc-review@example.com',


### PR DESCRIPTION
## Summary

[MR-2324](https://qmacbis.atlassian.net/browse/MR-2324)
Add logic for CHIP health plan package reviewer emails.

#### Related issues

#### Screenshots

#### Test cases covered

- templates.test.ts
   - `CHIP contract only submission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`
   - `CHIP contract and rate submission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`
   - `CHIP contract only unlock email does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`
   - `CHIP contract and rate unlock email does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`
   - `CHIP contract and rate resubmission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`
   - `CHIP contract only resubmission does not include ratesReviewSharedEmails and cmsRateHelpEmailAddress`


<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
