### PR TITLE
No longer need --enforce-hash-update

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -53,7 +53,7 @@ jobs:
           IAM_PATH: ${{ secrets.iam_path }}
           FULL_IAM_PERMISSIONS_BOUNDARY_POLICY: ${{ secrets.full_iam_permissions_boundary_policy }}
         run: |
-          pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }} --enforce-hash-update
+          pushd services/postgres && npx serverless deploy --stage ${{ inputs.stage_name }}
 
   ui:
     if: ${{ contains(inputs.changed_services, 'ui') }}


### PR DESCRIPTION
## Summary
Since #1027 was used for the Serverless v3 upgrade, we can remove this one time deploy option now that it has rolled out to dev/val/prod.