### PR TITLE
First rate-certification in multi-rate submission on Rate Details page should not be removable.

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -477,7 +477,7 @@ export const RateDetails = ({
                                     {({ remove, push }) => (
                                         <>
                                             {rateInfos.map(
-                                                (rateInfo, index, arr) => (
+                                                (rateInfo, index) => (
                                                     <div
                                                         key={rateInfo.uuid}
                                                         id={rateInfo.uuid}
@@ -1130,7 +1130,7 @@ export const RateDetails = ({
                                                                 </FormGroup>
                                                             </>
                                                         )}
-                                                        {arr.length > 1 &&
+                                                        {index >= 1 &&
                                                             showMultiRates && (
                                                                 <Button
                                                                     type="button"


### PR DESCRIPTION
## Summary
[MR-2231](https://qmacbis.atlassian.net/browse/MR-2231)
First rate-certification in multi-rate submission on Rate Details page should not be removable.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
