### PR TITLE
Run app-web serverless serially

### DIFF
--- a/services/app-web/serverless.yml
+++ b/services/app-web/serverless.yml
@@ -75,12 +75,5 @@ custom:
         export REACT_APP_OTEL_COLLECTOR_URL=${self:custom.api_url}/otel
         export REACT_APP_LD_CLIENT_ID=${self:custom.react_app_ld_client_id}
 
-        # run the app-api build and the storybook build in parallel. 
-        # this isn't elegant but saves us CI time, it's probably more correct to break
-        # these out into separate processes. N.B. the output of these two commands
-        # will be interleaved.
-        yarn run build &
-        P1=$!
-        yarn build-storybook &
-        P2=$!
-        wait $P1 && wait $P2
+        yarn run build
+        yarn build-storybook


### PR DESCRIPTION
## Summary

Maz had been seeing some CI issues in `app-web` where the serverless deploy would hit an OOM. We fixed it in his branch, but it looks like it got reverted with #1075 . This adds it back in order to avoid those occasional GHA OOMs in `app-web`.
