### PR TITLE
MR-2539: Move getting some emails to email parameter store

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,8 +27,6 @@ export LD_SDK_KEY='this-value-can-be-set-in-local'
 export PARAMETER_STORE_MODE='LOCAL'
 
 export SES_SOURCE_EMAIL_ADDRESS='dev@localhost'
-export SES_REVIEW_TEAM_EMAIL_ADDRESSES='mc-review-qa@truss.works'
-export SES_RATES_EMAIL_ADDRESSES='mc-rates-review-qa@truss.works'
 export SES_REVIEW_HELP_EMAIL_ADDRESS='MCOGDMCOActions@cms.hhs.gov'
 export SES_RATE_HELP_EMAIL_ADDRESS='MMCratesetting@cms.hhs.gov'
 export SES_DEV_TEAM_HELP_EMAIL_ADDRESS='mc-review@cms.hhs.gov'

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -109,24 +109,6 @@ Read by `app-api`
 
 Sets the "from" address for all emails sent by the system. This address must have been added to SES and validated there, in order to work.
 
-### `SES_REVIEW_TEAM_EMAIL_ADDRESSES`
-
-Read by `app-api`
-
-Sets the "to" addresses for generic emails sent to the shared CMS inbox (there may be multiple). Value is comma separated string.
-
-### `SES_RATES_EMAIL_ADDRESSES`
-
-Read by `app-api`
-
-Sets additional "to" addresses for emails about packages that contain rates, sent to rate reviewers (there may be multiple). Value is comma separated string.
-
-### `SES_RATES_EMAIL_ADDRESSES`
-
-Read by `app-api`
-
-Sets additional "to" addresses for emails about packages that contain rates, sent to rate reviewers (there may be multiple). Value is comma separated string.
-
 ### `SES_REVIEW_HELP_EMAIL_ADDRESS`, `SES_RATE_HELP_EMAIL_ADDRESS`, `SES_DEV_TEAM_HELP_EMAIL_ADDRESS`
 
 Read by `app-api`

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -128,7 +128,6 @@ provider:
     SES_REVIEW_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/reviewHelpAddress}
     SES_RATE_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/rateHelpAddress}
     SES_DEV_TEAM_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/devTeamHelpAddress}
-    SES_RATES_EMAIL_ADDRESSES: ${ssm:/configuration/email/ratesAddresses}
     APPLICATION_ENDPOINT: ${self:custom.applicationEndpoint, 'http://localhost:3000'}
     AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-handler
     OPENTELEMETRY_COLLECTOR_CONFIG_FILE: /var/task/collector.yml

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -58,9 +58,6 @@ custom:
       '/configuration/default/vpc/subnets/private/c/id': 'offline'
       '/configuration/iam/full_permissions_boundary_policy': 'arn:aws:iam::local:policy/local/developer-boundary-policy'
       '/configuration/email/sourceAddress': ${env:SES_SOURCE_EMAIL_ADDRESS, 'offline'}
-      '/configuration/email/reviewTeamAddresses': ${env:SES_REVIEW_TEAM_EMAIL_ADDRESSES, 'offline'}
-      '/configuration/email/ratesAddresses': ${env:SES_RATES_EMAIL_ADDRESSES, 'offline'}
-      '/configuration/email/reviewHelpAddress': ${env:SES_REVIEW_HELP_EMAIL_ADDRESS, 'offline'}
       '/configuration/email/rateHelpAddress': ${env:SES_RATE_HELP_EMAIL_ADDRESS, 'offline'}
       '/configuration/email/devTeamHelpAddress': ${env:SES_DEV_TEAM_HELP_EMAIL_ADDRESS, 'offline'}
   vpcId: ${ssm:/configuration/${sls:stage}/vpc/id, ssm:/configuration/default/vpc/id}
@@ -128,7 +125,6 @@ provider:
     EMAILER_MODE: ${self:custom.emailerMode}
     PARAMETER_STORE_MODE: ${self:custom.parameterStoreMode}
     SES_SOURCE_EMAIL_ADDRESS: ${ssm:/configuration/email/sourceAddress}
