### PR TITLE
Fix error in protobuf data migrator imports

### DIFF
--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -62,6 +62,10 @@ jobs:
       - name: Generate Code
         run: lerna run generate-code
 
+      - name: Compile proto migration files
+        working-directory: services/app-api
+        run: yarn run build
+
       - uses: actions/download-artifact@v3
         with:
           name: lambda-layers-prisma-client-migration

--- a/.github/workflows/deploy-app-to-env.yml
+++ b/.github/workflows/deploy-app-to-env.yml
@@ -63,7 +63,7 @@ jobs:
         run: lerna run generate-code
 
       - name: Compile proto migration files
-        working-directory: services/app-api
+        working-directory: services/app-proto
         run: yarn run build
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       always() &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
 
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-a-fourth-one
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
       app_version: ${{ needs.begin-deployment.outputs.app-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       always() &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
 
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-a-fourth-one
     with:
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
       app_version: ${{ needs.begin-deployment.outputs.app-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ services/app-api/lambda-layers-prisma-client
 services/app-api/lambda-layers-prisma-client-migration
 services/app-api/lambda-layers-prisma-client-query
 services/app-api/lambda-layers-prisma-client-engine
+services/app-api/healthPlanFormDataMigrations
+
+services/app-proto/build

--- a/services/app-api/scripts/prepare-prisma-layer.sh
+++ b/services/app-api/scripts/prepare-prisma-layer.sh
@@ -51,7 +51,6 @@ function preparePrismaLayer() {
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/libquery_engine-debian-openssl-1.1.x.so.node 
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/migration-engine-debian-openssl-1.1.x
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/prisma-fmt-debian-openssl-1.1.x
-    rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/.prisma/client/libquery_engine-rhel-openssl-1.0.x.so.node
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/libquery_engine-rhel-openssl-1.0.x.so.node
 
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node

--- a/services/app-api/scripts/prepare-prisma-layer.sh
+++ b/services/app-api/scripts/prepare-prisma-layer.sh
@@ -10,8 +10,6 @@ function preparePrismaLayer() {
     mkdir -p lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/engines
     mkdir -p lambda-layers-prisma-client-migration/nodejs/node_modules/prisma
     mkdir -p lambda-layers-prisma-client-migration/nodejs/prisma
-    mkdir -p lambda-layers-prisma-client-migration/nodejs/healthPlanFormDataMigrations
-    mkdir -p lambda-layers-prisma-client-migration/nodejs/gen
 
     echo "Creating engine layer ..."
     mkdir -p lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma
@@ -41,10 +39,6 @@ function preparePrismaLayer() {
     rsync -av prisma/ lambda-layers-prisma-client-migration/nodejs/prisma
     rsync -av prisma/ lambda-layers-prisma-client-engine/nodejs/prisma
 
-    echo "Copy proto migrations to layer..."
-    rsync -av ../app-proto/protoMigrations/healthPlanFormDataMigrations/ lambda-layers-prisma-client-migration/nodejs/healthPlanFormDataMigrations
-    rsync -av ../app-proto/gen/ lambda-layers-prisma-client-migration/nodejs/gen
-
     echo "Remove Prisma CLI ..."
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/cli
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/cli
@@ -57,6 +51,8 @@ function preparePrismaLayer() {
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/libquery_engine-debian-openssl-1.1.x.so.node 
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/migration-engine-debian-openssl-1.1.x
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/prisma-fmt-debian-openssl-1.1.x
+    rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/.prisma/client/libquery_engine-rhel-openssl-1.0.x.so.node
+    rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/libquery_engine-rhel-openssl-1.0.x.so.node
 
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/prisma/engines

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -3,7 +3,6 @@ service: app-api
 frameworkVersion: '^3.19.0'
 
 package:
-  individually: true
   patterns:
     - '!node_modules/prisma'
     - '!node_modules/.prisma'
@@ -40,6 +39,7 @@ custom:
         - '@prisma/client'
       nodeModulesRelativeDir: '../../'
     excludeRegex: 'darwin|debian'
+    keepOutputDirectory: true
   serverlessTerminationProtection:
     stages:
       - dev

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -39,7 +39,6 @@ custom:
         - '@prisma/client'
       nodeModulesRelativeDir: '../../'
     excludeRegex: 'darwin|debian'
-    keepOutputDirectory: true
   serverlessTerminationProtection:
     stages:
       - dev

--- a/services/app-api/src/handlers/postgres_migrate.ts
+++ b/services/app-api/src/handlers/postgres_migrate.ts
@@ -102,7 +102,7 @@ export const main: APIGatewayProxyHandler = async () => {
     // run the data migration. this will run any data changes to the protobufs stored in postgres
     try {
         const migrator = newDBMigrator(dbConnectionURL)
-        await migrate(migrator, '/opt/nodejs/healthPlanFormDataMigrations')
+        await migrate(migrator, '/opt/nodejs/')
     } catch (err) {
         console.log(err)
         return {

--- a/services/app-api/webpack.config.js
+++ b/services/app-api/webpack.config.js
@@ -90,6 +90,9 @@ module.exports = {
                             );
                     },
                 },
+                {
+                    from: path.resolve(__dirname, '../app-proto/build'),
+                },
             ],
         }),
     ],

--- a/services/app-proto/package.json
+++ b/services/app-proto/package.json
@@ -11,7 +11,8 @@
         "proto:ts": "pbts -o ./gen/healthPlanFormDataProto.d.ts ./gen/healthPlanFormDataProto.js",
         "proto:copy-web": "rsync -av ./gen/ ../app-web/src/gen",
         "precommit": "lint-staged",
-        "lint": "protolint lint ."
+        "lint": "protolint lint .",
+        "build": "tsc"
     },
     "lint-staged": {
         "*.proto": [

--- a/services/app-proto/tsconfig.json
+++ b/services/app-proto/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "outDir": "./build",
-        "baseUrl": "/",
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "preserveConstEnums": true,
@@ -14,5 +13,6 @@
         "allowJs": true,
         "module": "commonjs",
         "lib": ["esnext"]
-    }
+    },
+    "include": ["protoMigrations/healthPlanFormDataMigrations"]
 }


### PR DESCRIPTION
## Summary

This fixes up the CI process around importing migration scripts into the migrator. It turns out that there is a bug in AWS lambda environments where imports cannot come from lambda layers. There are [some](https://github.com/vibe/aws-esm-modules-layer-support) [hacks](https://github.com/coderbyheart/aws-lambda-esm-with-layer) to work around this limitation, but here we're just moving away from using the layer altogether and instead using webpack. 

We compile the scripts from `app-proto` and then use copy webpack to move them into the bundle. 

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2614


## QA guidance

<!---These are developer instructions on how to test or validate the work -->
