### PR TITLE
MR-2464: Fill in rate program names from programIDs

### DIFF
--- a/services/app-web/src/components/FileUpload/FileUpload.tsx
+++ b/services/app-web/src/components/FileUpload/FileUpload.tsx
@@ -109,7 +109,7 @@ export const FileUpload = ({
 
     const isAcceptableFile = (file: File): boolean => {
         const acceptedTypes = inputProps?.accept?.split(',') || []
-        if (acceptedTypes === []) return true
+        if (acceptedTypes.length === 0) return true
         const acceptedFile = acceptedTypes.some(
             (fileType) =>
                 file.name.indexOf(fileType) > 0 ||

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -332,4 +332,28 @@ describe('RateDetailsSummarySection', () => {
         const programList = within(programElement).getByText('SNBC, PMAP')
         expect(programList).toBeInTheDocument()
     })
+
+    it('renders rate program names even when rate program ids are missing', async () => {
+        const draftSubmission = mockContractAndRatesDraft()
+        draftSubmission.rateProgramIDs = []
+        draftSubmission.programIDs = [
+            'abbdf9b0-c49e-4c4c-bb6f-040cb7b51cce',
+            'd95394e5-44d1-45df-8151-1cc1ee66f100',
+        ]
+        draftSubmission.rateCapitationType = 'RATE_RANGE'
+        renderWithProviders(
+            <RateDetailsSummarySection
+                submission={draftSubmission}
+                navigateTo="rate-details"
+                submissionName="MN-PMAP-0001"
+                statePrograms={statePrograms}
+            />
+        )
+        const programElement = screen.getByRole('definition', {
+            name: 'Programs this rate certification covers',
+        })
+        expect(programElement).toBeInTheDocument()
+        const programList = within(programElement).getByText('SNBC, PMAP')
+        expect(programList).toBeInTheDocument()
+    })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -49,12 +49,20 @@ export const RateDetailsSummarySection = ({
             : 'Certification of rate ranges of capitation rates per rate cell'
         : ''
 
-    const ratePrograms =
-        submission.rateProgramIDs && submission.rateProgramIDs.length > 0
+    const ratePrograms = () => {
+        /* if we have rateProgramIDs, use them, otherwise use programIDs */
+        let programIDs = [] as string[]
+        if (submission.rateProgramIDs && submission.rateProgramIDs.length > 0) {
+            programIDs = submission.rateProgramIDs
+        } else if (submission.programIDs && submission.programIDs.length > 0) {
+            programIDs = submission.programIDs
+        }
+        return programIDs
             ? statePrograms
-                  .filter((p) => submission.rateProgramIDs?.includes(p.id))
+                  .filter((p) => programIDs.includes(p.id))
                   .map((p) => p.name)
             : undefined
+    }
 
     useEffect(() => {
         // get all the keys for the documents we want to zip
@@ -114,7 +122,7 @@ export const RateDetailsSummarySection = ({
                         <DataDetail
                             id="ratePrograms"
                             label="Programs this rate certification covers"
-                            data={ratePrograms}
+                            data={ratePrograms()}
                         />
                     )}
                     <DataDetail


### PR DESCRIPTION
## Summary

We now allow users to assign programs to rates (rateProgramIDs), as we've always done for submissions as a whole (with programIDs).  But that means older submissions don't have user-selected program names for their rates.  This PR falls back to program IDs to fill in program names for rates from older submissions.

#### Test cases covered

Added a test to check that the fallback works.  The real test will be pulling up older submissions in a deployed environment and seeing program names in the rate detail section.

