### PR TITLE
[MR-25] Recently unlocked submissions should be at top of submission dashboard

### DIFF
--- a/services/app-api/src/postgres/insertHealthPlanRevision.ts
+++ b/services/app-api/src/postgres/insertHealthPlanRevision.ts
@@ -16,8 +16,9 @@ export async function insertHealthPlanRevision(
     client: PrismaClient,
     args: InsertHealthPlanRevisionArgsType
 ): Promise<HealthPlanPackageType | StoreError> {
-    const protobuf = toProtoBuffer(args.draft)
+    args.draft.updatedAt = new Date()
 
+    const protobuf = toProtoBuffer(args.draft)
     const buffer = Buffer.from(protobuf)
 
     const { unlockInfo, pkgID } = args

--- a/services/app-web/src/pages/App/App.tsx
+++ b/services/app-web/src/pages/App/App.tsx
@@ -50,9 +50,7 @@ function App({
                         <S3Provider client={s3Client}>
                             <AuthProvider authMode={authMode}>
                                 <PageProvider>
-                                    <>
-                                        <AppBody authMode={authMode} />
-                                    </>
+                                    <AppBody authMode={authMode} />
                                 </PageProvider>
                             </AuthProvider>
                         </S3Provider>


### PR DESCRIPTION
## Summary
[MR-25](https://qmacbis.atlassian.net/browse/MR-25)

Recently unlocked submissions should be at top of submission dashboard. Unlocking a submission was not updating the `updatedAt` field in the `protobuf` data. Add `args.draft.updatedAt = new Date()` in `insetHealthPlanRevision.ts` function updates the field when unlocking.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
