### PR TITLE
Enforce the v3 hashing update on an unchange func

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -53,7 +53,7 @@ jobs:
           IAM_PATH: ${{ secrets.iam_path }}
           FULL_IAM_PERMISSIONS_BOUNDARY_POLICY: ${{ secrets.full_iam_permissions_boundary_policy }}
         run: |
-          pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
+          pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }} --enforce-hash-update
 
   ui:
     if: ${{ contains(inputs.changed_services, 'ui') }}

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -1,5 +1,4 @@
 service: postgres
-variablesResolutionMode: 20210326
 
 frameworkVersion: '^3.19.0'
 


### PR DESCRIPTION
## Summary

Serverless v3 uses a new hashing function for lambdas. Since we use the AWS supplied function for secrets manager rotation, we'll need to [tell serverless to update the hashing algo](https://www.serverless.com/framework/docs/guides/upgrading-v3#lambda-hashing-algorithm) used. We can remove this once it goes through promote once.
