### PR TITLE
[MR-2333] Files with commas in the name throw errors in Edge and Chrome

### DIFF
--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -134,7 +134,7 @@ export const main: APIGatewayProxyHandler = async (event) => {
         zip.pipe(streamPassThrough)
         s3DownloadStreams.forEach((streamDetails: S3DownloadStreamDetails) =>
             zip.append(streamDetails.stream, {
-                name: streamDetails.filename,
+                name: decodeURIComponent(streamDetails.filename),
             })
         )
 

--- a/services/app-api/src/handlers/bulk_download.ts
+++ b/services/app-api/src/handlers/bulk_download.ts
@@ -134,6 +134,7 @@ export const main: APIGatewayProxyHandler = async (event) => {
         zip.pipe(streamPassThrough)
         s3DownloadStreams.forEach((streamDetails: S3DownloadStreamDetails) =>
             zip.append(streamDetails.stream, {
+                //decoding file names encoded in s3Amplify.ts
                 name: decodeURIComponent(streamDetails.filename),
             })
         )

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -112,8 +112,6 @@ export const ContractDetailsSummarySection = ({
                 .filter((key) => key !== '')
 
             // call the lambda to zip the files and get the url
-            console.log('Keys from S3')
-            console.log(keysFromDocs)
             const zippedURL = await getBulkDlURL(
                 keysFromDocs,
                 submissionName + '-contract-details.zip'

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -112,6 +112,8 @@ export const ContractDetailsSummarySection = ({
                 .filter((key) => key !== '')
 
             // call the lambda to zip the files and get the url
+            console.log('Keys from S3')
+            console.log(keysFromDocs)
             const zippedURL = await getBulkDlURL(
                 keysFromDocs,
                 submissionName + '-contract-details.zip'

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -39,6 +39,9 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             const uuid = uuidv4()
             const ext = file.name.split('.').pop()
 
+            console.log('File extension')
+            console.log(ext)
+
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
                     contentType: file.type,

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -42,7 +42,7 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
                     contentType: file.type,
-                    contentDisposition: `attachment; filename=${file.name}`,
+                    contentDisposition: `attachment; filename="${file.name}"`,
                 })
 
                 assertIsS3PutResponse(stored)

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -38,6 +38,7 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
         uploadFile: async (file: File): Promise<string | S3Error> => {
             const uuid = uuidv4()
             const ext = file.name.split('.').pop()
+            //encode file names and decoding done in bulk_downloads.ts
             const fileName = encodeURIComponent(file.name)
 
             try {

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -38,14 +38,12 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
         uploadFile: async (file: File): Promise<string | S3Error> => {
             const uuid = uuidv4()
             const ext = file.name.split('.').pop()
-
-            console.log('File extension')
-            console.log(ext)
+            const fileName = encodeURIComponent(file.name)
 
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
                     contentType: file.type,
-                    contentDisposition: `attachment; filename=${file.name}"`,
+                    contentDisposition: `attachment; filename=${fileName}`,
                 })
 
                 assertIsS3PutResponse(stored)
@@ -114,8 +112,6 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
         },
         getKey: (s3URL: string) => {
             const key = parseKey(s3URL)
-            console.log('S3 File Key')
-            console.log(key)
             return key instanceof Error ? null : key
         },
         getURL: async (key: string): Promise<string> => {
@@ -133,8 +129,6 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             filename: string
         ): Promise<string | Error> => {
             const prependedKeys = keys.map((key) => `allusers/${key}`)
-            console.log('Prepended Keys')
-            console.log(prependedKeys)
             const prependedFilename = `allusers/${filename}`
 
             const zipRequestParams = {

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -42,7 +42,7 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
                     contentType: file.type,
-                    contentDisposition: `attachment; filename="${file.name}"`,
+                    contentDisposition: `attachment; filename=${file.name}"`,
                 })
 
                 assertIsS3PutResponse(stored)
@@ -111,6 +111,8 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
         },
         getKey: (s3URL: string) => {
             const key = parseKey(s3URL)
+            console.log('S3 File Key')
+            console.log(key)
             return key instanceof Error ? null : key
         },
         getURL: async (key: string): Promise<string> => {
@@ -128,6 +130,8 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             filename: string
         ): Promise<string | Error> => {
             const prependedKeys = keys.map((key) => `allusers/${key}`)
+            console.log('Prepended Keys')
+            console.log(prependedKeys)
             const prependedFilename = `allusers/${filename}`
 
             const zipRequestParams = {


### PR DESCRIPTION
## Summary
[MR-2333](https://qmacbis.atlassian.net/browse/MR-2333)

Fixed by encoding file names in `s3Amplify.ts` then decoding in `bulk_download.ts`. 
#### Related issues

Ticket [2335](https://qmacbis.atlassian.net/browse/MR-2335) for inconsistent file names when downloading a single document.

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

- **Please make sure to test on Chrome/Safari/Edge/Firefox and windows machine.**

<!---These are developer instructions on how to test or validate the work -->
