### PR TITLE
Add GH permissions to 'end-deployment' and 'cypress'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -275,7 +275,8 @@ jobs:
     if: always() && needs.begin-deployment.result == 'success'
     name: End Deployment
     runs-on: ubuntu-latest
-
+    permissions:
+      deployments: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -302,6 +302,8 @@ jobs:
     if: always() && needs.finishing-prep.result == 'success'
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome91-ff89
+    permissions:
+      deployments: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -282,7 +282,7 @@ jobs:
 
       - name: Update deployment status (failure)
         if: failure() && needs.begin-deployment.result == 'success'
-        uses: chrnorm/deployment-status@releases/v1
+        uses: chrnorm/deployment-status@releases/v2
         with:
           token: '${{ github.token }}'
           state: 'failure'


### PR DESCRIPTION
## Summary
This adds onto #1079, adding the `GITHUB_SECRET` permissions to the last phase of CI for dependabot.
