### PR TITLE
[MR-76] Link styling for contact emails is the wrong shade of blue

### DIFF
--- a/services/app-web/src/components/Footer/Footer.module.scss
+++ b/services/app-web/src/components/Footer/Footer.module.scss
@@ -38,7 +38,9 @@
     a {
         color: $cms-color-white;
 
-        &:hover {
+        &:hover,
+        &:active,
+        &:visited {
             color: $cms-color-white;
         }
     }

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -41,6 +41,7 @@ export const ContactsSummarySection = ({
                                         href={`mailto:${stateContact.email}`}
                                         target="_blank"
                                         variant="external"
+                                        rel="noreferrer"
                                     >
                                         {stateContact.email}
                                     </Link>
@@ -81,6 +82,7 @@ export const ContactsSummarySection = ({
                                                     href={`mailto:${actuaryContact.email}`}
                                                     target="_blank"
                                                     variant="external"
+                                                    rel="noreferrer"
                                                 >
                                                     {actuaryContact.email}
                                                 </Link>

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -6,10 +6,27 @@ import {
     ActuaryCommunicationRecord,
 } from '../../../constants/healthPlanPackages'
 import { HealthPlanFormDataType } from '../../../common-code/healthPlanFormDataType'
+import { ActuaryContact } from '../../../common-code/healthPlanFormDataType'
 
 export type ContactsSummarySectionProps = {
     submission: HealthPlanFormDataType
     navigateTo?: string
+}
+
+const getActuaryFirm = (actuaryContact: ActuaryContact): string => {
+    if (
+        actuaryContact.actuarialFirmOther &&
+        actuaryContact.actuarialFirm === 'OTHER'
+    ) {
+        return actuaryContact.actuarialFirmOther
+    } else if (
+        actuaryContact.actuarialFirm &&
+        ActuaryFirmsRecord[actuaryContact.actuarialFirm]
+    ) {
+        return ActuaryFirmsRecord[actuaryContact.actuarialFirm]
+    } else {
+        return ''
+    }
 }
 
 export const ContactsSummarySection = ({
@@ -87,24 +104,7 @@ export const ContactsSummarySection = ({
                                                     {actuaryContact.email}
                                                 </Link>
                                                 <br />
-                                                {actuaryContact.actuarialFirm ===
-                                                'OTHER' ? (
-                                                    <>
-                                                        {
-                                                            actuaryContact.actuarialFirmOther
-                                                        }
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        {/*TODO: make this more clear, a const or something */}
-                                                        {actuaryContact.actuarialFirm
-                                                            ? ActuaryFirmsRecord[
-                                                                  actuaryContact
-                                                                      .actuarialFirm
-                                                              ]
-                                                            : ''}
-                                                    </>
-                                                )}
+                                                {getActuaryFirm(actuaryContact)}
                                             </address>
                                         </Grid>
                                     )

--- a/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContactsSummarySection/ContactsSummarySection.tsx
@@ -1,4 +1,4 @@
-import { Grid, GridContainer } from '@trussworks/react-uswds'
+import { Grid, GridContainer, Link } from '@trussworks/react-uswds'
 import styles from '../SubmissionSummarySection.module.scss'
 import { SectionHeader } from '../../SectionHeader'
 import {
@@ -37,9 +37,13 @@ export const ContactsSummarySection = ({
                                     <br />
                                     {stateContact.titleRole}
                                     <br />
-                                    <a href={`mailto:${stateContact.email}`}>
+                                    <Link
+                                        href={`mailto:${stateContact.email}`}
+                                        target="_blank"
+                                        variant="external"
+                                    >
                                         {stateContact.email}
-                                    </a>
+                                    </Link>
                                     <br />
                                 </address>
                             </Grid>
@@ -73,11 +77,13 @@ export const ContactsSummarySection = ({
                                                 <br />
                                                 {actuaryContact.titleRole}
                                                 <br />
-                                                <a
+                                                <Link
                                                     href={`mailto:${actuaryContact.email}`}
+                                                    target="_blank"
+                                                    variant="external"
                                                 >
                                                     {actuaryContact.email}
-                                                </a>
+                                                </Link>
                                                 <br />
                                                 {actuaryContact.actuarialFirm ===
                                                 'OTHER' ? (


### PR DESCRIPTION
## Summary
[MR-76](https://qmacbis.atlassian.net/browse/MR-76)

Fixed styling of the contact email links. Changed the email links to use `Link` from react-uswds and opening up new tab when clicking on email link.

**NOTE** Also fixed the feedback email text color in the footer to be white after visited.

#### Related issues

#### Screenshots
![Screen Shot 2022-06-21 at 10 53 46 AM](https://user-images.githubusercontent.com/98117700/174832528-9f693643-f61f-41c2-9681-7a0ff29dfd11.png)

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
