### PR TITLE
Add useLocalStorage hook

### DIFF
--- a/services/app-web/src/constants/localStorage.ts
+++ b/services/app-web/src/constants/localStorage.ts
@@ -3,7 +3,7 @@
  * around local storage keys
  */
 
-const LOCAL_STORAGE_KEYS = ['LOGIN_REDIRECT', 'LOGIN_ATTEMPTED'] as const
+const LOCAL_STORAGE_KEYS = ['LOGIN_REDIRECT'] as const
 
 export type LocalStorageKeyType = typeof LOCAL_STORAGE_KEYS[number]
 
@@ -12,8 +12,4 @@ export const LocalStorageKeys: Record<LocalStorageKeyType, string> = {
      * Stores application URL path that requires authentication. Used when a logged out user tries to visit an authenticated path. We will redirect them after a successful login in these cases.
      */
     LOGIN_REDIRECT: 'LOGIN_REDIRECT',
-    /**
-     * Stores stringified boolean to determine if login has already been attempted. Used to display errors to logged out users when login as failed.
-     */
-    LOGIN_ATTEMPTED: 'LOGIN_ATTEMPTED',
 }

--- a/services/app-web/src/constants/localStorage.ts
+++ b/services/app-web/src/constants/localStorage.ts
@@ -1,0 +1,19 @@
+/*
+ * Contains a list of all our local storage keys. This is used to give us type safety
+ * around local storage keys
+ */
+
+const LOCAL_STORAGE_KEYS = ['LOGIN_REDIRECT', 'LOGIN_ATTEMPTED'] as const
+
+export type LocalStorageKeyType = typeof LOCAL_STORAGE_KEYS[number]
+
+export const LocalStorageKeys: Record<LocalStorageKeyType, string> = {
+    /**
+     * Stores application URL path that requires authentication. Used when a logged out user tries to visit an authenticated path. We will redirect them after a successful login in these cases.
+     */
+    LOGIN_REDIRECT: 'LOGIN_REDIRECT',
+    /**
+     * Stores stringified boolean to determine if login has already been attempted. Used to display errors to logged out users when login as failed.
+     */
+    LOGIN_ATTEMPTED: 'LOGIN_ATTEMPTED',
+}

--- a/services/app-web/src/hooks/useLocalStorage.ts
+++ b/services/app-web/src/hooks/useLocalStorage.ts
@@ -2,16 +2,19 @@ import { useState, useEffect } from 'react'
 import { LocalStorageKeyType } from '../constants/localStorage'
 type LocalStorage = {
     key: LocalStorageKeyType
-    value: string | null
+    value?: string | string[] | boolean | object
 }
 
