### PR TITLE
MR-2566: Rate-supporting documents not converting to Contract-supporting when switching submission types

### DIFF
--- a/services/app-api/src/resolvers/submitHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/submitHealthPlanPackage.test.ts
@@ -301,7 +301,12 @@ describe('submitHealthPlanPackage', () => {
                     {
                         name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
                         s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED' as const],
+                        documentCategories: ['CONTRACT_RELATED'],
+                    },
+                    {
+                        name: 'rate_only_supporting_doc.pdf',
+                        s3URL: 'fakeS3URL',
+                        documentCategories: ['CONTRACT_RELATED'],
                     },
                 ],
                 rateDocuments: [],

--- a/services/app-api/src/resolvers/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/updateHealthPlanFormData.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
 import {
     UnlockedHealthPlanFormDataType,
-    convertRateToContractDocs,
+    convertRateSupportingDocs,
 } from '../../../app-web/src/common-code/healthPlanFormDataType'
 import {
     base64ToDomain,
@@ -202,7 +202,7 @@ export function updateHealthPlanFormDataResolver(
                 document.documentCategories.includes('RATES_RELATED')
             )
         ) {
-            const convertedDocs = convertRateToContractDocs(
+            const convertedDocs = convertRateSupportingDocs(
                 unlockedFormData.documents
             )
             unlockedFormData.documents = convertedDocs

--- a/services/app-api/src/resolvers/updateHealthPlanFormData.ts
+++ b/services/app-api/src/resolvers/updateHealthPlanFormData.ts
@@ -1,5 +1,8 @@
 import { ForbiddenError, UserInputError } from 'apollo-server-lambda'
-import { UnlockedHealthPlanFormDataType } from '../../../app-web/src/common-code/healthPlanFormDataType'
+import {
+    UnlockedHealthPlanFormDataType,
+    convertRateToContractDocs,
+} from '../../../app-web/src/common-code/healthPlanFormDataType'
 import {
     base64ToDomain,
     toDomain,
@@ -187,6 +190,23 @@ export function updateHealthPlanFormDataResolver(
         }
 
         const editableRevision = planPackage.revisions[0]
+
+        // If CONTRACT_ONLY submission has supporting documents with RATES_RELATED category we convert this to CONTRACT_RELATED.
+        // This was done on the front end in FileUpload.tsx, but we are doing this here to convert these documents when
+        // the submission type has changed in order to save this across the forms because specifically the review and
+        // submit page, will not display documents that are RATE_RELATED under Contract Details sections when changing
+        // submission type to CONTRACT_ONLY.
+        if (
+            unlockedFormData.submissionType === 'CONTRACT_ONLY' &&
+            unlockedFormData.documents.some((document) =>
+                document.documentCategories.includes('RATES_RELATED')
+            )
+        ) {
+            const convertedDocs = convertRateToContractDocs(
+                unlockedFormData.documents
+            )
+            unlockedFormData.documents = convertedDocs
+        }
 
         // save the new form data to the db
         const updateResult = await store.updateHealthPlanRevision(

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
@@ -6,6 +6,7 @@ import {
     mockStateSubmissionContractAmendment,
 } from '../../testHelpers/apolloHelpers'
 import {
+    convertRateSupportingDocs,
     generateRateName,
     hasValidSupportingDocumentCategories,
     HealthPlanFormDataType,
@@ -547,7 +548,7 @@ describe('submission type assertions', () => {
     const contractOnlyWithValidRateData: {
         submission: UnlockedHealthPlanFormDataType
         testDescription: string
-        expectedResult: Partial<UnlockedHealthPlanFormDataType>
+        expectedResult: Partial<UnlockedHealthPlanFormDataType> | Error
     }[] = [
         {
             submission: {
@@ -706,7 +707,7 @@ describe('submission type assertions', () => {
                     {
                         name: 'rate_only_supporting_doc.pdf',
                         s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED' as const],
+                        documentCategories: ['CONTRACT_RELATED'],
                     },
                 ],
                 rateDocuments: [],
@@ -714,11 +715,114 @@ describe('submission type assertions', () => {
         },
     ]
     test.each(contractOnlyWithValidRateData)(
-        'Submit CONTRACT_ONLY with valid rate data: $testDescription',
+        'Remove rates data on CONTRACT_ONLY submission: $testDescription',
         ({ submission, expectedResult }) => {
             expect(removeRatesData(submission)).toEqual(
                 expect.objectContaining(expectedResult)
             )
         }
     )
+
+    test('convertRateSupportingDocs does convert rate supporting documents to contract supporting', () => {
+        const documents = [
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also_2.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: [
+                    'RATES_RELATED' as const,
+                    'CONTRACT_RELATED' as const,
+                ],
+            },
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also_3.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED' as const],
+            },
+            {
+                name: 'rate_only_supporting_doc.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['RATES_RELATED' as const],
+            },
+        ]
+
+        expect(convertRateSupportingDocs(documents)).toEqual([
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED'],
+            },
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also_2.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED'],
+            },
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also_3.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED'],
+            },
+            {
+                name: 'rate_only_supporting_doc.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT_RELATED'],
+            },
+        ])
+    })
+
+    test('convertRateSupportingDocs throws error with CONTRACT or RATE documents', () => {
+        const contractDocument = [
+            {
+                name: 'contract_certification.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['CONTRACT' as const],
+            },
+        ]
+
+        const rateDocument = [
+            {
+                name: 'rates_certification.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: ['RATES' as const],
+            },
+        ]
+
+        const mixedDocuments = [
+            {
+                name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: [
+                    'CONTRACT_RELATED' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+            {
+                name: 'rates_certification.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: [
+                    'RATES' as const,
+                    'RATES_RELATED' as const,
+                ],
+            },
+            {
+                name: 'contract_certification.pdf',
+                s3URL: 'fakeS3URL',
+                documentCategories: [
+                    'CONTRACT' as const,
+                    'CONTRACT_RELATED' as const,
+                ],
+            },
+        ]
+
+        expect(() => convertRateSupportingDocs(contractDocument)).toThrow()
+        expect(() => convertRateSupportingDocs(rateDocument)).toThrow()
+        expect(() => convertRateSupportingDocs(mixedDocuments)).toThrow()
+    })
 })

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.test.ts
@@ -607,12 +607,17 @@ describe('submission type assertions', () => {
                     {
                         name: 'contract_supporting_that_applies_to_a_rate_also.pdf',
                         s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED' as const],
+                        documentCategories: ['CONTRACT_RELATED'],
                     },
                     {
                         name: 'contract_supporting_that_applies_to_a_rate_also_2.pdf',
                         s3URL: 'fakeS3URL',
-                        documentCategories: ['CONTRACT_RELATED' as const],
+                        documentCategories: ['CONTRACT_RELATED'],
+                    },
+                    {
+                        name: 'rate_only_supporting_doc.pdf',
+                        s3URL: 'fakeS3URL',
+                        documentCategories: ['CONTRACT_RELATED'],
                     },
                 ],
                 rateDocuments: [],
@@ -660,6 +665,11 @@ describe('submission type assertions', () => {
                         s3URL: 'fakeS3URL',
                         documentCategories: ['CONTRACT_RELATED' as const],
                     },
+                    {
+                        name: 'rate_only_supporting_doc.pdf',
+                        s3URL: 'fakeS3URL',
+                        documentCategories: ['CONTRACT_RELATED' as const],
+                    },
                 ],
                 rateDocuments: [],
             },
@@ -692,7 +702,13 @@ describe('submission type assertions', () => {
                 rateAmendmentInfo: undefined,
                 rateProgramIDs: [],
                 actuaryContacts: [],
-                documents: [],
+                documents: [
+                    {
+                        name: 'rate_only_supporting_doc.pdf',
+                        s3URL: 'fakeS3URL',
+                        documentCategories: ['CONTRACT_RELATED' as const],
+                    },
+                ],
                 rateDocuments: [],
             },
         },

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -251,17 +251,24 @@ const generateRateName = (
     return rateName
 }
 
-const convertRateToContractDocs = (
+const convertRateSupportingDocs = (
     documents: SubmissionDocument[]
 ): SubmissionDocument[] => {
+    if (
+        documents.some(
+            (document) =>
+                document.documentCategories.includes('CONTRACT') ||
+                document.documentCategories.includes('RATES')
+        )
+    ) {
+        const errorMessage =
+            'convertRateSupportingDocs does not support CONTRACT or RATES documents.'
+        console.error(errorMessage)
+        throw new Error(errorMessage)
+    }
     return documents.map((document) => ({
         ...document,
-        //Convert rate supporting documents to contract supporting and contract to rate documents.
-        documentCategories:
-            document.documentCategories.includes('CONTRACT_RELATED') ||
-            document.documentCategories.includes('RATES_RELATED')
-                ? ['CONTRACT_RELATED']
-                : ['CONTRACT'],
+        documentCategories: ['CONTRACT_RELATED'],
     }))
 }
 
@@ -276,7 +283,7 @@ const removeRatesData = (
     pkg.rateAmendmentInfo = undefined
     pkg.actuaryContacts = []
     pkg.rateProgramIDs = []
-    pkg.documents = convertRateToContractDocs(pkg.documents)
+    pkg.documents = convertRateSupportingDocs(pkg.documents)
     pkg.rateDocuments = []
 
     return pkg
@@ -295,6 +302,6 @@ export {
     programNames,
     packageName,
     generateRateName,
-    convertRateToContractDocs,
+    convertRateSupportingDocs,
     removeRatesData,
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -251,7 +251,7 @@ const generateRateName = (
     return rateName
 }
 
-const removeRateRelatedDocuments = (
+const updateRateRelatedDocuments = (
     documents: SubmissionDocument[]
 ): SubmissionDocument[] => {
     const noRateDocs: SubmissionDocument[] = []
@@ -262,12 +262,26 @@ const removeRateRelatedDocuments = (
         const includesContractDocs =
             document.documentCategories.includes('CONTRACT_RELATED') ||
             document.documentCategories.includes('CONTRACT')
+        //If rate document contains CONTRACT OR CONTRACT_RELATED categories, remove RATE and RATE_RELATED, keep contract.
         if (includesContractDocs) {
             if (ratesDocIndex !== -1) {
                 document.documentCategories.splice(ratesDocIndex, 1)
             }
             if (ratesRelatedDocIndex !== -1) {
                 document.documentCategories.splice(ratesRelatedDocIndex, 1)
+            }
+            noRateDocs.push(document)
+            //If only rate documents we want to convert to contract.
+        } else {
+            if (ratesDocIndex !== -1) {
+                document.documentCategories.splice(ratesDocIndex, 1, 'CONTRACT')
+            }
+            if (ratesRelatedDocIndex !== -1) {
+                document.documentCategories.splice(
+                    ratesRelatedDocIndex,
+                    1,
+                    'CONTRACT_RELATED'
+                )
             }
             noRateDocs.push(document)
         }
@@ -286,7 +300,7 @@ const removeRatesData = (
     pkg.rateAmendmentInfo = undefined
     pkg.actuaryContacts = []
     pkg.rateProgramIDs = []
-    pkg.documents = removeRateRelatedDocuments(pkg.documents)
+    pkg.documents = updateRateRelatedDocuments(pkg.documents)
     pkg.rateDocuments = []
 
     return pkg
@@ -305,6 +319,6 @@ export {
     programNames,
     packageName,
     generateRateName,
-    removeRateRelatedDocuments,
+    updateRateRelatedDocuments,
     removeRatesData,
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/healthPlanFormData.ts
@@ -251,42 +251,18 @@ const generateRateName = (
     return rateName
 }
 
-const updateRateRelatedDocuments = (
+const convertRateToContractDocs = (
     documents: SubmissionDocument[]
 ): SubmissionDocument[] => {
-    const noRateDocs: SubmissionDocument[] = []
-    documents.forEach((document) => {
-        const ratesRelatedDocIndex =
-            document.documentCategories.indexOf('RATES_RELATED')
-        const ratesDocIndex = document.documentCategories.indexOf('RATES')
-        const includesContractDocs =
+    return documents.map((document) => ({
+        ...document,
+        //Convert rate supporting documents to contract supporting and contract to rate documents.
+        documentCategories:
             document.documentCategories.includes('CONTRACT_RELATED') ||
-            document.documentCategories.includes('CONTRACT')
-        //If rate document contains CONTRACT OR CONTRACT_RELATED categories, remove RATE and RATE_RELATED, keep contract.
-        if (includesContractDocs) {
-            if (ratesDocIndex !== -1) {
-                document.documentCategories.splice(ratesDocIndex, 1)
-            }
-            if (ratesRelatedDocIndex !== -1) {
-                document.documentCategories.splice(ratesRelatedDocIndex, 1)
-            }
-            noRateDocs.push(document)
-            //If only rate documents we want to convert to contract.
-        } else {
-            if (ratesDocIndex !== -1) {
-                document.documentCategories.splice(ratesDocIndex, 1, 'CONTRACT')
-            }
-            if (ratesRelatedDocIndex !== -1) {
-                document.documentCategories.splice(
-                    ratesRelatedDocIndex,
-                    1,
-                    'CONTRACT_RELATED'
-                )
-            }
-            noRateDocs.push(document)
-        }
-    })
-    return noRateDocs
+            document.documentCategories.includes('RATES_RELATED')
+                ? ['CONTRACT_RELATED']
+                : ['CONTRACT'],
+    }))
 }
 
 const removeRatesData = (
@@ -300,7 +276,7 @@ const removeRatesData = (
     pkg.rateAmendmentInfo = undefined
     pkg.actuaryContacts = []
     pkg.rateProgramIDs = []
-    pkg.documents = updateRateRelatedDocuments(pkg.documents)
+    pkg.documents = convertRateToContractDocs(pkg.documents)
     pkg.rateDocuments = []
 
     return pkg
@@ -319,6 +295,6 @@ export {
     programNames,
     packageName,
     generateRateName,
-    updateRateRelatedDocuments,
+    convertRateToContractDocs,
     removeRatesData,
 }

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -39,7 +39,7 @@ export {
     programNames,
     packageName,
     generateRateName,
-    updateRateRelatedDocuments,
+    convertRateToContractDocs,
     removeRatesData,
 } from './healthPlanFormData'
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -39,7 +39,7 @@ export {
     programNames,
     packageName,
     generateRateName,
-    convertRateToContractDocs,
+    convertRateSupportingDocs,
     removeRatesData,
 } from './healthPlanFormData'
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/index.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/index.ts
@@ -39,7 +39,7 @@ export {
     programNames,
     packageName,
     generateRateName,
-    removeRateRelatedDocuments,
+    updateRateRelatedDocuments,
     removeRatesData,
 } from './healthPlanFormData'
 

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -97,23 +97,23 @@ export const FileUpload = ({
         onFileItemsUpdate({ fileItems })
     }, [fileItems, onFileItemsUpdate])
 
-    React.useEffect(() => {
-        /* guard against empty documentCategories when user starts with contract & rates
-        and switches to contract-only */
-        setFileItems((prevItems) => {
-            const newItems = [...prevItems]
-            return newItems.map((item) => {
-                if (renderMode === 'table' && isContractOnly) {
-                    return {
-                        ...item,
-                        documentCategories: ['CONTRACT_RELATED'],
-                    } as FileItemT
-                } else {
-                    return item
-                }
-            })
-        })
-    }, [renderMode, isContractOnly])
+    // React.useEffect(() => {
+    //     /* guard against empty documentCategories when user starts with contract & rates
+    //     and switches to contract-only */
+    //     setFileItems((prevItems) => {
+    //         const newItems = [...prevItems]
+    //         return newItems.map((item) => {
+    //             if (renderMode === 'table' && isContractOnly) {
+    //                 return {
+    //                     ...item,
+    //                     documentCategories: ['CONTRACT_RELATED'],
+    //                 } as FileItemT
+    //             } else {
+    //                 return item
+    //             }
+    //         })
+    //     })
+    // }, [renderMode, isContractOnly])
 
     const isDuplicateItem = (
         existingList: FileItemT[],

--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -97,24 +97,6 @@ export const FileUpload = ({
         onFileItemsUpdate({ fileItems })
     }, [fileItems, onFileItemsUpdate])
 
-    // React.useEffect(() => {
-    //     /* guard against empty documentCategories when user starts with contract & rates
-    //     and switches to contract-only */
-    //     setFileItems((prevItems) => {
-    //         const newItems = [...prevItems]
-    //         return newItems.map((item) => {
-    //             if (renderMode === 'table' && isContractOnly) {
-    //                 return {
-    //                     ...item,
-    //                     documentCategories: ['CONTRACT_RELATED'],
-    //                 } as FileItemT
-    //             } else {
-    //                 return item
-    //             }
-    //         })
-    //     })
-    // }, [renderMode, isContractOnly])
-
     const isDuplicateItem = (
         existingList: FileItemT[],
         currentItem: FileItemT

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -93,16 +93,9 @@ export const ContractDetailsSummarySection = ({
     // Get the zip file for the contract
     const { getKey, getBulkDlURL } = useS3()
     const [zippedFilesURL, setZippedFilesURL] = useState<string>('')
-    // This will display rate supporting docs as contract supporting when changing submission type from CONTRACT_AND_RATE
-    // to CONTRACT_ONLY.
-    // This follows what is done on the supporting documents page in the instance of changing submission types. We may
-    // change how we handle rate supporting documents when changing submission type pages, but that is to be determined.
-    const contractSupportingDocuments =
-        submission.submissionType === 'CONTRACT_ONLY'
-            ? submission.documents
-            : submission.documents.filter((doc) =>
-                  doc.documentCategories.includes('CONTRACT_RELATED' as const)
-              )
+    const contractSupportingDocuments = submission.documents.filter((doc) =>
+        doc.documentCategories.includes('CONTRACT_RELATED' as const)
+    )
     const isSubmitted = submission.status === 'SUBMITTED'
     const isEditing = !isSubmitted && navigateTo !== undefined
 

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -93,9 +93,16 @@ export const ContractDetailsSummarySection = ({
     // Get the zip file for the contract
     const { getKey, getBulkDlURL } = useS3()
     const [zippedFilesURL, setZippedFilesURL] = useState<string>('')
-    const contractSupportingDocuments = submission.documents.filter((doc) =>
-        doc.documentCategories.includes('CONTRACT_RELATED' as const)
-    )
+    // This will display rate supporting docs as contract supporting when changing submission type from CONTRACT_AND_RATE
+    // to CONTRACT_ONLY.
+    // This follows what is done on the supporting documents page in the instance of changing submission types. We may
+    // change how we handle rate supporting documents when changing submission type pages, but that is to be determined.
+    const contractSupportingDocuments =
+        submission.submissionType === 'CONTRACT_ONLY'
+            ? submission.documents
+            : submission.documents.filter((doc) =>
+                  doc.documentCategories.includes('CONTRACT_RELATED' as const)
+              )
     const isSubmitted = submission.status === 'SUBMITTED'
     const isEditing = !isSubmitted && navigateTo !== undefined
 


### PR DESCRIPTION
## Summary
[MR-2566](https://qmacbis.atlassian.net/browse/MR-2566)

Fixed a bug where converting `Rate-supporting` docs to `Contract-supporting` when changing from `Contract and Rate` submission to `Contract Only` was not displaying previously `Rate-supporting` documents as `Contract supporting documents` on the `Review and Submit` page. 

Add code to convert `Rate-supporting` docs to `Contract-supporting` in `updateHealthPlanFormData.ts` resolver and removing code in `FileUpload.tsx` that converted `Rate-supporting` docs to `Contract-supporting` when changing from `Contract and Rate` submission to `Contract Only`. This will handle the converting of documents at the time of changing from `Contract and Rate` submission to `Contract Only` on the `Submission Type` page.

#### Related issues
[2532](https://qmacbis.atlassian.net/browse/MR-2532) This PR will also refactors the code that would remove of `Rate-supporting` only document to instead only convert them to `Contract-supporting` if for some reason the documents had not been converted at the time submission type was changed.

#### Screenshots

#### Test cases covered

`updateHealthPlanPackage.test.ts`
- `'converts RATES_RELATED documents to CONTRACT_RELATED on contract only submissions'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
