### PR TITLE
[MR-2485] Program selection combobox not focused when error clicked

### DIFF
--- a/services/app-web/src/components/FileUpload/FileProcessor/FileProcessor.tsx
+++ b/services/app-web/src/components/FileUpload/FileProcessor/FileProcessor.tsx
@@ -127,8 +127,6 @@ export const FileProcessor = ({
     const isComplete = status === 'UPLOAD_COMPLETE'
     const fileType = path.extname(name)
 
-    console.log(fileType)
-
     const isPDF = fileTypes.PDF.indexOf(fileType) >= 0
     const isWord = fileTypes.WORD.indexOf(fileType) >= 0
     const isVideo = fileTypes.VIDEO.indexOf(fileType) >= 0

--- a/services/app-web/src/components/ProgramSelect/ProgramSelect.stories.tsx
+++ b/services/app-web/src/components/ProgramSelect/ProgramSelect.stories.tsx
@@ -11,6 +11,7 @@ const statePrograms = mockMNState().programs
 
 export const Default: Story<ProgramSelectPropType> = () => (
     <ProgramSelect
+        name="programSelect"
         statePrograms={statePrograms}
         programIDs={['ea16a6c0-5fc6-4df8-adac-c627e76660ab']}
     />

--- a/services/app-web/src/components/ProgramSelect/ProgramSelect.test.tsx
+++ b/services/app-web/src/components/ProgramSelect/ProgramSelect.test.tsx
@@ -14,6 +14,7 @@ describe('ProgramSelect', () => {
         })
         renderWithProviders(
             <ProgramSelect
+                name="programSelect"
                 statePrograms={mockStatePrograms}
                 programIDs={[]}
                 onChange={mockOnChange}
@@ -38,6 +39,7 @@ describe('ProgramSelect', () => {
         })
         renderWithProviders(
             <ProgramSelect
+                name="programSelect"
                 statePrograms={mockStatePrograms}
                 programIDs={[]}
                 onChange={mockOnChange}
@@ -74,6 +76,7 @@ describe('ProgramSelect', () => {
         })
         renderWithProviders(
             <ProgramSelect
+                name="programSelect"
                 statePrograms={mockStatePrograms}
                 programIDs={[
                     '3fd36500-bf2c-47bc-80e8-e7aa417184c5',

--- a/services/app-web/src/components/ProgramSelect/ProgramSelect.tsx
+++ b/services/app-web/src/components/ProgramSelect/ProgramSelect.tsx
@@ -52,9 +52,8 @@ export const ProgramSelect = ({
             })}
             className={styles.multiSelect}
             classNamePrefix="program-select"
-            id="programSelect"
+            id={`${name}-programSelect`}
             name={name}
-            aria-label="programs (required)"
             options={programOptions}
             isMulti
             ariaLiveMessages={{

--- a/services/app-web/src/components/ProgramSelect/ProgramSelect.tsx
+++ b/services/app-web/src/components/ProgramSelect/ProgramSelect.tsx
@@ -4,6 +4,7 @@ import Select, { AriaOnFocus, Props } from 'react-select'
 import { Program } from '../../gen/gqlClient'
 
 export type ProgramSelectPropType = {
+    name: string
     statePrograms: Program[]
     programIDs: string[]
 }
@@ -16,6 +17,7 @@ interface ProgramOption {
 }
 
 export const ProgramSelect = ({
+    name,
     statePrograms,
     programIDs,
     ...selectProps
@@ -50,8 +52,8 @@ export const ProgramSelect = ({
             })}
             className={styles.multiSelect}
             classNamePrefix="program-select"
-            id="programIDs"
-            name="programIDs"
+            id="programSelect"
+            name={name}
             aria-label="programs (required)"
             options={programOptions}
             isMulti

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -87,7 +87,7 @@ export const RateDetails = ({
     const ldClient = useLDClient()
 
     //If rate program feature flag is off, then turn off displaying program list and omit from Yup schema.
-    const showRatePrograms = !ldClient?.variation(
+    const showRatePrograms = ldClient?.variation(
         featureFlags.RATE_CERT_PROGRAMS,
         false
     )

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -87,7 +87,7 @@ export const RateDetails = ({
     const ldClient = useLDClient()
 
     //If rate program feature flag is off, then turn off displaying program list and omit from Yup schema.
-    const showRatePrograms = ldClient?.variation(
+    const showRatePrograms = !ldClient?.variation(
         featureFlags.RATE_CERT_PROGRAMS,
         false
     )
@@ -334,6 +334,26 @@ export const RateDetails = ({
         }
     }
 
+    const generateErrorSummaryErrors = (
+        errors: FormikErrors<RateDetailsFormValues>
+    ) => {
+        const errorSummaryErrors = { ...errors }
+        //If rate certification program(s) is not selected and error is in FormikErrors, replace rateProgramIDs key with #rateProgramIDs.
+        // This is done in order to be able to focus the input element by id from react-select component.
+        if (errorSummaryErrors.rateProgramIDs) {
+            delete errorSummaryErrors.rateProgramIDs
+            Object.assign(errorSummaryErrors, {
+                '#rateProgramIDs': errors.rateProgramIDs,
+            })
+        }
+        if (documentsErrorMessage) {
+            Object.assign(errorSummaryErrors, {
+                [documentsErrorKey]: documentsErrorMessage,
+            })
+        }
+        return errorSummaryErrors
+    }
+
     return (
         <Formik
             initialValues={rateDetailsInitialValues}
@@ -374,15 +394,9 @@ export const RateDetails = ({
                             <FormGroup error={showFileUploadError}>
                                 {shouldValidate && (
                                     <ErrorSummary
-                                        errors={
-                                            documentsErrorMessage
-                                                ? {
-                                                      [documentsErrorKey]:
-                                                          documentsErrorMessage,
-                                                      ...errors,
-                                                  }
-                                                : errors
-                                        }
+                                        errors={generateErrorSummaryErrors(
+                                            errors
+                                        )}
                                         headingRef={errorSummaryHeadingRef}
                                     />
                                 )}
@@ -438,8 +452,8 @@ export const RateDetails = ({
                                         {/* @ts-ignore */}
                                         {({ form }) => (
                                             <ProgramSelect
-                                                id="rateProgramIDs"
                                                 name="rateProgramIDs"
+                                                inputId="rateProgramIDs"
                                                 statePrograms={statePrograms}
                                                 programIDs={
                                                     values.rateProgramIDs

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -458,6 +458,7 @@ export const RateDetails = ({
                                                 programIDs={
                                                     values.rateProgramIDs
                                                 }
+                                                aria-label="programs (required)"
                                                 onChange={(selectedOption) =>
                                                     form.setFieldValue(
                                                         'rateProgramIDs',

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -337,21 +337,22 @@ export const RateDetails = ({
     const generateErrorSummaryErrors = (
         errors: FormikErrors<RateDetailsFormValues>
     ) => {
-        const errorSummaryErrors = { ...errors }
-        //If rate certification program(s) is not selected and error is in FormikErrors, replace rateProgramIDs key with #rateProgramIDs.
-        // This is done in order to be able to focus the input element by id from react-select component.
-        if (errorSummaryErrors.rateProgramIDs) {
-            delete errorSummaryErrors.rateProgramIDs
-            Object.assign(errorSummaryErrors, {
-                '#rateProgramIDs': errors.rateProgramIDs,
-            })
-        }
+        const errorObject = {}
+        const formikErrors = { ...errors }
+
         if (documentsErrorMessage) {
-            Object.assign(errorSummaryErrors, {
+            Object.assign(errorObject, {
                 [documentsErrorKey]: documentsErrorMessage,
             })
         }
-        return errorSummaryErrors
+        if (formikErrors.rateProgramIDs) {
+            Object.assign(errorObject, {
+                '#rateProgramIDs': formikErrors.rateProgramIDs,
+            })
+            delete formikErrors.rateProgramIDs
+        }
+
+        return { ...errorObject, ...formikErrors }
     }
 
     return (

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetailsSchema.ts
@@ -5,6 +5,7 @@ import { validateDateFormat } from '../../../formHelpers'
 Yup.addMethod(Yup.date, 'validateDateFormat', validateDateFormat)
 
 const RateDetailsFormSchema = Yup.object().shape({
+    rateProgramIDs: Yup.array().min(1, 'You must select a program'),
     rateType: Yup.string().defined('You must choose a rate certification type'),
     rateCapitationType: Yup.string().defined(
         "You must select whether you're certifying rates or rate ranges"
@@ -86,6 +87,5 @@ const RateDetailsFormSchema = Yup.object().shape({
                 'The end date must come after the start date'
             ),
     }),
-    rateProgramIDs: Yup.array().min(1, 'You must select a program'),
 })
 export { RateDetailsFormSchema }

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -210,16 +210,17 @@ export const SubmissionType = ({
     const generateErrorSummaryErrors = (
         errors: FormikErrors<SubmissionTypeFormValues>
     ) => {
-        const errorSummaryErrors = { ...errors }
-        //If package program(s) is not selected and error is in FormikErrors, replace programIDs key with #programIDs.
-        // This is done in order to be able to focus the input element by id from react-select component.
-        if (errorSummaryErrors.programIDs) {
-            delete errorSummaryErrors.programIDs
-            Object.assign(errorSummaryErrors, {
-                '#programIDs': errors.programIDs,
+        const errorObject = {}
+        const formikErrors = { ...errors }
+
+        if (formikErrors.programIDs) {
+            Object.assign(errorObject, {
+                '#programIDs': formikErrors.programIDs,
             })
+            delete formikErrors.programIDs
         }
-        return errorSummaryErrors
+
+        return { ...errorObject, ...formikErrors }
     }
 
     return (

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -279,6 +279,7 @@ export const SubmissionType = ({
                                             inputId="programIDs"
                                             statePrograms={statePrograms}
                                             programIDs={values.programIDs}
+                                            aria-label="programs (required)"
                                             onChange={(selectedOption) =>
                                                 form.setFieldValue(
                                                     'programIDs',

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -207,6 +207,21 @@ export const SubmissionType = ({
         }
     }
 
+    const generateErrorSummaryErrors = (
+        errors: FormikErrors<SubmissionTypeFormValues>
+    ) => {
+        const errorSummaryErrors = { ...errors }
+        //If package program(s) is not selected and error is in FormikErrors, replace programIDs key with #programIDs.
+        // This is done in order to be able to focus the input element by id from react-select component.
+        if (errorSummaryErrors.programIDs) {
+            delete errorSummaryErrors.programIDs
+            Object.assign(errorSummaryErrors, {
+                '#programIDs': errors.programIDs,
+            })
+        }
+        return errorSummaryErrors
+    }
+
     return (
         <Formik
             initialValues={submissionTypeInitialValues}
@@ -241,7 +256,7 @@ export const SubmissionType = ({
 
                             {shouldValidate && (
                                 <ErrorSummary
-                                    errors={errors}
+                                    errors={generateErrorSummaryErrors(errors)}
                                     headingRef={errorSummaryHeadingRef}
                                 />
                             )}
@@ -260,8 +275,8 @@ export const SubmissionType = ({
                                     {/* @ts-ignore */}
                                     {({ form }) => (
                                         <ProgramSelect
-                                            id="programIDs"
                                             name="programIDs"
+                                            inputId="programIDs"
                                             statePrograms={statePrograms}
                                             programIDs={values.programIDs}
                                             onChange={(selectedOption) =>


### PR DESCRIPTION
## Summary
[MR-2485](https://qmacbis.atlassian.net/browse/MR-2485)

Seems like the issue was the `name` prop for `Select` component was not applying or incorrectly applying to the `input` element used in the component. Then focusing using the `name` attribute did not work. 

The fix was to pass `inputId` to `Select` component from `react-select` and then focus using `id` instead of `name` attribute. Then refactor forming error object passed into `ErrorSummary` to select `rateProgramIDs/programIDs` by adding `#` in front of each key. As described in the comments in `ErrorSummary` adding an `#` will switch from focusing using `name` to `id` attribute.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
1. Please make sure `rate-certificiation-programs` feature flag is enabled in LaunchDarkly.
2. On the Submission type or Rate Details page, leave the program selection box empty and click continue. 
3. Click on the link the error summary should now scroll to the program select box and highlight it.
4. Please make sure to disable feature flag when finished.