### PR TITLE
Add last updated to CMS Dashboard

### DIFF
--- a/services/app-web/src/common-code/dateHelpers/index.ts
+++ b/services/app-web/src/common-code/dateHelpers/index.ts
@@ -1,3 +1,4 @@
 export { formatCalendarDate, formatRateNameDate } from './calendarDate'
 export { formatGQLDate } from './gqlDate'
+export { mostRecentDate, isDate } from './mostRecentDate'
 export { dayjs } from './dayjs'

--- a/services/app-web/src/common-code/dateHelpers/mostRecentDate.test.ts
+++ b/services/app-web/src/common-code/dateHelpers/mostRecentDate.test.ts
@@ -1,0 +1,32 @@
+import { mostRecentDate } from './'
+
+describe('mostRecentDate', () => {
+    const timeNow = new Date()
+    const timeABitLater = new Date()
+    const may1998 = new Date('1998-05-01')
+    const jan2100 = new Date('2100-01-01')
+
+    test.each([
+        [[may1998, new Date('1998-01-15'), new Date('1998-02-01')], may1998],
+        [
+            [may1998, undefined, jan2100, new Date('1998-02-01'), undefined],
+            jan2100,
+        ],
+        [
+            [
+                may1998,
+                timeNow,
+                new Date('1998-01-15'),
+                timeABitLater,
+                undefined,
+            ],
+            timeNow,
+        ],
+        [[undefined, undefined, undefined], undefined],
+    ])(
+        'given %p as dates array, returns the date %p',
+        (dates, expectedResult) => {
+            expect(mostRecentDate(dates)).toEqual(expectedResult)
+        }
+    )
+})

--- a/services/app-web/src/common-code/dateHelpers/mostRecentDate.ts
+++ b/services/app-web/src/common-code/dateHelpers/mostRecentDate.ts
@@ -1,0 +1,20 @@
+const isDate = (item: Date | undefined): item is Date => {
+    return !!item
+}
+
+// Calculate most recent date from a list of options
+// Allow undefined as parameter since most of our dates types can be undefined coming from the data model.
+const mostRecentDate = (dates: Array<Date | undefined>): Date | undefined => {
+    if (dates.every((date) => date === undefined)) {
+        console.error(
+            'Cannot calculate most recent date. All dates are undefined'
+        )
+        return undefined
+    }
+
+    const times = dates.filter(isDate).map((date) => date.getTime())
+
+    return new Date(Math.max(...times))
+}
+
+export { mostRecentDate, isDate }

--- a/services/app-web/src/common-code/dateHelpers/mostRecentDate.ts
+++ b/services/app-web/src/common-code/dateHelpers/mostRecentDate.ts
@@ -12,7 +12,7 @@ const mostRecentDate = (dates: Array<Date | undefined>): Date | undefined => {
         return undefined
     }
 
