### PR TITLE
Add new yarn lock and remove ld use client spy from single test

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -172,8 +172,6 @@ describe('RateDetails', () => {
 
     it('cannot continue if no documents are added', async () => {
         const mockUpdateDraftFn = jest.fn()
-        ldUseClientSpy({ 'rate-certification-programs': true })
-
         renderWithProviders(
             <RateDetails
                 draftSubmission={emptyRateDetailsDraft}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11956,6 +11956,11 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
 concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"


### PR DESCRIPTION
## Summary
Removed `ldUseClientSpy` from test not testing feature flag code.

When `yarn install` from `main` this new `yarn.lock` file was generated. Pushing up to keep subsequent branches from having this generated. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
