### PR TITLE
Add site maintenance banner and feature flag

### DIFF
--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -6,6 +6,10 @@ export const featureFlags = {
     /*
      Toggles the /health api endpoint
     */
+    SITE_MAINTENANCE_BANNER: 'site-maintenance-banner',
+    /*
+     Toggles the /health api endpoint
+    */
     API_ENABLE_HEALTH_ENDPOINT: 'enable-health-endpoint',
     /*
      Enables the modal that alerts the user to an expiring session

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -4,7 +4,7 @@
  */
 export const featureFlags = {
     /*
-     Toggles the /health api endpoint
+     Toggles the site maintenance alert on the landing page
     */
     SITE_MAINTENANCE_BANNER: 'site-maintenance-banner',
     /*

--- a/services/app-web/src/pages/Landing/Landing.test.tsx
+++ b/services/app-web/src/pages/Landing/Landing.test.tsx
@@ -1,0 +1,31 @@
+import { screen, render } from '@testing-library/react'
+import { ldUseClientSpy } from '../../testHelpers/jestHelpers'
+import { Landing } from './Landing'
+
+describe('Landing', () => {
+    it('displays maintenance banner when flag is on', async () => {
+        ldUseClientSpy({ 'site-maintenance-banner': true })
+        render(<Landing />)
+        expect(
+            await screen.findByRole('heading', { name: 'Site Unavailable' })
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText(
+                /MC-Review is currently unavailable due to technical issues/
+            )
+        ).toBeInTheDocument()
+    })
+
+    it('does not display maintenance banner when flag is off', async () => {
+        ldUseClientSpy({ 'site-maintenance-banner': false })
+        render(<Landing />)
+        expect(
+            await screen.queryByRole('heading', { name: 'Site Unavailable' })
+        ).toBeNull()
+        expect(
+            await screen.queryByText(
+                /MC-Review is currently unavailable due to technical issues/
+            )
+        ).toBeNull()
+    })
+})

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -1,12 +1,42 @@
 import React from 'react'
-import { GridContainer, Grid } from '@trussworks/react-uswds'
+import { Alert, GridContainer, Grid } from '@trussworks/react-uswds'
 import styles from './Landing.module.scss'
+import { featureFlags } from '../../common-code/featureFlags'
+import { useLDClient } from 'launchdarkly-react-client-sdk'
 
 export const Landing = (): React.ReactElement => {
+    const ldClient = useLDClient()
+    const siteMaintenanceBanner: boolean = ldClient?.variation(
+        featureFlags.SITE_MAINTENANCE_BANNER,
+        false
+    )
+
     return (
         <>
             <section className={styles.detailsSection}>
                 <GridContainer className={styles.detailsSectionContent}>
+                    {siteMaintenanceBanner && (
+                        <Alert
+                            type="error"
+                            heading="Site Unavailable"
+                            className="margin-bottom-2"
+                        >
+                            MC-Review is currently unavailable due to technical
+                            issues. We are working to resolve these issues as
+                            quickly as possible. If you have questions or need
+                            immediate assistance with your submission, please
+                            email&nbsp;
+                            <a
+                                href="mailto: mc-review@cms.hhs.gov, mc-review-team@truss.works"
+                                className="usa-link"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                mc-review@cms.hhs.gov
+                            </a>
+                            .
+                        </Alert>
+                    )}
                     <Grid row gap className="margin-top-2">
                         <Grid tablet={{ col: 6 }}>
                             <div className={styles.detailsSteps}>


### PR DESCRIPTION
## Summary
This came up during incident response.  We want to use LD to easily toggle on a site maintenance flag when we have an issue to communicate to users (in this case the API was down for an unexpected reason due to AWS outage).

#### Related issues
n/a 

#### Test cases covered
Added tests for flag on and off state. 