### PR TITLE
Move to AWS::AccountId

### DIFF
--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -109,7 +109,7 @@ resources:
       Type: AWS::S3::Bucket
       Condition: CreateNRInfraMonitoring
       Properties:
-        BucketName: !Sub newrelic-firehose-${sls:stage}-${aws:accountId}
+        BucketName: !Sub newrelic-firehose-${sls:stage}-${AWS::AccountId}
         PublicAccessBlockConfiguration:
           BlockPublicAcls: true
           BlockPublicPolicy: true
@@ -160,7 +160,7 @@ resources:
                 - 'sts:AssumeRole'
               Condition:
                 StringEquals:
-                  'sts:ExternalId': !Sub ${aws:accountId}
+                  'sts:ExternalId': !Sub ${AWS::AccountId}
         Policies:
           - PolicyName: MetricStreams-FirehosePutRecords
             PolicyDocument:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -41,14 +41,14 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   iamPermissionsBoundaryPolicy: ${env:FULL_IAM_PERMISSIONS_BOUNDARY_POLICY, ""}
   iamPath: ${env:IAM_PATH, "/"}
-  databaseName: !Sub aurora_${self:service}_${sls:stage}_${aws:accountId}
+  databaseName: !Sub aurora_${self:service}_${sls:stage}_${AWS::AccountId}
   vpcId: ${ssm:/configuration/${sls:stage}/vpc/id, ssm:/configuration/default/vpc/id}
   sgId: ${ssm:/configuration/${sls:stage}/vpc/sg/id, ssm:/configuration/default/vpc/sg/id}
   privateSubnets:
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/a/id, ssm:/configuration/default/vpc/subnets/private/a/id}
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/b/id, ssm:/configuration/default/vpc/subnets/private/b/id}
     - ${ssm:/configuration/${sls:stage}/vpc/subnets/private/c/id, ssm:/configuration/default/vpc/subnets/private/c/id}
-  rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${aws:accountId}:function:${self:service}-${sls:stage}-rotator'
+  rotatorArn: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:service}-${sls:stage}-rotator'
   serverlessTerminationProtection:
     stages:
       - dev
@@ -124,7 +124,7 @@ resources:
       Type: AWS::SecretsManager::SecretTargetAttachment
       Properties:
         SecretId: !Ref PostgresSecret
-        TargetId: !Sub 'arn:aws:rds:${AWS::Region}:${aws:accountId}:cluster:${PostgresAurora}'
+        TargetId: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAurora}'
         TargetType: AWS::RDS::DBCluster
 
     PostgresSecretsRotationSchedule:
@@ -149,4 +149,4 @@ resources:
 
   Outputs:
     PostgresAuroraArn:
-      Value: !Sub 'arn:aws:rds:${AWS::Region}:${aws:accountId}:cluster:${PostgresAurora}'
+      Value: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:${PostgresAurora}'

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -58,7 +58,7 @@ resources:
           Fn::If:
             - CreateEmailConfiguration
             - EmailSendingAccount: DEVELOPER
-              SourceArn: !Sub arn:aws:ses:us-east-1:${aws:accountId}:identity/${self:custom.sesSourceEmailAddress}
+              SourceArn: !Sub arn:aws:ses:us-east-1:${AWS::AccountId}:identity/${self:custom.sesSourceEmailAddress}
             - !Ref AWS::NoValue
         Schema:
           - Name: given_name
@@ -183,7 +183,7 @@ resources:
                 - Effect: 'Allow'
                   Action:
                     - 'execute-api:Invoke'
-                  Resource: !Sub arn:aws:execute-api:${AWS::Region}:${aws:accountId}:${self:custom.api_gateway_rest_api_name}/*
+                  Resource: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${self:custom.api_gateway_rest_api_name}/*
 
                 - Effect: 'Allow'
                   Action:

--- a/services/uploads/package.json
+++ b/services/uploads/package.json
@@ -11,6 +11,7 @@
         "copy-webpack-plugin": "^10.2.4",
         "serverless-webpack": "^5.7.1",
         "serverless": "^3.19.0",
+        "serverless-offline": "^8.8.0",
         "serverless-iam-helper": "CMSgov/serverless-iam-helper",
         "serverless-idempotency-helper": "CMSgov/serverless-idempotency-helper",
         "serverless-plugin-scripts": "^1.0.2",

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '^3.19.0'
 plugins:
   - serverless-plugin-scripts
   - serverless-s3-local
+  - serverless-offline
   - serverless-stack-termination-protection
   - serverless-idempotency-helper
   - serverless-iam-helper
@@ -31,14 +32,14 @@ provider:
             - s3:DeleteObject
             - s3:ListBucket
           Resource:
-            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${aws:accountId}/*
-            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-avscan-${aws:accountId}/*
+            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${AWS::AccountId}/*
+            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-avscan-${AWS::AccountId}/*
         - Effect: 'Allow'
           Action:
             - s3:ListBucket
           Resource:
-            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${aws:accountId}
-            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-avscan-${aws:accountId}
+            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${AWS::AccountId}
+            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-avscan-${AWS::AccountId}
 
 custom:
   region: ${aws:region}
@@ -110,7 +111,7 @@ resources:
     DocumentUploadsBucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: !Sub ${self:service}-${sls:stage}-uploads-${aws:accountId}
+        BucketName: !Sub ${self:service}-${sls:stage}-uploads-${AWS::AccountId}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
@@ -182,13 +183,13 @@ resources:
         FunctionName: !GetAtt AvScanLambdaFunction.Arn
         Action: lambda:InvokeFunction
         Principal: s3.amazonaws.com
-        SourceAccount: !Sub ${aws:accountId}
-        SourceArn: !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${aws:accountId}
+        SourceAccount: !Sub ${AWS::AccountId}
+        SourceArn: !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${AWS::AccountId}
 
     ClamDefsBucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: !Sub ${self:service}-${sls:stage}-avscan-${aws:accountId}
+        BucketName: !Sub ${self:service}-${sls:stage}-avscan-${AWS::AccountId}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:


### PR DESCRIPTION
## Summary

In the Serverless v3 upgrade we moved to using the ${aws.accountId} variable replacement syntax, but it looks like it's causing some issues with the `serverless-s3-local` plugin. It also doesn't have a fallback value. Since the ${AWS::AccountId} syntax is still available, let's just use that, as it seems to work fine and doesn't cause s3 local to break.

### Related Issues
Fixes:
https://qmacbis.atlassian.net/browse/MR-2378
https://qmacbis.atlassian.net/browse/MR-2375