### PR TITLE
Fix storybook certificate

### DIFF
--- a/services/storybook/serverless.yml
+++ b/services/storybook/serverless.yml
@@ -9,7 +9,7 @@ plugins:
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${aws:region}
-  cloudfrontCertificateArn: ${ssm:/configuration/cloudfront/certificate_arn, ""}
+  cloudfrontCertificateArn: ${ssm:/configuration/${sls:stage}/cloudfront/certificate_arn, ""}
   cloudfrontStorybookDomainName: ${ssm:/configuration/${sls:stage}/cloudfront/storybook_domain_name, ""}
   serverlessTerminationProtection:
     stages:


### PR DESCRIPTION
## Summary

This should fix the certificate issues with Storybook. When we moved to using Parameter Store for configuration values there was a typo in the `serverless.yml` that caused the logic in the configuration to not deploy the subdomain needed.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2531


## QA guidance

<!---These are developer instructions on how to test or validate the work -->
