### PR TITLE
MR-2405: Error in updatedAt on draft submission

### DIFF
--- a/services/app-api/src/resolvers/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/updateHealthPlanFormData.ts
@@ -155,14 +155,14 @@ export function updateHealthPlanFormDataResolver(
         ]
         const unfixedFields = []
         for (const fixedField of fixedFields) {
-            console.log(
-                `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
-            )
             const prevVal = previousFormData[fixedField]
             const newVal = unlockedFormData[fixedField]
 
             if (prevVal instanceof Date && newVal instanceof Date) {
                 if (prevVal.getTime() !== newVal.getTime()) {
+                    console.log(
+                        `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
+                    )
                     unfixedFields.push(fixedField)
                 }
             } else {
@@ -170,6 +170,9 @@ export function updateHealthPlanFormDataResolver(
                     previousFormData[fixedField] !==
                     unlockedFormData[fixedField]
                 ) {
+                    console.log(
+                        `ERRMOD ${fixedField}: old: ${previousFormData[fixedField]} new: ${unlockedFormData[fixedField]}`
+                    )
                     unfixedFields.push(fixedField)
                 }
             }


### PR DESCRIPTION
## Summary
[MR-2405](https://qmacbis.atlassian.net/browse/MR-2405)

We received a production error while RI was filling out a submission in prod: New Relic (NR) error `Attempted to modify un-modifiable field(s): updatedAt` and on updating a draft submission we get this error in the api on every draft update done in the `updateHealthPlanFormData.ts` resolver.

```
api| ERRMOD id: old: baef1ccc-8715-40a7-98a6-e8051c5eec6b new: baef1ccc-8715-40a7-98a6-e8051c5eec6b
api| ERRMOD stateCode: old: MN new: MN
api| ERRMOD stateNumber: old: 1 new: 1
api| ERRMOD createdAt: old: Tue Jun 28 2022 20:00:00 GMT-0400 (Eastern Daylight Time) new: Tue Jun 28 2022 20:00:00 GMT-0400 (Eastern Daylight Time)
api| ERRMOD updatedAt: old: Wed Jun 29 2022 16:13:14 GMT-0400 (Eastern Daylight Time) new: Wed Jun 29 2022 16:13:14 GMT-0400 (Eastern Daylight Time)
```
The `ERRMOD` logs are not really the concern here, because this is logged on every update. **In this PR, those `ERRMOD` messages will log when there are differences in the fixed fields.**

**It seems to that this NR Error is not a bug and is working as intended. Although I do not think the intent of this error is for handling simultaneous editing of the same submission.**

`Attempted to modify un-modifiable field(s): updatedAt` error log in NR. This error is only logged when a draft submission fixed fields `'id', 'stateCode', 'stateNumber', 'createdAt', 'updatedAt'` is different than what was pulled, at `updateHealthPlanFormData.ts` resolver, from the database.** I believe `updatedAt` is what's causing the unintended error handling for simultaneous edits and updating using stale data.**

This [slack thread](https://cmsgov.slack.com/archives/C014CRU197U/p1656527906062039) goes into this bug some more.  

Simultaneously editing the same submission with two users or the same user logged in two different places (incognito mode for testing) will cause this error to be Logged. One user will get a `System Error` banner asking the user to refresh the page which will fetch the submission with the most up-to-date data. 

If only one person is editing, then having two tabs opened to the same submission and editing on one tab then going to the other (maybe accidentally?) and trying to edit there would cause this error to be logged.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
