### PR TITLE
Fix system error when adding additional rate when existing rates have incompletion errors.

### DIFF
--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -1175,6 +1175,18 @@ export const RateDetails = ({
                                                         const newRate =
                                                             rateInfoFormValues()
                                                         push(newRate)
+                                                        setFileItemsMatrix(
+                                                            (fileMatrix) => {
+                                                                const newMatrix =
+                                                                    [
+                                                                        ...fileMatrix,
+                                                                    ]
+                                                                newMatrix.push(
+                                                                    []
+                                                                )
+                                                                return newMatrix
+                                                            }
+                                                        )
                                                         setFocusNewRate(true)
                                                     }}
                                                     ref={newRateButtonRef}

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -574,16 +574,16 @@ export const RateDetails = ({
                                                                         (
                                                                             fileMatrix
                                                                         ) => {
-                                                                            const newFiles =
+                                                                            const newMatrix =
                                                                                 [
                                                                                     ...fileMatrix,
                                                                                 ]
-                                                                            newFiles.splice(
+                                                                            newMatrix.splice(
                                                                                 index,
                                                                                 1,
                                                                                 fileItems
                                                                             )
-                                                                            return newFiles
+                                                                            return newMatrix
                                                                         }
                                                                     )
                                                                 }


### PR DESCRIPTION
## Summary
[MR-2231](https://qmacbis.atlassian.net/browse/MR-2231?focusedCommentId=114581)

The new array is added when `FileUpload` component calls `onFileItemsUpdate` to update `fileItemsMatrix` with the files for the specific rate certification. `getDocumentsError` ran before a new array was added into `fileItemsMatrix` state so using any array method caused crashes. 

The fix was to push in new empty array into `fileItemsMatrix` when clicking on `Add another rate certification`. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
