### PR TITLE
Configure Postgres Aurora DeletionPolicy

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -64,6 +64,10 @@ custom:
     other: true
     val: false
     prod: false
+  deletionPolicy:
+    other: 'Delete'
+    val: 'Retain'
+    prod: 'Retain'
 
 package:
   individually: true
@@ -108,6 +112,7 @@ resources:
 
     PostgresAurora:
       Type: AWS::RDS::DBCluster
+      DeletionPolicy: ${self:custom.deletionPolicy.${opt:stage}, self:custom.deletionPolicy.other}
       Properties:
         Engine: aurora-postgresql
         EngineMode: serverless


### PR DESCRIPTION
## Summary
The default [Aurora DeletionPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) for `AWS::RDS::DBCluster` is `Snapshot`. This is fine for `val` and `prod`, where we do want to retain snapshots in the unlikely situation that our DB gets deleted. For our testing environments this is unnecessary, as there is only test data in the DB and each snapshot takes up AWS resources.

This configures it to delete snapshots when we're in any environment other than `val` and `prod`

#### Related issues
https://qmacbis.atlassian.net/browse/MR-958