-type UseLocalStorage = [LocalStorage['value'], (value: string | null) => void]
-// Get and set keys in local storage. If key is set to a value of null, clear and remove from local storage, return default fallback value
+type UseLocalStorage = [
+    LocalStorage['value'],
+    (value: string | undefined) => void
+]
+// Get and set keys in local storage. If key is set to a value of undefined, clear and remove from local storage, return default fallback value
 function useLocalStorage(
     key: LocalStorage['key'],
     defaultValue: LocalStorage['value']
 ): UseLocalStorage {
-    const [storedValue, setStoredValue] = useState<string | null>(() => {
+    const [storedValue, setStoredValue] = useState<string | undefined>(() => {
         if (typeof window === 'undefined') {
             console.error('Unable to find local storage. window is undefined')
             return defaultValue
@@ -32,7 +35,7 @@ function useLocalStorage(
     })
 
     useEffect(() => {
-        if (storedValue === null) {
+        if (storedValue === undefined) {
             try {
                 window.localStorage.removeItem(key)
             } catch (error) {

--- a/services/app-web/src/hooks/useLocalStorage.ts
+++ b/services/app-web/src/hooks/useLocalStorage.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react'
+import { LocalStorageKeyType } from '../constants/localStorage'
+type LocalStorage = {
+    key: LocalStorageKeyType
+    value: string | null
+}
+
+type UseLocalStorage = [LocalStorage['value'], (value: string | null) => void]
+// Get, set, and remove keys from local storage with error handling. Returns a tuple similar to setState with one additional function [ value, setValue, clearValue]
+function useLocalStorage(
+    key: LocalStorage['key'],
+    defaultValue: LocalStorage['value']
+): UseLocalStorage {
+    const [storedValue, setStoredValue] = useState<string | null>(() => {
+        if (typeof window === 'undefined') {
+            console.error('Unable to find local storage. window is undefined')
+            return defaultValue
+        }
+
+        let value
+        try {
+            value = JSON.parse(
+                window.localStorage.getItem(key) || JSON.stringify(defaultValue)
+            )
+        } catch (error) {
+            console.error(
+                `Unable to set local storage. Error message: ${error}`
+            )
+            value = defaultValue
+        }
+        return value
+    })
+
+    useEffect(() => {
+        if (storedValue === null) {
+            try {
+                window.localStorage.removeItem(key)
+            } catch (error) {
+                console.error(
+                    `Unable to remove ${key} local storage. Error message: ${error.message}`
+                )
+            }
+        } else {
+            try {
+                window.localStorage.setItem(key, JSON.stringify(storedValue))
+            } catch (error) {
+                console.error(
+                    `Unable to set ${key} in local storage. Error message: ${error.message}`
+                )
+            }
+        }
+    }, [key, storedValue])
+
+    return [storedValue, setStoredValue]
+}
+
+export { useLocalStorage }

--- a/services/app-web/src/hooks/useLocalStorage.ts
+++ b/services/app-web/src/hooks/useLocalStorage.ts
@@ -6,7 +6,7 @@ type LocalStorage = {
 }
 
 type UseLocalStorage = [LocalStorage['value'], (value: string | null) => void]
-// Get, set, and remove keys from local storage with error handling. Returns a tuple similar to setState with one additional function [ value, setValue, clearValue]
+// Get and set keys in local storage. If key is set to a value of null, clear and remove from local storage, return default fallback value
 function useLocalStorage(
     key: LocalStorage['key'],
     defaultValue: LocalStorage['value']

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -23,9 +23,7 @@ import { SubmissionSummary } from '../SubmissionSummary'
 import { SubmissionRevisionSummary } from '../SubmissionRevisionSummary'
 import { useScrollToPageTop } from '../../hooks/useScrollToPageTop'
 import { featureFlags } from '../../common-code/featureFlags'
-
-const LOGIN_REDIRECT_STORAGE_KEY = 'LOGIN_REDIRECT'
-const LocalStorage = window.localStorage
+import { useLocalStorage } from '../../hooks/useLocalStorage'
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -146,6 +144,10 @@ export const AppRoutes = ({
     const { pathname } = useLocation()
     const navigate = useNavigate()
     const ldClient = useLDClient()
+    const [redirectPath, setRedirectPath] = useLocalStorage(
+        'LOGIN_REDIRECT',
+        null
+    )
     const showExpirationModal: boolean = ldClient?.variation(
         featureFlags.SESSION_EXPIRING_MODAL,
         true
@@ -175,6 +177,7 @@ export const AppRoutes = ({
     useEffect(() => {
         // When AppRoutes mounts and we are logged out, stash the url we navigated to in local storage
         // and redirect them to auth if they aren't heading for the dashboard.
+
         const dontRedirectToAuthRoutes: (RouteT | 'UNKNOWN_ROUTE')[] = [
             'ROOT' as const,
             'AUTH' as const,
@@ -184,12 +187,9 @@ export const AppRoutes = ({
             const currentRoute = getRouteName(initialPath)
             if (!dontRedirectToAuthRoutes.includes(currentRoute)) {
                 try {
-                    console.log('Storing For Redirect: ', initialPath)
-                    LocalStorage.setItem(
-                        LOGIN_REDIRECT_STORAGE_KEY,
-                        initialPath
-                    )
-
+                    if (redirectPath !== initialPath) {
+                        setRedirectPath(initialPath)
+                    }
                     if (authMode === 'IDM') {
                         console.log('redirecting to', idmRedirectURL())
                         window.location.href = idmRedirectURL()
@@ -198,24 +198,28 @@ export const AppRoutes = ({
                         navigate('/auth')
                     }
                 } catch (err) {
-                    console.log(
-                        'Error: Local Storage is Full Attempting to Save Redirect URL'
+                    console.error(
+                        `Error attempting to save login redirect URL. Error message: ${err}`
                     )
                 }
             }
             // Then, when we login, read that key, if it exists, go forth.
         } else {
-            const redirectPath = LocalStorage.getItem(
-                LOGIN_REDIRECT_STORAGE_KEY
-            )
             console.log('Retrieved For Redirect: ', redirectPath)
 
             if (redirectPath) {
                 navigate(redirectPath)
-                LocalStorage.removeItem(LOGIN_REDIRECT_STORAGE_KEY)
+                setRedirectPath(null)
             }
         }
-    }, [initialPath, loggedInUser, navigate, authMode])
+    }, [
+        initialPath,
+        loggedInUser,
+        navigate,
+        authMode,
+        redirectPath,
+        setRedirectPath,
+    ])
 
     /*
         Side effects that happen on page change

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -25,6 +25,7 @@ import { SubmissionRevisionSummary } from '../SubmissionRevisionSummary'
 import { useScrollToPageTop } from '../../hooks/useScrollToPageTop'
 import { featureFlags } from '../../common-code/featureFlags'
 import { useLocalStorage } from '../../hooks/useLocalStorage'
+import { recordJSException } from '../../otelHelpers'
 
 function componentForAuthMode(
     authMode: AuthModeType
@@ -199,7 +200,7 @@ export const AppRoutes = ({
                         navigate('/auth')
                     }
                 } catch (err) {
-                    console.error(
+                    recordJSException(
                         `Error attempting to save login redirect URL. Error message: ${err}`
                     )
                 }

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -146,7 +146,7 @@ export const AppRoutes = ({
     const ldClient = useLDClient()
     const [redirectPath, setRedirectPath] = useLocalStorage(
         'LOGIN_REDIRECT',
-        null
+        undefined
     )
     const showExpirationModal: boolean = ldClient?.variation(
         featureFlags.SESSION_EXPIRING_MODAL,


### PR DESCRIPTION
## Summary
Add new `useLocalStorage` hook and a constants file for local storage key values. 

#### Related issues
Prep for https://qmacbis.atlassian.net/browse/MR-897 I want to be able to quickly add a new keys to local storage and have error handling if local storage is already full or JSON.parse fails.  In the case of this bug want to track if a user is coming back from a failed login 

#### Screenshots

#### Test cases covered
- This hook can be tested within the components where it is used. For example, we already have CMS unlock and resubmit tests that test that the hook is working when a CMS user tries to visit a submission url directly (and is redirected through Auth flow and then login) 

## QA guidance

Test that IDM local is working as expected for CMS user visiting a specific submission URL
