### PR TITLE
Change deploy.yml GH permissions for dependabot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,5 @@
 name: Deploy
 
-permissions:
-  pull-requests: write
-
 on:
   push:
     branches:
@@ -15,6 +12,8 @@ jobs:
   begin-deployment:
     name: Begin Deployment
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     outputs:
       deploy-id: ${{ steps.ghdeployment.outputs.deployment_id }}
       stage-name: ${{ steps.stage-name.outputs.stage-name-for-branch}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy
 
+permissions:
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary

We'd like to have dependabot PRs run through CI without needing to be manually triggered by an engineer. This gives PRs opened by dependabot write access via the `GITHUB_TOKEN` so that our review apps can be created.
