### PR TITLE
[MR-2321] reorder submission id to have number before programs

### DIFF
--- a/services/app-api/src/resolvers/indexHealthPlanPackages.test.ts
+++ b/services/app-api/src/resolvers/indexHealthPlanPackages.test.ts
@@ -203,9 +203,13 @@ describe('indexHealthPlanPackages', () => {
             query: INDEX_HEALTH_PLAN_PACKAGES,
         })
 
-        expect(result.errors).toBeUndefined() // Is this really what we want? I thought this would be 403 unauthorized
+        expect(result.errors).toBeUndefined()
 
         const indexHealthPlanPackages = result.data?.indexHealthPlanPackages
-        expect(indexHealthPlanPackages).toEqual({ edges: [], totalCount: 0 })
+        const otherStatePackages = indexHealthPlanPackages.edges.filter(
+            (pkg: HealthPlanPackageEdge) => pkg.node.stateCode !== 'VA'
+        )
+
+        expect(otherStatePackages).toEqual([])
     })
 })

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
@@ -349,25 +349,25 @@ describe('submission type assertions', () => {
     )
 
     test.each([
-        [['foo-bar', 'baz-bin'], 'MCR-MN-UNKNOWNPROGRAM-UNKNOWNPROGRAM-0005'],
-        [['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'], 'MCR-MN-SNBC-0005'],
+        [['foo-bar', 'baz-bin'], 'MCR-MN-0005-UNKNOWNPROGRAM-UNKNOWNPROGRAM'],
+        [['abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce'], 'MCR-MN-0005-SNBC'],
         [
             [
                 'd95394e5-44d1-45df-8151-1cc1ee66f100',
                 'ea16a6c0-5fc6-4df8-adac-c627e76660ab',
             ],
-            'MCR-MN-MSC+-PMAP-0005',
+            'MCR-MN-0005-MSC+-PMAP',
         ],
         [
             [
                 'ea16a6c0-5fc6-4df8-adac-c627e76660ab',
                 'd95394e5-44d1-45df-8151-1cc1ee66f100',
             ],
-            'MCR-MN-MSC+-PMAP-0005',
+            'MCR-MN-0005-MSC+-PMAP',
         ],
         [
             ['3fd36500-bf2c-47bc-80e8-e7aa417184c5', 'baz-bin'],
-            'MCR-MN-MSHO-UNKNOWNPROGRAM-0005',
+            'MCR-MN-0005-MSHO-UNKNOWNPROGRAM',
         ],
         [
             [
@@ -375,7 +375,7 @@ describe('submission type assertions', () => {
                 'd95394e5-44d1-45df-8151-1cc1ee66f100',
                 'ea16a6c0-5fc6-4df8-adac-c627e76660ab',
             ],
-            'MCR-MN-MSC+-PMAP-SNBC-0005',
+            'MCR-MN-0005-MSC+-PMAP-SNBC',
         ],
     ])('submission name is correct', (programIDs, expectedName) => {
         const programs = mockMNState().programs

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -174,7 +174,7 @@ function packageName(
                 .toUpperCase()
         )
         .join('-')
-    return `MCR-${submission.stateCode.toUpperCase()}-${formattedProgramNames}-${padNumber}`
+    return `MCR-${submission.stateCode.toUpperCase()}-${padNumber}-${formattedProgramNames}`
 }
 
 const generateRateName = (


### PR DESCRIPTION
## Summary

Reorder the submssion name to put the number before programs. 

#### Related issues

https://qmacbis.atlassian.net/browse/MR-2321

#### Screenshots

<img width="678" alt="Screen Shot 2022-06-15 at 2 06 40 PM" src="https://user-images.githubusercontent.com/55759/173930116-fe6f1f54-a78a-48c4-8405-2946754086fd.png">

#### Test cases covered

shockingly the only tests that broke were the ones related to the name generation code. 