### PR TITLE
Add templates folder, ADR and design doc templates

### DIFF
--- a/docs/templates/decision-record-template.md
+++ b/docs/templates/decision-record-template.md
@@ -1,0 +1,46 @@
+---
+title: Architectural Decision Record Template
+---
+
+# 0000 — Title of Decision Record
+
+- Status: [In progress or Decided]
+- Deciders: [Names of deciders]
+- Date: [Date created]
+
+## Assumptions
+​
+A brief listing of any underlying assumptions specific to this decision: cost, timeline, technologies, compliance, etc.
+​
+## Constraints
+​
+Include any decisions explicitly out of scope for this ADR.
+​
+
+## Considered Options
+
+### Option 1
+
+Short description of option 1
+
+### Option 2
+
+Short description of option 2. Also you could have several options you are comparing, does not just have to be 2 options overall.
+
+## Chosen Solution
+
+Describe what the decision is and some high level information about why it was chosen without rehashing all pros/cons.
+
+### Pros and Cons of the Alternatives
+​
+#### Option 1
+​
+- `+` A pro of the option
+- `±` A facet of the option that could be both positive and negative
+- `-` A con of the option
+
+#### Option 2
+
+- `+` A pro of the option
+- `±` A facet of the option that could be both positive and negative
+- `-` A con of the option

--- a/docs/templates/technical-design-template.md
+++ b/docs/templates/technical-design-template.md
@@ -1,0 +1,84 @@
+---
+title: Technical Design Discussion Template
+---
+
+## Title of Design Doc
+
+- Contributors:
+- Proposal Date:
+- Feedback Accepted Until:
+
+## Overview
+
+In one or two sentences,
+summarize what the problem is and how you intend on solving it.
+It's helpful to outline the stakeholders here,
+as it informs why this problem merits solving.
+
+## Constraints (optional)
+
+Write what this document will not cover.
+
+## Terminology (optional)
+
+Define any terminology you are using that could be application system jargon 
+
+## Background
+
+This section is for going into more detail about the problem.
+
+- Who are the stakeholders and how have they been impacted?
+- Historically, what effect has the problem it had?
+- Is there data to illustrate the impact?
+- Is there an existing solution?
+  If so, why does it need to be improved on?
+- Are there past projects or designs to link for context?
+
+## Examples
+
+At least one example should be used to help the audience understand the context better.
+
+## Proposed Solution
+
+Detail your solution here.
+Start with a broad overview and then go into detail on each portion of the design.
+
+- What changes will the stakeholder/client see?
+  This should clearly illustrate how the stakeholders' needs are being met
+- How exactly does it solve the problem outlined above?
+  Explain how this solution applies to the use cases identified.
+- Why are you picking this solution?
+- What are the limits of the proposed solution?
+  At what point will the design cease to be a viable solution?
+- How will you measure the success of your solution?
+- If priorities shift or the solution becomes too cumbersome to implement, how will you roll back?
+
+Visual representations of the solution can be helpful here (ex. a diagram for a request lifecycle).
+
+## Implementation
+
+Without going too much into individual tasks,
+write an overview of what this solution's implementation would look like.
+
+- Can this be broken down into multiple technical efforts?
+- What is the tech stack involved?
+- Will additional infrastructure be needed to achieve this?
+- How will you test this?
+
+## Trade-offs
+
+- This section should go over other possible solutions,
+  and why you chose yours over them.
+- Was there a build vs. buy solution?
+- What industry standards/practices already exist?
+- Why is your solution better?
+
+## Cross Team Dependencies (optional)
+
+If there are multiple teams or clients that are dependencies for implementation to be successful,
+list them here.
+Examples of this are security or design collaboration/reviews.
+
+## Further Reading
+
+List any resources you found helpful to make this design.


### PR DESCRIPTION
## Summary
Add a templates folder so we have example templates on which to base our documentation. 

We can add more templates in the future as needed. For example I was thinking a "How to" template might be nice since some of the docs in the design docs folder are more how to style documentation.