-    SES_REVIEW_TEAM_EMAIL_ADDRESSES: ${ssm:/configuration/email/reviewTeamAddresses}
     SES_REVIEW_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/reviewHelpAddress}
     SES_RATE_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/rateHelpAddress}
     SES_DEV_TEAM_HELP_EMAIL_ADDRESS: ${ssm:/configuration/email/devTeamHelpAddress}

--- a/services/app-api/src/parameterStore/emailParameterStore/cmsReviewSharedEmails/getCmsReviewSharedEmails.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/cmsReviewSharedEmails/getCmsReviewSharedEmails.ts
@@ -1,0 +1,21 @@
+import { getParameterStore } from '../../awsParameterStore'
+
+export const getCmsReviewSharedEmails = async (): Promise<string[] | Error> => {
+    const reviewTeamAddresses = await getParameterStore(
+        `/configuration/email/reviewTeamAddresses`
+    )
+    if (reviewTeamAddresses instanceof Error) {
+        return reviewTeamAddresses
+    } else {
+        //Split string into array using ',' separator and trim each array item.
+        return reviewTeamAddresses.split(',').map((email) => email.trim())
+    }
+}
+
+export const getCmsReviewSharedEmailsLocal = async (): Promise<
+    string[] | Error
+> => [
+    `CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
+    `"CMS Reviewer 2" <CMS.reviewer.2@example.com>`,
+    `"CMS Reviewer 3" <CMS.reviewer.3@example.com>`,
+]

--- a/services/app-api/src/parameterStore/emailParameterStore/cmsReviewSharedEmails/getCmsReviewSharedEmails.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/cmsReviewSharedEmails/getCmsReviewSharedEmails.ts
@@ -15,7 +15,7 @@ export const getCmsReviewSharedEmails = async (): Promise<string[] | Error> => {
 export const getCmsReviewSharedEmailsLocal = async (): Promise<
     string[] | Error
 > => [
-    `CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
+    `"CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
     `"CMS Reviewer 2" <CMS.reviewer.2@example.com>`,
     `"CMS Reviewer 3" <CMS.reviewer.3@example.com>`,
 ]

--- a/services/app-api/src/parameterStore/emailParameterStore/emailParameterStore.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/emailParameterStore.ts
@@ -1,21 +1,31 @@
 import {
     getStateAnalystsEmails,
     getStateAnalystsEmailsLocal,
-} from './getStateAnalystsEmails'
+    getCmsReviewSharedEmails,
+    getCmsReviewSharedEmailsLocal,
+    getRatesReviewSharedEmails,
+    getRatesReviewSharedEmailsLocal,
+} from './'
 
 export type EmailParameterStore = {
     getStateAnalystsEmails: (stateCode: string) => Promise<string[] | Error>
+    getCmsReviewSharedEmails: () => Promise<string[] | Error>
+    getRatesReviewSharedEmails: () => Promise<string[] | Error>
 }
 
 function newLocalEmailParameterStore(): EmailParameterStore {
     return {
         getStateAnalystsEmails: getStateAnalystsEmailsLocal,
+        getCmsReviewSharedEmails: getCmsReviewSharedEmailsLocal,
+        getRatesReviewSharedEmails: getRatesReviewSharedEmailsLocal,
     }
 }
 
 function newAWSEmailParameterStore(): EmailParameterStore {
     return {
         getStateAnalystsEmails: getStateAnalystsEmails,
+        getCmsReviewSharedEmails: getCmsReviewSharedEmails,
+        getRatesReviewSharedEmails: getRatesReviewSharedEmails,
     }
 }
 

--- a/services/app-api/src/parameterStore/emailParameterStore/index.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/index.ts
@@ -1,0 +1,12 @@
+export {
+    getStateAnalystsEmails,
+    getStateAnalystsEmailsLocal,
+} from './stateAnalystsEmails/getStateAnalystsEmails'
+export {
+    getCmsReviewSharedEmails,
+    getCmsReviewSharedEmailsLocal,
+} from './cmsReviewSharedEmails/getCmsReviewSharedEmails'
+export {
+    getRatesReviewSharedEmails,
+    getRatesReviewSharedEmailsLocal,
+} from './ratesReviewSharedEmails/getRatesReviewSharedEmails'

--- a/services/app-api/src/parameterStore/emailParameterStore/ratesReviewSharedEmails/getRatesReviewSharedEmails.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/ratesReviewSharedEmails/getRatesReviewSharedEmails.ts
@@ -1,0 +1,23 @@
+import { getParameterStore } from '../../awsParameterStore'
+
+export const getRatesReviewSharedEmails = async (): Promise<
+    string[] | Error
+> => {
+    const ratesAddresses = await getParameterStore(
+        `/configuration/email/ratesAddresses`
+    )
+    if (ratesAddresses instanceof Error) {
+        return ratesAddresses
+    } else {
+        //Split string into array using ',' separator and trim each array item.
+        return ratesAddresses.split(',').map((email) => email.trim())
+    }
+}
+
+export const getRatesReviewSharedEmailsLocal = async (): Promise<
+    string[] | Error
+> => [
+    `Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
+    `"Rate Submission Reviewer 2" <rate.reviewer.2@example.com>`,
+    `"Rate Submission Reviewer 3" <rate.reviewer.3@example.com>`,
+]

