### PR TITLE
Fix promote GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -232,7 +232,7 @@ jobs:
       always() &&
       (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
 
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@mt-more-proto-migrate
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: ${{ needs.begin-deployment.outputs.stage-name }}
       app_version: ${{ needs.begin-deployment.outputs.app-version }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -94,6 +94,10 @@ jobs:
         working-directory: services/app-api
         run: PRISMA_CLI_BINARY_TARGETS=rhel-openssl-1.0.x yarn install --prefer-offline --frozen-lockfile --cache-folder ${{ steps.yarn-cache-dir-path.outputs.dir }}
 
+      - name: Generate protos
+        working-directory: services/app-proto
+        run: yarn run protogen && yarn run build
+
       # Generate Prisma Client and binary that can run in a lambda environment
       - name: Prepare prisma client
         working-directory: services/app-api


### PR DESCRIPTION
## Summary

The recently merged #1233 had a missing step in the promote script. This also swaps back the deploy script to use `main`.