-    const times = dates.filter(isDate).map((date) => date.getTime())
+    const times = dates.filter(isDate).map((date) => new Date(date).getTime())
 
     return new Date(Math.max(...times))
 }

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -7,10 +7,6 @@ export const featureFlags = {
      Toggles the /health api endpoint
     */
     API_ENABLE_HEALTH_ENDPOINT: 'enable-health-endpoint',
-    /*
-     Toggles the CMS dashboard view
-    */
-    CMS_DASHBOARD: 'cms-dashboard',
     /* 
      Enables the modal that alerts the user to an expiring session
     */

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -2,6 +2,7 @@ import {
     UnlockedHealthPlanFormDataType,
     LockedHealthPlanFormDataType,
 } from '../healthPlanFormDataType'
+import { mockMNState } from '../../testHelpers/apolloHelpers'
 
 function newHealthPlanFormData(): UnlockedHealthPlanFormDataType {
     return {
@@ -426,7 +427,11 @@ function unlockedWithALittleBitOfEverything(): UnlockedHealthPlanFormDataType {
         status: 'DRAFT',
         stateCode: 'MN',
         stateNumber: 5,
-        programIDs: ['snbc'],
+        programIDs: [
+            mockMNState().programs[0].id,
+            mockMNState().programs[1].id,
+            mockMNState().programs[2].id,
+        ],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [
@@ -525,7 +530,7 @@ function basicLockedHealthPlanFormData(): LockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_ONLY',
         submissionDescription: 'A real submission',
         documents: [],

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -46,7 +46,7 @@ function newHealthPlanFormData(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [],
@@ -68,7 +68,7 @@ function basicHealthPlanFormData(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [],
@@ -94,7 +94,7 @@ function contractOnly(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_ONLY',
         submissionDescription: 'A real submission',
         documents: [],
@@ -120,7 +120,7 @@ function contractAmendedOnly(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_ONLY',
         submissionDescription: 'A real submission',
         documents: [],
@@ -166,7 +166,7 @@ function unlockedWithContacts(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [],
@@ -217,7 +217,7 @@ function unlockedWithDocuments(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [
@@ -285,7 +285,7 @@ function unlockedWithFullRates(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [
@@ -317,7 +317,7 @@ function unlockedWithFullRates(): UnlockedHealthPlanFormDataType {
             effectiveDateStart: new Date(Date.UTC(2022, 5, 21)),
             effectiveDateEnd: new Date(Date.UTC(2022, 9, 21)),
         },
-        rateProgramIDs: ['snbc'],
+        rateProgramIDs: [mockMNState().programs[0].id],
         stateContacts: [
             {
                 name: 'foo bar',
@@ -357,7 +357,7 @@ function unlockedWithFullContracts(): UnlockedHealthPlanFormDataType {
         stateNumber: 5,
         id: 'test-abc-123',
         stateCode: 'MN',
-        programIDs: ['snbc'],
+        programIDs: [mockMNState().programs[0].id],
         submissionType: 'CONTRACT_AND_RATES',
         submissionDescription: 'A real submission',
         documents: [
@@ -421,7 +421,7 @@ function unlockedWithFullContracts(): UnlockedHealthPlanFormDataType {
             effectiveDateStart: new Date(Date.UTC(2022, 5, 21)),
             effectiveDateEnd: new Date(Date.UTC(2022, 9, 21)),
         },
-        rateProgramIDs: ['snbc'],
+        rateProgramIDs: [mockMNState().programs[0].id],
         stateContacts: [
             {
                 name: 'foo bar',
@@ -523,7 +523,7 @@ function unlockedWithALittleBitOfEverything(): UnlockedHealthPlanFormDataType {
             effectiveDateStart: new Date(Date.UTC(2022, 5, 21)),
             effectiveDateEnd: new Date(Date.UTC(2022, 9, 21)),
         },
-        rateProgramIDs: ['snbc'],
+        rateProgramIDs: [mockMNState().programs[0].id],
         stateContacts: [
             {
                 name: 'foo bar',

--- a/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataMocks/healthPlanFormData.ts
@@ -1,8 +1,42 @@
 import {
     UnlockedHealthPlanFormDataType,
     LockedHealthPlanFormDataType,
+    ProgramArgType,
 } from '../healthPlanFormDataType'
-import { mockMNState } from '../../testHelpers/apolloHelpers'
+
+type State = {
+    code: string
+    name: string
+    programs: ProgramArgType[]
+}
+export function mockMNState(): State {
+    return {
+        name: 'Minnesota',
+        programs: [
+            {
+                id: 'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
+                fullName: 'Special Needs Basic Care',
+                name: 'SNBC',
+            },
+            {
+                id: 'd95394e5-44d1-45df-8151-1cc1ee66f100',
+                fullName: 'Prepaid Medical Assistance Program',
+                name: 'PMAP',
+            },
+            {
+                id: 'ea16a6c0-5fc6-4df8-adac-c627e76660ab',
+                fullName: 'Minnesota Senior Care Plus ',
+                name: 'MSC+',
+            },
+            {
+                id: '3fd36500-bf2c-47bc-80e8-e7aa417184c5',
+                fullName: 'Minnesota Senior Health Options',
+                name: 'MSHO',
+            },
+        ],
+        code: 'MN',
+    }
+}
 
 function newHealthPlanFormData(): UnlockedHealthPlanFormDataType {
     return {

--- a/services/app-web/src/common-code/healthPlanFormDataType/State.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/State.ts
@@ -1,0 +1,13 @@
+type StateType = {
+    code: string
+    name: string
+    programs: ProgramArgType[]
+}
+
+interface ProgramArgType {
+    id: string
+    name: string // short name. This is used most often in the application including in submission name
+    fullName: string // full name is used in submission summary page
+}
+
+export type { StateType, ProgramArgType }

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -4,6 +4,7 @@ import { LockedHealthPlanFormDataType } from './LockedHealthPlanFormDataType'
 import { HealthPlanFormDataType } from './HealthPlanFormDataType'
 import { RateDataType } from '.'
 import { formatRateNameDate } from '../../common-code/dateHelpers'
+import { ProgramArgType } from '.'
 
 const isContractOnly = (
     sub: UnlockedHealthPlanFormDataType | LockedHealthPlanFormDataType
@@ -141,12 +142,6 @@ const naturalSort = (a: string, b: string): number => {
 // Since these functions are in common code, we don't want to rely on the api or gql program types
 // instead we create an interface with what is required for these functions, since both those types
 // implement it, we can use it interchangeably
-interface ProgramArgType {
-    id: string
-    name: string // short name. This is used most often in the application including in submission name
-    fullName: string // full name is used in submission summary page
-}
-
 // Pull out the programs names for display from the program IDs
 function programNames(
     programs: ProgramArgType[],
@@ -239,5 +234,3 @@ export {
     packageName,
     generateRateName,
 }
-
-export type { ProgramArgType }

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -41,4 +41,4 @@ export {
 } from './healthPlanFormData'
 
 export type { HealthPlanFormDataType } from './HealthPlanFormDataType'
-export type { ProgramArgType } from './healthPlanFormData'
+export type { ProgramArgType, StateType } from './State'

--- a/services/app-web/src/components/Header/EmptyHeader.tsx
+++ b/services/app-web/src/components/Header/EmptyHeader.tsx
@@ -1,0 +1,35 @@
+import { Grid, GridContainer } from '@trussworks/react-uswds'
+import React from 'react'
+import onemacLogo from '../../assets/images/onemac-logo.svg'
+import { Logo } from '../Logo'
+import styles from './Header.module.scss'
+
+/**
+ * MC-Review Empty Header - this wrapper does not require any data on the page to display.
+ * For use on full page crashes in ErrorBoundaryRoot
+ */
+export const EmptyHeader = ({
+    children,
+}: {
+    children: React.ReactNode
+}): React.ReactElement => {
+    return (
+        <header>
+            <div className={styles.banner}>
+                <GridContainer>
+                    <Grid row className="flex-justify flex-align-center">
+                        <div className={styles.bannerLogo}>
+                            <Logo
+                                src={onemacLogo}
+                                alt="One Mac"
+                                className={styles.logoImg}
+                            />
+                            <span>Managed Care Review</span>
+                        </div>
+                        {children}
+                    </Grid>
+                </GridContainer>
+            </div>
+        </header>
+    )
+}

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
@@ -132,15 +132,15 @@ describe('CMSDashboard', () => {
             {},
             { updatedAt: new Date() }
         )
-        const unlocked2008 = mockUnlockedHealthPlanPackage(
+        const unlocked202108 = mockUnlockedHealthPlanPackage(
             {},
             {
-                updatedAt: new Date('2008-01-01'),
+                updatedAt: new Date('2021-08-01'),
             }
         )
-        const unlocked2009 = mockUnlockedHealthPlanPackage(
+        const unlocked202109 = mockUnlockedHealthPlanPackage(
             {},
-            { updatedAt: new Date('2009-01-01') }
+            { updatedAt: new Date('2021-09-01') }
         )
         const unlockedToday = mockUnlockedHealthPlanPackage(
             {},
@@ -156,17 +156,17 @@ describe('CMSDashboard', () => {
 
         submitted1.id = 'test-abc-submitted'
         submitted2.id = 'test-abc-submitted-most-recent'
-        unlocked2008.id = 'test-abc-unlocked2098'
-        unlocked2009.id = 'test-abc-unlocked2100'
+        unlocked202108.id = 'test-abc-unlocked202108'
+        unlocked202109.id = 'test-abc-unlocked202109'
         unlockedToday.id = 'test-abc-unlocked-top-of-list'
 
         // intentionally listed in a scrambled order to test sorting
         const submissions = [
             submitted1,
-            unlocked2008,
+            unlocked202108,
             submitted2,
             unlockedToday,
-            unlocked2009,
+            unlocked202109,
         ]
 
         renderWithProviders(<CMSDashboard />, {
@@ -181,8 +181,6 @@ describe('CMSDashboard', () => {
         const rows = await screen.findAllByRole('row') // remember, 0 index element is the table header
 
         const link1 = within(rows[1]).getByRole('link')
-        console.log(JSON.stringify(submitted1.revisions[0]))
-        console.log(JSON.stringify(submitted2.revisions[0]))
         expect(link1).toHaveAttribute('href', `/submissions/${submitted2.id}`)
 
         const link2 = within(rows[2]).getByRole('link')
@@ -195,10 +193,16 @@ describe('CMSDashboard', () => {
         expect(link3).toHaveAttribute('href', `/submissions/${submitted1.id}`)
 
         const link4 = within(rows[4]).getByRole('link')
-        expect(link4).toHaveAttribute('href', `/submissions/${unlocked2009.id}`)
+        expect(link4).toHaveAttribute(
+            'href',
+            `/submissions/${unlocked202109.id}`
+        )
 
         const link5 = within(rows[5]).getByRole('link')
-        expect(link5).toHaveAttribute('href', `/submissions/${unlocked2008.id}`)
+        expect(link5).toHaveAttribute(
+            'href',
+            `/submissions/${unlocked202108.id}`
+        )
     })
 
     it('displays submission type as expected for current revision that is submitted/resubmitted', async () => {
@@ -305,7 +309,7 @@ describe('CMSDashboard', () => {
                 updatedAt: new Date('2022-01-15'),
                 programIDs: [mockMN.programs[2].id],
             },
-            { updatedAt: new Date('2022-01-22') }
+            { updatedAt: new Date('2100-01-22') }
         )
         unlocked.id = 'test-state-edit-in-progress-unlocked'
 
@@ -344,6 +348,6 @@ describe('CMSDashboard', () => {
         const lastUpdated = within(unlockedRow).getByTestId(
             'submission-last-updated'
         )
-        expect(lastUpdated).toHaveTextContent('01/22/2022')
+        expect(lastUpdated).toHaveTextContent('01/22/2100')
     })
 })

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -138,7 +138,6 @@ export const CMSDashboard = (): React.ReactElement => {
                     previousRevision?.node?.unlockInfo?.updatedAt ??
                     previousRevision?.node?.submitInfo?.updatedAt ??
                     lastUpdated
-                console.log(lastUpdated)
             }
 
             const programs = sub.state.programs

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -17,7 +17,7 @@ import {
     Program,
     useIndexHealthPlanPackagesQuery,
 } from '../../gen/gqlClient'
-import { mostRecentDate, isDate } from '../../common-code/dateHelpers'
+import { mostRecentDate } from '../../common-code/dateHelpers'
 import styles from '../StateDashboard/StateDashboard.module.scss'
 import { GenericApiErrorBanner } from '../../components/Banner/GenericApiErrorBanner/GenericApiErrorBanner'
 import { recordJSException } from '../../otelHelpers/tracingHelper'
@@ -157,11 +157,11 @@ export const CMSDashboard = (): React.ReactElement => {
                 ])
             }
 
-            if (!isDate(lastUpdated)) {
+            if (!lastUpdated) {
                 recordJSException(
                     `CMSDashboard: Cannot find valid last updated date from submit and unlock info. Falling back to current revision's last edit timestamp. ID: ${sub.id}`
                 )
-                lastUpdated = currentFormData.updatedAt as Date
+                lastUpdated = new Date(currentFormData.updatedAt)
             }
             const programs = sub.state.programs
 

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -134,6 +134,7 @@ export const CMSDashboard = (): React.ReactElement => {
 
                     return
                 }
+                // Last updated at value should be CMS unlock time (if its unlocked) or else state submit time (if its just submitted). Fall back to last updated at for the current revision (this shouldn't happen but just making explicit what the fallback is)
                 lastUpdated =
                     previousRevision?.node?.unlockInfo?.updatedAt ??
                     previousRevision?.node?.submitInfo?.updatedAt ??
@@ -157,7 +158,7 @@ export const CMSDashboard = (): React.ReactElement => {
             })
         })
 
-    // Sort by the visible updatedAt for the displayed package (could be either current or the previous is submission in UNLOCKED)
+    // Sort rows by the CMS updatedAt date
     submissionRows.sort((a, b) => (a['updatedAt'] > b['updatedAt'] ? -1 : 1))
     const hasSubmissions = submissionRows.length > 0
 

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -103,11 +103,12 @@ export const CMSDashboard = (): React.ReactElement => {
             }
 
             // Calculate proper submission data to display in each row
-            // if UNLOCKED package, form data could be in progress of being edited, show the static form data from the last submitted revision
-            // also, use lastUpdated from unlockData (if unlocked) or last submit (if initial submission)
-            // otherwise, use data from current revision for Submitted or Resubmitted packages
+            // if Unlocked package, form data could be in progress of being edited, show the static form data from the last submitted revision
+            // otherwise, use current data for Submitted or Resubmitted packages
             let packageDataToDisplay = currentFormData
-            let lastUpdated = currentFormData.updatedAt
+            let lastUpdated =
+                currentRevision?.node?.submitInfo?.updatedAt ??
+                currentFormData.updatedAt
             if (sub.status === 'UNLOCKED') {
                 const previousRevision = sub.revisions[1]
                 const previousFormData = base64ToDomain(
@@ -124,21 +125,16 @@ export const CMSDashboard = (): React.ReactElement => {
 
                 packageDataToDisplay = previousFormData
 
-                if (
-                    !previousRevision?.node?.unlockInfo?.updatedAt &&
-                    !previousRevision?.node?.submitInfo?.updatedAt
-                ) {
+                if (!previousRevision?.node?.unlockInfo?.updatedAt) {
                     recordJSException(
                         `indexHealthPlanPackagesQuery: Error finding updatedAt for an UNLOCKED SUBMISSION. Check the revision data is properly formatted. ID: ${sub.id}`
                     )
 
                     return
                 }
-                // Last updated at value should be CMS unlock time (if its unlocked) or else state submit time (if its just submitted). Fall back to last updated at for the current revision (this shouldn't happen but just making explicit what the fallback is)
+                // Last updated at value should be CMS unlock time (if its unlocked) or else state submit time (if its just submitted).
                 lastUpdated =
-                    previousRevision?.node?.unlockInfo?.updatedAt ??
-                    previousRevision?.node?.submitInfo?.updatedAt ??
-                    lastUpdated
+                    previousRevision?.node?.unlockInfo?.updatedAt ?? lastUpdated
             }
 
             const programs = sub.state.programs

--- a/services/app-web/src/pages/Errors/ErrorBoundaryRoot.tsx
+++ b/services/app-web/src/pages/Errors/ErrorBoundaryRoot.tsx
@@ -1,9 +1,10 @@
 import { GenericErrorPage } from './GenericErrorPage'
 import { recordJSException, recordSpan } from '../../otelHelpers/tracingHelper'
 import { useEffect } from 'react'
-
+import { EmptyHeader } from '../../components/Header/EmptyHeader'
+import styles from '../App/AppBody.module.scss'
 // It is possible to have different error boundary fallback components at different levels of the hierarchy.
-// This is the root error boundary. If it is visible, this means that the React frontend has crashed entirely.
+// This is the root error boundary. If it is visible, this means that the React frontend has crashed entirely and the entire tree is gone.
 
 function ErrorBoundaryRoot({
     error,
@@ -25,7 +26,16 @@ function ErrorBoundaryRoot({
         })
     }, [error])
 
-    return <GenericErrorPage />
+    return (
+        <div id="ErrorBoundaryRoot" className={styles.app}>
+            <EmptyHeader>
+                <div></div>
+            </EmptyHeader>
+            <main id="main-content" className={styles.mainContent} role="main">
+                <GenericErrorPage />
+            </main>
+        </div>
+    )
 }
 
 export { ErrorBoundaryRoot }

--- a/services/app-web/src/pages/Errors/Errors.module.scss
+++ b/services/app-web/src/pages/Errors/Errors.module.scss
@@ -10,3 +10,8 @@
     display: flex;
     align-items: center;
 }
+
+.errorsFullPage{
+    flex: 1;
+    padding: units(4) 0;
+}

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -229,9 +229,11 @@ export const StateDashboard = (): React.ReactElement => {
                                                         <td>
                                                             {dayjs(
                                                                 dashboardSubmission.updatedAt
-                                                            ).format(
-                                                                'MM/DD/YYYY'
-                                                            )}
+                                                            )
+                                                                .tz('UTC')
+                                                                .format(
+                                                                    'MM/DD/YYYY'
+                                                                )}
                                                         </td>
                                                         <td data-testid="submission-status">
                                                             <StatusTag

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -427,7 +427,8 @@ export function mockDraftHealthPlanPackage(
 }
 
 export function mockSubmittedHealthPlanPackage(
-    submissionData?: Partial<UnlockedHealthPlanFormDataType>
+    submissionData?: Partial<UnlockedHealthPlanFormDataType>,
+    submitInfo?: Partial<UpdateInformation>
 ): HealthPlanPackage {
     // get a submitted DomainModel submission
     // turn it into proto
@@ -437,19 +438,20 @@ export function mockSubmittedHealthPlanPackage(
     return {
         id: 'test-id-123',
         status: 'SUBMITTED',
-        initiallySubmittedAt: '2022-01-01',
+        initiallySubmittedAt: '2022-01-02',
         stateCode: 'MN',
         state: mockMNState(),
         revisions: [
             {
                 node: {
                     id: 'revision1',
-                    createdAt: new Date(),
+                    createdAt: new Date('2021-01-01'),
                     unlockInfo: null,
                     submitInfo: {
-                        updatedAt: '2021-01-01',
+                        updatedAt: new Date('2021-01-02'),
                         updatedBy: 'test@example.com',
                         updatedReason: 'Initial submit',
+                        ...submitInfo,
                     },
                     formDataProto: b64,
                 },
@@ -581,7 +583,7 @@ export function mockUnlockedHealthPlanPackage(
                     createdAt: new Date('2020-01-01'),
                     unlockInfo: null,
                     submitInfo: {
-                        updatedAt: '2021-01-01',
+                        updatedAt: new Date('2021-01-02'),
                         updatedBy: 'test@example.com',
                         updatedReason: 'Initial submit',
                     },

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -562,15 +562,15 @@ export function mockUnlockedHealthPlanPackage(
             {
                 node: {
                     id: 'revision2',
-                    createdAt: new Date(),
+                    createdAt: new Date('2020-07-01'),
                     unlockInfo: {
-                        updatedAt: new Date(),
+                        updatedAt: new Date('2020-08-01'),
                         updatedBy: 'bob@dmas.mn.gov',
                         updatedReason: 'Test unlock reason',
                         ...unlockInfo,
                     },
                     submitInfo: {
-                        updatedAt: new Date(),
+                        updatedAt: new Date('2020-07-15'),
                         updatedBy: 'bob@dmas.mn.gov',
                         updatedReason: 'Second Submit',
                     },

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -535,7 +535,7 @@ export function mockUnlockedHealthPlanPackage(
     const b64Previous = domainToBase64({
         ...unlockedWithALittleBitOfEverything(),
     })
-    console.log(unlockInfo)
+
     return {
         id: 'test-id-123',
         status: 'UNLOCKED',

--- a/services/app-web/src/testHelpers/apolloHelpers.tsx
+++ b/services/app-web/src/testHelpers/apolloHelpers.tsx
@@ -6,6 +6,7 @@ import {
     basicHealthPlanFormData,
     unlockedWithALittleBitOfEverything,
 } from '../common-code/healthPlanFormDataMocks'
+
 import {
     LockedHealthPlanFormDataType,
     SubmissionDocument,
@@ -29,6 +30,7 @@ import {
     UpdateHealthPlanFormDataMutation,
     CreateHealthPlanPackageDocument,
     CreateHealthPlanPackageMutation,
+    UpdateInformation,
 } from '../gen/gqlClient'
 
 /* For use with Apollo MockedProvider in jest tests */
@@ -424,10 +426,12 @@ export function mockDraftHealthPlanPackage(
     }
 }
 
-export function mockSubmittedHealthPlanPackage(): HealthPlanPackage {
+export function mockSubmittedHealthPlanPackage(
+    submissionData?: Partial<UnlockedHealthPlanFormDataType>
+): HealthPlanPackage {
     // get a submitted DomainModel submission
     // turn it into proto
-    const submission = basicLockedHealthPlanFormData()
+    const submission = { ...basicLockedHealthPlanFormData(), ...submissionData }
     const b64 = domainToBase64(submission)
 
     return {
@@ -520,14 +524,18 @@ export function mockSubmittedHealthPlanPackageWithRevisions(): HealthPlanPackage
 }
 
 export function mockUnlockedHealthPlanPackage(
-    submissionData?: Partial<UnlockedHealthPlanFormDataType>
+    submissionData?: Partial<UnlockedHealthPlanFormDataType>,
+    unlockInfo?: Partial<UpdateInformation>
 ): HealthPlanPackage {
     const submission = {
         ...unlockedWithALittleBitOfEverything(),
         ...submissionData,
     }
     const b64 = domainToBase64(submission)
-
+    const b64Previous = domainToBase64({
+        ...unlockedWithALittleBitOfEverything(),
+    })
+    console.log(unlockInfo)
     return {
         id: 'test-id-123',
         status: 'UNLOCKED',
@@ -543,6 +551,7 @@ export function mockUnlockedHealthPlanPackage(
                         updatedAt: new Date(),
                         updatedBy: 'bob@dmas.mn.gov',
                         updatedReason: 'Test unlock reason',
+                        ...unlockInfo,
                     },
                     submitInfo: null,
                     formDataProto: b64,
@@ -556,13 +565,14 @@ export function mockUnlockedHealthPlanPackage(
                         updatedAt: new Date(),
                         updatedBy: 'bob@dmas.mn.gov',
                         updatedReason: 'Test unlock reason',
+                        ...unlockInfo,
                     },
                     submitInfo: {
                         updatedAt: new Date(),
                         updatedBy: 'bob@dmas.mn.gov',
                         updatedReason: 'Second Submit',
                     },
-                    formDataProto: b64,
+                    formDataProto: b64Previous,
                 },
             },
             {
@@ -575,7 +585,7 @@ export function mockUnlockedHealthPlanPackage(
                         updatedBy: 'test@example.com',
                         updatedReason: 'Initial submit',
                     },
-                    formDataProto: b64,
+                    formDataProto: b64Previous,
                 },
             },
         ],

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -1,6 +1,6 @@
 import * as path from 'path'
 
-describe('dashboard', () => {
+describe('CMS user', () => {
     it('can unlock and resubmit', () => {
         cy.logInAsStateUser()
 

--- a/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
@@ -1,70 +1,87 @@
-describe('CMS User can view submission', () => {
-        // state user adds a new package
-        cy.logInAsStateUser()
-        cy.startNewContractAndRatesSubmission()
-        cy.fillOutBaseContractDetails()
-        cy.navigateForm('CONTINUE')
-        cy.fillOutNewRateCertification()
-        cy.navigateForm('CONTINUE')
-        cy.fillOutStateContact()
-        cy.fillOutActuaryContact()
-        cy.navigateForm('CONTINUE')
-        cy.fillOutSupportingDocuments()
-        cy.navigateForm('CONTINUE')
+describe('CMS user can view submission', () => {
+    it('in the CMS dashboard', () => {
+    // state user adds a new package
+    cy.logInAsStateUser()
+    cy.startNewContractAndRatesSubmission()
+    cy.fillOutBaseContractDetails()
+    cy.navigateForm('CONTINUE')
+    cy.fillOutNewRateCertification()
+    cy.navigateForm('CONTINUE')
+    cy.fillOutStateContact()
+    cy.fillOutActuaryContact()
+    cy.navigateForm('CONTINUE')
+    cy.fillOutSupportingDocuments()
+    cy.navigateForm('CONTINUE')
 
-        // store submission id for reference later
-        let submissionId = ''
-        cy.location().then((fullUrl) => {
-            const { pathname } = fullUrl
-            const pathnameArray = pathname.split('/')
-            submissionId = pathnameArray[2]
+    // store submission id for reference later
+    let submissionId = ''
+    cy.location().then((fullUrl) => {
+        const { pathname } = fullUrl
+        const pathnameArray = pathname.split('/')
+        submissionId = pathnameArray[2]
+    })
+
+    // submit package
+    cy.findByRole('heading', { level: 2, name: /Review and submit/ })
+    cy.submitStateSubmissionForm()
+    cy.findByText('Dashboard').should('exist')
+    cy.findByText('Programs').should('exist')
+
+// store submission name for later
+    cy.location().then((loc) => {
+        expect(loc.search).to.match(/.*justSubmitted=*/)
+        const submissionName = loc.search.split('=').pop()
+        if (submissionName === undefined) {
+            throw new Error('No submission name found' + loc.search)
+        }
+
+// sign out state user
+    cy.findByRole('button', {
+            name: 'Sign out',
         })
+            .should('exist')
+            .click()
+    //  sign in CMS user 
+    cy.logInAsCMSUser()
+    cy.findByTestId('cms-dashboard-page').should('exist')
+    cy.findByRole('table').should('exist')
+    cy.findByText(submissionName).should('exist')
+    // check the table of submissions
 
-        // submit package
-        cy.findByRole('heading', { level: 2, name: /Review and submit/ })
-        cy.submitStateSubmissionForm()
-        cy.findByText('Dashboard').should('exist')
-        cy.findByText('Programs').should('exist')
-
-        // store submission name for later
-        cy.location().then((loc) => {
-            expect(loc.search).to.match(/.*justSubmitted=*/)
-            const submissionName = loc.search.split('=').pop()
-            if (submissionName === undefined) {
-                throw new Error('No submission name found' + loc.search)
-            }
-
-        // sign out state user
-            cy.findByRole('button', {
-                    name: 'Sign out',
-                })
-                    .should('exist')
-                    .click()
-            //  sign in CMS user 
-            cy.logInAsCMSUser()
-            cy.findByTestId('dashboard').should('exist')
-            cy.findByText('Dashboard').should('exist') 
-            cy.findByText(submissionName).should('exist')
-            // check the table of submissions--find a draft row, then the link in the ID column
-            cy.get('table')
-                .contains('span', 'Submitted')
-                .eq(1)
-                .parents('tr')
-                .findByTestId('submission-id')
-                .find('a')
-                .should('have.attr', 'href')
-                // draft submission URL is /submissions/${submission.id}/type
-                .and('include', 'type')
-            cy.get('table')
-                .contains('span', 'draft')
-                .eq(0)
-            cy.get('table')
-                .contains('span', 'Submitted')
-                .eq(0)
-                .parents('tr')
-                .findByTestId('submission-date')
-                .should('not.be.empty')
-            })
-        })
+    // only one matching entry
+    cy.get('table')
+        .findAllByText(submissionName).should('have.length', 1)
     
+    // has proper row data
+    cy.get('table')
+        .should('exist')
+        .findByText(submissionName)
+        .parent()
+        .findByTestId('submission-date')
+        .should('not.be.empty')
+
+     cy.get('table')
+         .should('exist')
+         .findByText(submissionName)
+         .parent()
+         .siblings('[data-testid="submission-status"]')
+         .should('have.text', 'Submitted')
+
+    
+    cy.get('table')
+        .contains('a', submissionName)
+        .parents('tr')
+        .findByTestId('submission-type')
+        .should('have.text', 'Contract action and rate certification' )
+
+    cy.get('table')
+        .contains('a', submissionName)
+        .should('have.attr', 'href')
+    
+    // can navigate to submission summary  by clicking link
+    cy.findByText(submissionName).should('exist').click()
+    cy.url({ timeout: 10_000 }).should('contain', submissionId)
+    cy.findByTestId('submission-summary').should('exist')      
+        })
+    })
 })

--- a/tests/cypress/support/loginCommands.ts
+++ b/tests/cypress/support/loginCommands.ts
@@ -59,6 +59,10 @@ Cypress.Commands.add(
             throw new Error(`Auth mode is not defined or is IDM: ${authMode}`)
         } 
         cy.wait('@fetchCurrentUserQuery', { timeout: 20000 })
-        cy.wait('@fetchHealthPlanPackageQuery', { timeout: 20000 }) // we only allow CMS users to go to a specific submission on login
+        if (initialURL !== '/') { 
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 20000 }) // for cases where CMs user goes to specific submission on login
+        } else {
+            cy.wait('@indexHealthPlanPackagesQuery', { timeout: 80000 }) 
+        }
     }
 )


### PR DESCRIPTION
## Summary
- remove CMS_DASHBOARD feature flag
- Add last updated column and in general move from looking at current revision to previous submitted revision for form data. That's something I overlooked in the first pass at the dashboard, likely this would cause bugs.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2466

#### Test cases covered
**Jest**
see `CMSDashboard.test.tsx` (web tests)
 - displays no submission text when no submitted packages exist
- displays submissions table when submitted packages exist
- displays submissions table with expected headers
- displays submissions table excluding any in progress drafts
- displays submission type as expected for current revision that is submitted/resubmitted
- displays the expected program tags for current revision that is submitted/resubmitted
- displays each health plan package status tag as expected
- displays name, type, programs and last update based on previously submitted revision for UNLOCKED package

**Cypress**
- CMS user can view submission in the CMS dashboard

## QA guidance
- Please test this work thoroughly with unlock and resubmit to make sure that state draft edits  data is not appearing in the dashboard. This is most relevant when an unlocked package is in progress of being edited
- check that last updated column displays as expected