### PR TITLE
Improve page view logging in Tealium 

### DIFF
--- a/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.tsx
+++ b/services/app-web/src/components/DynamicStepIndicator/DynamicStepIndicator.tsx
@@ -1,10 +1,10 @@
 import { StepIndicator, StepIndicatorStep } from '@trussworks/react-uswds'
 
-import { PageTitlesRecord, RouteT } from '../../constants/routes'
+import { PageTitlesRecord, RouteTWithUnknown } from '../../constants/routes'
 
 export type DynamicStepIndicatorProps = {
-    formPages: RouteT[]
-    currentFormPage: RouteT | 'UNKNOWN_ROUTE'
+    formPages: RouteTWithUnknown[]
+    currentFormPage: RouteTWithUnknown
 }
 
 type formStepStatusT = 'current' | 'complete' | undefined
@@ -21,19 +21,21 @@ export const DynamicStepIndicator = ({
     }
 
     let formStepCompleted = true
-    const formPagesWithStatus: { name: RouteT; status: formStepStatusT }[] =
-        formPages.map((formPageName) => {
-            let status: formStepStatusT = undefined
+    const formPagesWithStatus: {
+        name: RouteTWithUnknown
+        status: formStepStatusT
+    }[] = formPages.map((formPageName) => {
+        let status: formStepStatusT = undefined
 
-            if (formPageName === currentFormPage) {
-                formStepCompleted = false
-                status = 'current'
-            } else if (formStepCompleted) {
-                status = 'complete'
-            }
+        if (formPageName === currentFormPage) {
+            formStepCompleted = false
+            status = 'current'
+        } else if (formStepCompleted) {
+            status = 'complete'
+        }
 
-            return { name: formPageName, status: status }
-        })
+        return { name: formPageName, status: status }
+    })
 
     return (
         <StepIndicator headingLevel="h2">

--- a/services/app-web/src/components/Header/Header.test.tsx
+++ b/services/app-web/src/components/Header/Header.test.tsx
@@ -15,14 +15,14 @@ describe('Header', () => {
     })
 
     describe('when logged out', () => {
-        it('displays Medicaid logo image link that redirects to /dashboard', async () => {
+        it('displays Medicaid logo image link that redirects to /', async () => {
             renderWithProviders(<Header authMode={'AWS_COGNITO'} />)
             const logoImage = screen.getByRole('img')
             const logoLink = screen.getByRole('link', {
                 name: /One Mac/i,
             })
             expect(logoLink).toBeVisible()
-            expect(logoLink).toHaveAttribute('href', '/dashboard')
+            expect(logoLink).toHaveAttribute('href', '/')
             expect(logoLink).toContainElement(logoImage)
         })
 
@@ -60,7 +60,7 @@ describe('Header', () => {
     })
 
     describe('when logged in', () => {
-        it('displays Medicaid logo image link that redirects to /dashboard', () => {
+        it('displays Medicaid logo image link that redirects to /', () => {
             renderWithProviders(<Header authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],
@@ -71,7 +71,7 @@ describe('Header', () => {
                 name: /One Mac/i,
             })
             expect(logoLink).toBeVisible()
-            expect(logoLink).toHaveAttribute('href', '/dashboard')
+            expect(logoLink).toHaveAttribute('href', '/')
             expect(logoLink).toContainElement(logoImage)
         })
 

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -48,7 +48,7 @@ export const Header = ({
             <div className={styles.banner}>
                 <GridContainer>
                     <Grid row className="flex-justify flex-align-center">
-                        <NavLink className={styles.bannerLogo} to="/dashboard">
+                        <NavLink className={styles.bannerLogo} to="/">
                             <Logo
                                 src={onemacLogo}
                                 alt="One Mac"

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -1,6 +1,6 @@
 /*
     Every application route is named here.
-    These types ensure we use valid routes throughout the application.
+    These types ensure we use valid routes throughout the application.. 
 */
 const ROUTES = [
     'ROOT',
@@ -22,6 +22,11 @@ const ROUTES = [
 ] as const // iterable union type
 type RouteT = typeof ROUTES[number]
 
+/*
+    Every application url (excluding query parameters) is found in the RoutesRecord.
+    These types ensure we use valid route throughout the application
+
+*/
 const RoutesRecord: Record<RouteT, string> = {
     ROOT: '/',
     AUTH: '/auth',
@@ -51,17 +56,25 @@ const STATE_SUBMISSION_FORM_ROUTES: RouteT[] = [
 ]
 
 /*
-    Static page headings used in <header> h1 when logged in. Dynamic headings, when necessary, are set in page specific parent component.
-    Every route does not need a page heading in the record. It is a design choice what goes here. For example, we do not any headings when logged in user is on a Not Found page
+    Page headings used in the <header> when user logged in.
+    Dynamic headings, when necessary, are set in page specific parent component.
+    Every route does not need a page heading in the record. 
+    It is a design choice what goes here. For example, we do not any headings when logged in user is on the help page.
+    For a quick way to check page headings, look for the h1 of the application in the DOM tree. It is the dark blue row of the header.
+
 */
-const PageHeadingsRecord: Record<string, string> = {
-    ROOT: 'Dashboard',
+const PageHeadingsRecord: Partial<Record<RouteT | 'UNKNOWN_ROUTE', string>> = {
+    ROOT: 'Home',
     DASHBOARD: 'Dashboard',
     SUBMISSIONS_NEW: 'New submission',
+    UNKNOWN_ROUTE: '404',
 }
 
-// Static page titles used in <title>.
-// Every route must have a page title in the record for accessibility reasons. Dynamic page titles, when necessary, are set in AppRoutes
+/* 
+    Static page titles used in <title>.
+    Every route must have a page title in the record for accessibility reasons. Dynamic page titles, when necessary, are set in AppRoutes
+    For a quick way to check page titles, look at the tab text in your browser. 
+*/
 const PageTitlesRecord: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     ROOT: 'Home',
     AUTH: 'Login',

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -69,7 +69,7 @@ const STATE_SUBMISSION_SUMMARY_ROUTES: RouteTWithUnknown[] = [
 
 */
 const PageHeadingsRecord: Partial<Record<RouteTWithUnknown, string>> = {
-    ROOT: 'Home',
+    ROOT: 'Dashboard',
     DASHBOARD: 'Dashboard',
     SUBMISSIONS_NEW: 'New submission',
     UNKNOWN_ROUTE: '404',

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -21,7 +21,7 @@ const ROUTES = [
     'SUBMISSIONS_SUMMARY',
 ] as const // iterable union type
 type RouteT = typeof ROUTES[number]
-
+type RouteTWithUnknown = RouteT | 'UNKNOWN_ROUTE'
 /*
     Every application url (excluding query parameters) is found in the RoutesRecord.
     These types ensure we use valid route throughout the application
@@ -46,13 +46,18 @@ const RoutesRecord: Record<RouteT, string> = {
     SUBMISSIONS_REVISION: '/submissions/:id/revisions/:revisionVersion',
 }
 
-const STATE_SUBMISSION_FORM_ROUTES: RouteT[] = [
+const STATE_SUBMISSION_FORM_ROUTES: RouteTWithUnknown[] = [
     'SUBMISSIONS_TYPE',
     'SUBMISSIONS_CONTRACT_DETAILS',
     'SUBMISSIONS_RATE_DETAILS',
     'SUBMISSIONS_CONTACTS',
     'SUBMISSIONS_DOCUMENTS',
     'SUBMISSIONS_REVIEW_SUBMIT',
+]
+
+const STATE_SUBMISSION_SUMMARY_ROUTES: RouteTWithUnknown[] = [
+    'SUBMISSIONS_SUMMARY',
+    'SUBMISSIONS_REVISION',
 ]
 
 /*
@@ -63,7 +68,7 @@ const STATE_SUBMISSION_FORM_ROUTES: RouteT[] = [
     For a quick way to check page headings, look for the h1 of the application in the DOM tree. It is the dark blue row of the header.
 
 */
-const PageHeadingsRecord: Partial<Record<RouteT | 'UNKNOWN_ROUTE', string>> = {
+const PageHeadingsRecord: Partial<Record<RouteTWithUnknown, string>> = {
     ROOT: 'Home',
     DASHBOARD: 'Dashboard',
     SUBMISSIONS_NEW: 'New submission',
@@ -101,6 +106,7 @@ export {
     RoutesRecord,
     ROUTES,
     STATE_SUBMISSION_FORM_ROUTES,
+    STATE_SUBMISSION_SUMMARY_ROUTES,
 }
 
-export type { RouteT }
+export type { RouteT, RouteTWithUnknown }

--- a/services/app-web/src/constants/tealium.ts
+++ b/services/app-web/src/constants/tealium.ts
@@ -1,5 +1,10 @@
 import { User } from '../gen/gqlClient'
-import { PageTitlesRecord, RoutesRecord, RouteT } from './routes'
+import {
+    PageTitlesRecord,
+    RouteT,
+    STATE_SUBMISSION_FORM_ROUTES,
+    STATE_SUBMISSION_SUMMARY_ROUTES,
+} from './routes'
 
 // TYPES
 type TealiumDataObject = {
@@ -43,7 +48,6 @@ const CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     UNKNOWN_ROUTE: '404',
 }
 
-
 type TealiumEvent =
     | 'search'
     | 'submission_view'
@@ -65,10 +69,29 @@ function getTealiumEnv(stage: string) {
     }
 }
 
-const getTealiumPageName = ({route, heading, user} : {route: RouteT | 'UNKNOWN_ROUTE', heading: string | undefined, user: User | undefined} ) => {
-    const formatPageName = ({heading, title}: {title: string, heading?: string}) => {
-        const headingPrefix = heading? `${heading}: ` : '';
-         return`${headingPrefix}${title}`
+const getTealiumPageName = ({
+    route,
+    heading,
+    user,
+}: {
+    route: RouteT | 'UNKNOWN_ROUTE'
+    heading: string | undefined
+    user: User | undefined
+}) => {
+    const addSubmissionNameHeading =
+        STATE_SUBMISSION_FORM_ROUTES.includes(route) ||
+        STATE_SUBMISSION_SUMMARY_ROUTES.includes(route)
+
+    const formatPageName = ({
+        heading,
+        title,
+    }: {
+        title: string
+        heading?: string
+    }) => {
+        const headingPrefix =
+            heading && addSubmissionNameHeading ? `${heading}: ` : ''
+        return `${headingPrefix}${title}`
     }
     switch (route) {
         case 'ROOT':
@@ -86,7 +109,7 @@ const getTealiumPageName = ({route, heading, user} : {route: RouteT | 'UNKNOWN_R
         case 'DASHBOARD':
             if (user && user.__typename === 'CMSUser') {
                 return formatPageName({ title: 'CMS Dashboard' })
-            }else if (user && user.__typename === 'StateUser') {
+            } else if (user && user.__typename === 'StateUser') {
                 return formatPageName({
                     heading,
                     title: 'State dashboard',
@@ -99,5 +122,5 @@ const getTealiumPageName = ({route, heading, user} : {route: RouteT | 'UNKNOWN_R
     }
 }
 
-export { CONTENT_TYPE_BY_ROUTE, getTealiumEnv,getTealiumPageName }
+export { CONTENT_TYPE_BY_ROUTE, getTealiumEnv, getTealiumPageName }
 export type { TealiumLinkDataObject, TealiumViewDataObject, TealiumEvent }

--- a/services/app-web/src/constants/tealium.ts
+++ b/services/app-web/src/constants/tealium.ts
@@ -1,5 +1,7 @@
-import { RouteT } from './routes'
+import { User } from '../gen/gqlClient'
+import { PageTitlesRecord, RoutesRecord, RouteT } from './routes'
 
+// TYPES
 type TealiumDataObject = {
     content_language: string
     content_type: string
@@ -20,20 +22,7 @@ type TealiumLinkDataObject = {
 
 type TealiumViewDataObject = TealiumDataObject // event default to page_view in useTealium hook
 
-// map stage names to tealium env name
-function getTealiumEnv(stage: string) {
-    switch (stage) {
-        case 'prod':
-            return 'prod'
-        case 'val':
-            return 'qa'
-        case 'main':
-            return 'dev'
-        default:
-            return 'dev'
-    }
-}
-
+// CONSTANTS
 const CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     ROOT: 'root',
     AUTH: 'login',
@@ -54,6 +43,7 @@ const CONTENT_TYPE_BY_ROUTE: Record<RouteT | 'UNKNOWN_ROUTE', string> = {
     UNKNOWN_ROUTE: '404',
 }
 
+
 type TealiumEvent =
     | 'search'
     | 'submission_view'
@@ -61,5 +51,53 @@ type TealiumEvent =
     | 'user_logout'
     | 'save_draft'
 
-export { getTealiumEnv, CONTENT_TYPE_BY_ROUTE }
+// HELPER FUNCTIONS
+function getTealiumEnv(stage: string) {
+    switch (stage) {
+        case 'prod':
+            return 'prod'
+        case 'val':
+            return 'qa'
+        case 'main':
+            return 'dev'
+        default:
+            return 'dev'
+    }
+}
+
+const getTealiumPageName = ({route, heading, user} : {route: RouteT | 'UNKNOWN_ROUTE', heading: string | undefined, user: User | undefined} ) => {
+    const formatPageName = ({heading, title}: {title: string, heading?: string}) => {
+        const headingPrefix = heading? `${heading}: ` : '';
+         return`${headingPrefix}${title}`
+    }
+    switch (route) {
+        case 'ROOT':
+            if (!user) {
+                return formatPageName({ title: 'Landing' })
+            } else if (user.__typename === 'CMSUser') {
+                return formatPageName({ heading, title: 'CMS Dashboard' })
+            } else if (user.__typename === 'StateUser') {
+                return formatPageName({
+                    heading,
+                    title: 'State dashboard',
+                })
+            }
+            return formatPageName({ heading, title: PageTitlesRecord[route] })
+        case 'DASHBOARD':
+            if (user && user.__typename === 'CMSUser') {
+                return formatPageName({ title: 'CMS Dashboard' })
+            }else if (user && user.__typename === 'StateUser') {
+                return formatPageName({
+                    heading,
+                    title: 'State dashboard',
+                })
+            }
+            return formatPageName({ heading, title: PageTitlesRecord[route] })
+
+        default:
+            return formatPageName({ heading, title: PageTitlesRecord[route] })
+    }
+}
+
+export { CONTENT_TYPE_BY_ROUTE, getTealiumEnv,getTealiumPageName }
 export type { TealiumLinkDataObject, TealiumViewDataObject, TealiumEvent }

--- a/services/app-web/src/hooks/useCurrentRoute.ts
+++ b/services/app-web/src/hooks/useCurrentRoute.ts
@@ -10,7 +10,7 @@ const useCurrentRoute = (): {
     const { pathname } = useLocation()
 
     const routeName = getRouteName(pathname)
-    return { currentRoute: routeName, pathname: pathname }
+    return { currentRoute: routeName, pathname }
 }
 
 export { useCurrentRoute }

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -4,7 +4,11 @@ import { useCurrentRoute } from './useCurrentRoute'
 import { createScript } from './useScript'
 import { PageTitlesRecord } from '../constants/routes'
 import { useAuth } from '../contexts/AuthContext'
-import {CONTENT_TYPE_BY_ROUTE, getTealiumEnv, getTealiumPageName } from '../constants/tealium'
+import {
+    CONTENT_TYPE_BY_ROUTE,
+    getTealiumEnv,
+    getTealiumPageName,
+} from '../constants/tealium'
 import type {
     TealiumLinkDataObject,
     TealiumViewDataObject,
@@ -95,21 +99,9 @@ const useTealium = (): {
     // Add page view
     // this effect should fire on each page view or if something changes about logged in user
     useEffect(() => {
-        console.log(currentRoute, loggedInUser, pathname, heading)
-        // Do not add page views while page is still loading
-        if (!pathname){
-            return
-        }
-
         // Do not add tealium for local dev or review apps
         if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
-            console.log(
-                `mock tealium page view: ${getTealiumPageName({
-                    heading,
-                    route: currentRoute,
-                    user: loggedInUser,
-                })}`
-            )
+            console.log(`mock tealium page view: ${tealiumPageName}`)
             return
         }
 
@@ -119,7 +111,7 @@ const useTealium = (): {
                 'PROGRAMMING ERROR: tried to use tealium utag before it was loaded'
             )
         }
-        
+
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         const utag = window.utag || { link: () => {}, view: () => {} }
         const tagData: TealiumViewDataObject = {

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -92,6 +92,11 @@ const useTealium = (): {
     useEffect(() => {
         // Do not add tealium for local dev or review apps
         if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
+            console.log(
+                `mock tealium page view: ${JSON.stringify(
+                    `${heading}: ${PageTitlesRecord[currentRoute]}`
+                )}`
+            )
             return
         }
 

--- a/services/app-web/src/hooks/useTealium.ts
+++ b/services/app-web/src/hooks/useTealium.ts
@@ -4,7 +4,7 @@ import { useCurrentRoute } from './useCurrentRoute'
 import { createScript } from './useScript'
 import { PageTitlesRecord } from '../constants/routes'
 import { useAuth } from '../contexts/AuthContext'
-import { getTealiumEnv, CONTENT_TYPE_BY_ROUTE } from '../constants/tealium'
+import {CONTENT_TYPE_BY_ROUTE, getTealiumEnv, getTealiumPageName } from '../constants/tealium'
 import type {
     TealiumLinkDataObject,
     TealiumViewDataObject,
@@ -25,6 +25,11 @@ const useTealium = (): {
     const { currentRoute, pathname } = useCurrentRoute()
     const { heading } = usePage()
     const { loggedInUser } = useAuth()
+    const tealiumPageName = getTealiumPageName({
+        heading,
+        route: currentRoute,
+        user: loggedInUser,
+    })
 
     // Add Tealium setup
     // this effect should only fire on initial app load
@@ -90,12 +95,20 @@ const useTealium = (): {
     // Add page view
     // this effect should fire on each page view or if something changes about logged in user
     useEffect(() => {
+        console.log(currentRoute, loggedInUser, pathname, heading)
+        // Do not add page views while page is still loading
+        if (!pathname){
+            return
+        }
+
         // Do not add tealium for local dev or review apps
         if (process.env.REACT_APP_AUTH_MODE !== 'IDM') {
             console.log(
-                `mock tealium page view: ${JSON.stringify(
-                    `${heading}: ${PageTitlesRecord[currentRoute]}`
-                )}`
+                `mock tealium page view: ${getTealiumPageName({
+                    heading,
+                    route: currentRoute,
+                    user: loggedInUser,
+                })}`
             )
             return
         }
@@ -106,12 +119,13 @@ const useTealium = (): {
                 'PROGRAMMING ERROR: tried to use tealium utag before it was loaded'
             )
         }
+        
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         const utag = window.utag || { link: () => {}, view: () => {} }
         const tagData: TealiumViewDataObject = {
             content_language: 'en',
             content_type: `${CONTENT_TYPE_BY_ROUTE[currentRoute]}`,
-            page_name: `${heading}: ${PageTitlesRecord[currentRoute]}`,
+            page_name: tealiumPageName,
             page_path: pathname,
             site_domain: 'cms.gov',
             site_environment: `${process.env.REACT_APP_STAGE_NAME}`,
@@ -119,7 +133,7 @@ const useTealium = (): {
             logged_in: `${Boolean(loggedInUser) ?? false}`,
         }
         utag.view(tagData)
-    }, [currentRoute, loggedInUser, pathname, heading])
+    }, [currentRoute, loggedInUser, pathname, tealiumPageName])
 
     // Add user event
     const logTealiumEvent = (linkData: {

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -212,9 +212,8 @@ export const AppRoutes = ({
             }
             // Then, when we login, read that key, if it exists, go forth.
         } else {
-            console.log('Retrieved For Redirect: ', redirectPath)
-
             if (typeof redirectPath === 'string') {
+                console.log('Retrieved For Redirect: ', redirectPath)
                 navigate(redirectPath)
                 setRedirectPath(null)
             }

--- a/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
+++ b/services/app-web/src/pages/StateSubmission/StateSubmissionForm.tsx
@@ -14,6 +14,7 @@ import { usePage } from '../../contexts/PageContext'
 import {
     STATE_SUBMISSION_FORM_ROUTES,
     RouteT,
+    RouteTWithUnknown,
     RoutesRecord,
 } from '../../constants/routes'
 import { getRelativePath } from '../../routeHelpers'
@@ -88,7 +89,9 @@ const PageBannerAlerts = ({
     )
 }
 
-const activeFormPages = (draft: UnlockedHealthPlanFormDataType): RouteT[] => {
+const activeFormPages = (
+    draft: UnlockedHealthPlanFormDataType
+): RouteTWithUnknown[] => {
     // If submission type is contract only, rate details is left out of the step indicator
     return STATE_SUBMISSION_FORM_ROUTES.filter(
         (formPage) =>


### PR DESCRIPTION
## Summary
The page_view events were not being properly associated in google analytics. There was some bad or just confusing data (things like `undefined: Home`, `Home: Home`, `Dashboard:Dashboard`  being logged).  I added a function to better determine the name of pages, particularly with a shared route (such as ROOT `/`)

I've also added new types `RouteTWithUnknown` to reflect a type that is already used in the app currently in a few places. 

### Related issues
This is a small part of MR-2572 I can complete now without waiting for response to Blast ticket. 
https://qmacbis.atlassian.net/browse/MR-2572 
 
### Screenshots
![Screen Shot 2022-09-29 at 5 34 48 PM](https://user-images.githubusercontent.com/10750442/193155217-d1cba28c-cf9e-4f0f-add5-8bd012e48787.png)

## QA guidance
If you navigate through the app locally you can see the mock Tealium event console log showing what page name would be logged. 

**Note to reviewers 😄 :** 
Even though the page names are now more correct you will see they are happening twice on certain pages. This is _not_ unexpected and could mess up analytics but I wasn't able to address this quick re-render bug easily. I tried a couple things to cleanup the effect but couldn't pinpoint what was causing the issue (what is causing AppBody to unmount). I think it is one of the contexts (pagecontext or authcontext) but also couldn't work around that either - here's an [article](https://javascript.plainenglish.io/react-context-why-am-i-getting-unnecessary-re-renders-b61836d224a7) I was referencing. 

I welcome code review on this now if you can see where the bug is (or have suggestions).  However, since this was a bug present with the existing implementation on prod, I don't think this issue should block the incremental improvement.

 