--- a/services/app-api/src/parameterStore/emailParameterStore/ratesReviewSharedEmails/getRatesReviewSharedEmails.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/ratesReviewSharedEmails/getRatesReviewSharedEmails.ts
@@ -17,7 +17,7 @@ export const getRatesReviewSharedEmails = async (): Promise<
 export const getRatesReviewSharedEmailsLocal = async (): Promise<
     string[] | Error
 > => [
-    `Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
+    `"Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
     `"Rate Submission Reviewer 2" <rate.reviewer.2@example.com>`,
     `"Rate Submission Reviewer 3" <rate.reviewer.3@example.com>`,
 ]

--- a/services/app-api/src/parameterStore/emailParameterStore/stateAnalystsEmails/getStateAnalystsEmails.test.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/stateAnalystsEmails/getStateAnalystsEmails.test.ts
@@ -1,5 +1,5 @@
 import { getStateAnalystsEmails } from './getStateAnalystsEmails'
-import * as ParameterStore from './awsParameterStore'
+import * as ParameterStore from '../../awsParameterStore'
 
 describe('getStateAnalystEmails', () => {
     it('returns state analysts emails in an array', async () => {

--- a/services/app-api/src/parameterStore/emailParameterStore/stateAnalystsEmails/getStateAnalystsEmails.ts
+++ b/services/app-api/src/parameterStore/emailParameterStore/stateAnalystsEmails/getStateAnalystsEmails.ts
@@ -1,4 +1,4 @@
-import { getParameterStore } from './awsParameterStore'
+import { getParameterStore } from '../../awsParameterStore'
 
 export const getStateAnalystsEmails = async (
     stateCode: string

--- a/services/app-api/src/parameterStore/index.ts
+++ b/services/app-api/src/parameterStore/index.ts
@@ -1,6 +1,6 @@
 export {
     newAWSEmailParameterStore,
     newLocalEmailParameterStore,
-} from './emailParameterStore'
+} from './emailParameterStore/emailParameterStore'
 
-export type { EmailParameterStore } from './emailParameterStore'
+export type { EmailParameterStore } from './emailParameterStore/emailParameterStore'

--- a/services/app-api/src/testHelpers/parameterStoreHelpers.ts
+++ b/services/app-api/src/testHelpers/parameterStoreHelpers.ts
@@ -29,13 +29,13 @@ const getTestStateAnalystsEmails = (
 ]
 
 const getTestCmsReviewSharedEmails = (): string[] => [
-    `CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
+    `"CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
     `"CMS Reviewer 2" <CMS.reviewer.2@example.com>`,
     `"CMS Reviewer 3" <CMS.reviewer.3@example.com>`,
 ]
 
 const getTestRatesReviewSharedEmails = (): string[] => [
-    `Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
+    `"Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
     `"Rate Submission Reviewer 2" <rate.reviewer.2@example.com>`,
     `"Rate Submission Reviewer 3" <rate.reviewer.3@example.com>`,
 ]

--- a/services/app-api/src/testHelpers/parameterStoreHelpers.ts
+++ b/services/app-api/src/testHelpers/parameterStoreHelpers.ts
@@ -2,12 +2,20 @@ import { HealthPlanFormDataType } from 'app-web/src/common-code/healthPlanFormDa
 
 export type ParameterStore = {
     getStateAnalystsEmails: (stateCode: string) => Promise<string[] | Error>
+    getCmsReviewSharedEmails: () => Promise<string[] | Error>
+    getRatesReviewSharedEmails: () => Promise<string[] | Error>
 }
 
 function mockEmailParameterStoreError(error?: string): ParameterStore {
     const message = error || 'No store found'
     return {
         getStateAnalystsEmails: async (stateCode: string): Promise<Error> => {
+            return new Error(message)
+        },
+        getCmsReviewSharedEmails: async (): Promise<Error> => {
+            return new Error(message)
+        },
+        getRatesReviewSharedEmails: async (): Promise<Error> => {
             return new Error(message)
         },
     }
@@ -20,4 +28,21 @@ const getTestStateAnalystsEmails = (
     `"${submission.stateCode} State Analyst 2" <${submission.stateCode}StateAnalyst2@example.com>`,
 ]
 
-export { mockEmailParameterStoreError, getTestStateAnalystsEmails }
+const getTestCmsReviewSharedEmails = (): string[] => [
+    `CMS Reviewer 1" <CMS.reviewer.1@example.com>`,
+    `"CMS Reviewer 2" <CMS.reviewer.2@example.com>`,
+    `"CMS Reviewer 3" <CMS.reviewer.3@example.com>`,
+]
+
+const getTestRatesReviewSharedEmails = (): string[] => [
+    `Rate Submission Reviewer 1" <rate.reviewer.1@example.com>`,
+    `"Rate Submission Reviewer 2" <rate.reviewer.2@example.com>`,
+    `"Rate Submission Reviewer 3" <rate.reviewer.3@example.com>`,
+]
+
+export {
+    mockEmailParameterStoreError,
+    getTestStateAnalystsEmails,
+    getTestCmsReviewSharedEmails,
+    getTestRatesReviewSharedEmails,
+}

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -24,6 +24,7 @@ describe('submission type', () => {
 
             // Navigate to type page
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             // Navigate to dashboard page by clicking save as draft
             cy.navigateForm('SAVE_DRAFT')
@@ -31,6 +32,7 @@ describe('submission type', () => {
 
             // Navigate to back to submission type page
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             // Navigate to contract details page by clicking continue for contract only submission
             cy.navigateForm('CONTINUE')
@@ -48,6 +50,7 @@ describe('submission type', () => {
             const pathnameArray = pathname.split('/')
             const draftSubmissionId = pathnameArray[2]
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             cy.findByText('Contract action and rate certification').click()
 
@@ -57,6 +60,7 @@ describe('submission type', () => {
 
             // Navigate to type page
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             cy.findByLabelText('Contract action and rate certification').should(
                 'be.checked'
@@ -89,6 +93,7 @@ describe('submission type', () => {
 
             // Navigate to type page
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             //Edit some stuff here
             cy.findByRole('combobox', { name: 'programs (required)' }).click()
@@ -105,6 +110,7 @@ describe('submission type', () => {
 
             // Navigate back to submission type page
             cy.visit(`/submissions/${draftSubmissionId}/edit/type`)
+            cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
 
             //Check to make sure edited stuff was saved
             cy.get('[aria-label="Remove PMAP"]').should('exist')


### PR DESCRIPTION
## Summary
[MR-2539](https://qmacbis.atlassian.net/browse/MR-2539)

This will change `cmsReviewSharedEmails` and `ratesReviewSharedEmails` that was set using ENV variables to be pulled directly from parameter store. This is exactly how we are pulling state analyst emails. 

Also removed `SES_REVIEW_TEAM_EMAIL_ADDRESSES` and `SES_RATES_EMAIL_ADDRESSES` from `app-api/serverless.yml` and `.envrc`

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
