### PR TITLE
turn off eslint in code climate b/c it is erroring

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -49,9 +49,9 @@ plugins:
       languages:
         javascript:
           count_threshold: 3
-  eslint:
-    enabled: true
-    channel: 'eslint-7'
+  # eslint:
+  #   enabled: true
+  #   channel: 'eslint-7'
 
 exclude_patterns:
   - 'config/'


### PR DESCRIPTION
## Summary

eslint has been erroring in code climate every single time for more than a month now. It might be a version mismatch problem, we install 8 but code climate only goes to 7. I’m turning it off so that Stephanie Copell doesn’t keep getting inundated with emails about the errors. 

Example failure: https://codeclimate.com/repos/616dbb175e8227015001784f/builds/2851
