### PR TITLE
Remove rate_certification_programs flag

### DIFF
--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -49,13 +49,6 @@ export const featureFlags = {
         flag: 'app-api-graphql-errors',
         defaultValue: false,
     },
-    /**
-     * Enables selection of programs that apply to rate certification
-     */
-    RATE_CERT_PROGRAMS: {
-        flag: 'rate-certification-programs',
-        defaultValue: false,
-    },
 } as const
 
 export type FlagEnumType = keyof typeof featureFlags

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -4,10 +4,7 @@ import {
     mockStateSubmission,
     mockMNState,
 } from '../../../testHelpers/apolloHelpers'
-import {
-    renderWithProviders,
-    ldUseClientSpy,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { RateDetailsSummarySection } from './RateDetailsSummarySection'
 import { generateRateName } from '../../../common-code/healthPlanFormDataType'
 
@@ -314,8 +311,6 @@ describe('RateDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
     it('renders programs that apply to rate certification', async () => {
-        ldUseClientSpy({ 'rate-certification-programs': true })
-
         const draftSubmission = mockContractAndRatesDraft()
         draftSubmission.rateProgramIDs = [
             'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -12,8 +12,6 @@ import { generateRateName } from '../../../common-code/healthPlanFormDataType/'
 import styles from '../SubmissionSummarySection.module.scss'
 import { HealthPlanFormDataType } from '../../../common-code/healthPlanFormDataType'
 import { Program } from '../../../gen/gqlClient'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../../common-code/featureFlags'
 
 export type RateDetailsSummarySectionProps = {
     submission: HealthPlanFormDataType
@@ -41,14 +39,6 @@ export const RateDetailsSummarySection = ({
     const [zippedFilesURL, setZippedFilesURL] = useState<string>('')
     const rateSupportingDocuments = submission.documents.filter((doc) =>
         doc.documentCategories.includes('RATES_RELATED')
-    )
-
-    const ldClient = useLDClient()
-
-    //If rate program feature flag is off, then turn off displaying program list and omit from Yup schema.
-    const showRatePrograms = ldClient?.variation(
-        featureFlags.RATE_CERT_PROGRAMS.flag,
-        featureFlags.RATE_CERT_PROGRAMS.defaultValue
     )
 
     const rateName = generateRateName(submission, statePrograms)
@@ -120,7 +110,7 @@ export const RateDetailsSummarySection = ({
                 </h3>
 
                 <DoubleColumnGrid>
-                    {ratePrograms && showRatePrograms && (
+                    {ratePrograms && (
                         <DataDetail
                             id="ratePrograms"
                             label="Programs this rate certification covers"

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -13,7 +13,6 @@ import {
     TEST_XLS_FILE,
     TEST_PNG_FILE,
     dragAndDrop,
-    ldUseClientSpy,
 } from '../../../testHelpers/jestHelpers'
 import { RateDetails } from './RateDetails'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
@@ -217,7 +216,7 @@ describe('RateDetails', () => {
                 ],
             },
         }
-        ldUseClientSpy({ 'rate-certification-programs': true })
+
         renderWithProviders(
             <RateDetails
                 draftSubmission={emptyRateDetailsDraft}
@@ -332,7 +331,6 @@ describe('RateDetails', () => {
                 ],
             },
         }
-        ldUseClientSpy({ 'rate-certification-programs': true })
 
         renderWithProviders(
             <RateDetails

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -36,14 +36,12 @@ import {
     formatFormDateForDomain,
 } from '../../../formHelpers'
 import { isS3Error } from '../../../s3'
-import { RateDetailsFormSchema as DefaultRateDetailsFormSchema } from './RateDetailsSchema'
+import { RateDetailsFormSchema } from './RateDetailsSchema'
 import { useS3 } from '../../../contexts/S3Context'
 import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { useStatePrograms } from '../../../hooks/useStatePrograms'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../../common-code/featureFlags'
 
 type FormError =
     FormikErrors<RateDetailsFormValues>[keyof FormikErrors<RateDetailsFormValues>]
@@ -83,17 +81,6 @@ export const RateDetails = ({
     const navigate = useNavigate()
 
     const statePrograms = useStatePrograms()
-
-    const ldClient = useLDClient()
-
-    //If rate program feature flag is off, then turn off displaying program list and omit from Yup schema.
-    const showRatePrograms = ldClient?.variation(
-        featureFlags.RATE_CERT_PROGRAMS.flag,
-        featureFlags.RATE_CERT_PROGRAMS.defaultValue
-    )
-    const RateDetailsFormSchema = showRatePrograms
-        ? DefaultRateDetailsFormSchema
-        : DefaultRateDetailsFormSchema.omit(['rateProgramIDs'])
 
     // Rate documents state management
     const { deleteFile, getKey, getS3URL, scanFile, uploadFile } = useS3()

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -421,47 +421,42 @@ export const RateDetails = ({
                                     onFileItemsUpdate={onFileItemsUpdate}
                                 />
                             </FormGroup>
-                            {showRatePrograms && (
-                                <FormGroup
-                                    error={showFieldErrors(
-                                        errors.rateProgramIDs
-                                    )}
-                                >
-                                    <Label htmlFor="rateProgramIDs">
-                                        Programs this rate certification covers
-                                    </Label>
-                                    {showFieldErrors(errors.rateProgramIDs) && (
-                                        <PoliteErrorMessage>
-                                            {errors.rateProgramIDs}
-                                        </PoliteErrorMessage>
-                                    )}
-                                    <Field name="rateProgramIDs">
-                                        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
-                                        {/* @ts-ignore */}
-                                        {({ form }) => (
-                                            <ProgramSelect
-                                                name="rateProgramIDs"
-                                                inputId="rateProgramIDs"
-                                                statePrograms={statePrograms}
-                                                programIDs={
-                                                    values.rateProgramIDs
-                                                }
-                                                aria-label="programs (required)"
-                                                onChange={(selectedOption) =>
-                                                    form.setFieldValue(
-                                                        'rateProgramIDs',
-                                                        selectedOption.map(
-                                                            (item: {
-                                                                value: string
-                                                            }) => item.value
-                                                        )
+                            <FormGroup
+                                error={showFieldErrors(errors.rateProgramIDs)}
+                            >
+                                <Label htmlFor="rateProgramIDs">
+                                    Programs this rate certification covers
+                                </Label>
+                                {showFieldErrors(errors.rateProgramIDs) && (
+                                    <PoliteErrorMessage>
+                                        {errors.rateProgramIDs}
+                                    </PoliteErrorMessage>
+                                )}
+                                <Field name="rateProgramIDs">
+                                    {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+                                    {/* @ts-ignore */}
+                                    {({ form }) => (
+                                        <ProgramSelect
+                                            name="rateProgramIDs"
+                                            inputId="rateProgramIDs"
+                                            statePrograms={statePrograms}
+                                            programIDs={values.rateProgramIDs}
+                                            aria-label="programs (required)"
+                                            onChange={(selectedOption) =>
+                                                form.setFieldValue(
+                                                    'rateProgramIDs',
+                                                    selectedOption.map(
+                                                        (item: {
+                                                            value: string
+                                                        }) => item.value
                                                     )
-                                                }
-                                            />
-                                        )}
-                                    </Field>
-                                </FormGroup>
-                            )}
+                                                )
+                                            }
+                                        />
+                                    )}
+                                </Field>
+                            </FormGroup>
+
                             <FormGroup error={showFieldErrors(errors.rateType)}>
                                 <Fieldset
                                     className={styles.radioGroup}

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/rateDetails.spec.ts
@@ -89,26 +89,4 @@ describe('rate details', () => {
 
         })
     })
-
-    it('can get fill out rate details with rate-certification-program feature flag on', () => {
-        // Toggle feature flag on
-        cy.interceptFeatureFlags({'rate-certification-programs': true})
-
-        cy.logInAsStateUser()
-        cy.startNewContractAndRatesSubmission()
-
-        // Navigate to rate details page
-        cy.location().then((fullUrl) => {
-            const { pathname } = fullUrl
-            const pathnameArray = pathname.split('/')
-            const draftSubmissionId = pathnameArray[2]
-            cy.navigateFormByDirectLink(`/submissions/${draftSubmissionId}/edit/rate-details`)
-
-            cy.fillOutAmendmentToPriorRateCertification()
-
-            // Navigate to contacts page by clicking continue
-            cy.navigateFormByButtonClick('CONTINUE')
-            cy.findByRole('heading', { level: 2, name: /Contacts/ })
-        })
-    })
 })

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -224,6 +224,9 @@ Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', () => {
     cy.findAllByLabelText('End date').eq(0).type('02/28/2025')
     cy.findAllByLabelText('Start date').eq(1).type('03/01/2024')
     cy.findAllByLabelText('End date').eq(1).type('03/01/2025')
+    cy.findByRole('combobox', { name: 'programs (required)' }).click({
+        force: true,
+    })
     cy.findByText('PMAP').click()
 
     cy.findByLabelText('Date certified for rate amendment').type('03/01/2024')

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -198,20 +198,17 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
     cy.findByLabelText('End date').type('02/28/2025')
     cy.findByLabelText('Date certified').type('03/01/2024')
 
-    cy.getFeatureFlagStore(['rate-certification-programs']).then((store) => {
-        if (store['rate-certification-programs']) {
-            cy.findByRole('combobox', { name: 'programs (required)' }).click({
-                force: true,
-            })
-            cy.findByText('PMAP').click()
-        }
-        cy.findByTestId('file-input-input').attachFile(
-            'documents/trussel-guide.pdf'
-        )
-        cy.verifyDocumentsHaveNoErrors()
-        cy.waitForDocumentsToLoad()
-        cy.findAllByTestId('errorMessage').should('have.length', 0)
+    cy.findByRole('combobox', { name: 'programs (required)' }).click({
+        force: true,
     })
+    cy.findByText('PMAP').click()
+
+    cy.findByTestId('file-input-input').attachFile(
+        'documents/trussel-guide.pdf'
+    )
+    cy.verifyDocumentsHaveNoErrors()
+    cy.waitForDocumentsToLoad()
+    cy.findAllByTestId('errorMessage').should('have.length', 0)
 })
 
 Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', () => {
@@ -227,22 +224,17 @@ Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', () => {
     cy.findAllByLabelText('End date').eq(0).type('02/28/2025')
     cy.findAllByLabelText('Start date').eq(1).type('03/01/2024')
     cy.findAllByLabelText('End date').eq(1).type('03/01/2025')
-    cy.getFeatureFlagStore(['rate-certification-programs']).then((store) => {
-        if (store['rate-certification-programs']) {
-            cy.findByRole('combobox', { name: 'programs (required)' }).click({
-                force: true,
-            })
-            cy.findByText('PMAP').click()
-        }
-        cy.findByLabelText('Date certified for rate amendment').type('03/01/2024')
-        cy.findByTestId('file-input-input').attachFile(
-            'documents/trussel-guide.pdf'
-        )
+    cy.findByText('PMAP').click()
 
-        cy.verifyDocumentsHaveNoErrors()
-        cy.waitForDocumentsToLoad()
-        cy.findAllByTestId('errorMessage').should('have.length', 0)
-    })
+    cy.findByLabelText('Date certified for rate amendment').type('03/01/2024')
+    cy.findByTestId('file-input-input').attachFile(
+        'documents/trussel-guide.pdf'
+    )
+
+    cy.verifyDocumentsHaveNoErrors()
+    cy.waitForDocumentsToLoad()
+    cy.findAllByTestId('errorMessage').should('have.length', 0)
+
 })
 
 Cypress.Commands.add('fillOutStateContact', () => {


### PR DESCRIPTION
## Summary
Remove the multi program rates flag from codebase.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2591

#### Test cases covered

 I adjusted tests that referenced the flag and removed a test that tested if the flag worked. 

## QA guidance

Check that multi-program rates workflows work as expected. 
