### PR TITLE
Add Serverless Waf Plugin

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -22,6 +22,7 @@ custom:
   applicationEndpoint: ${env:APPLICATION_ENDPOINT, cf:ui-${sls:stage}.CloudFrontEndpointUrl}
   appApiGatewayId: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.ApiGatewayRestApiId}
   appApiGatewayRootResourceId: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.AppApiGatewayRootResourceId}
+  appApiWafAclArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.WafPluginAcl}
   emailerMode: ${env:EMAILER_MODE, ssm:/configuration/emailer_mode}
   parameterStoreMode: ${env:PARAMETER_STORE_MODE, ssm:/configuration/parameterStoreMode}
   auroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:postgres-${sls:stage}.PostgresAuroraArn }
@@ -290,6 +291,13 @@ functions:
           authorizer: aws_iam
 
 resources:
+  Resources:
+    ApiGwWebAclAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      DependsOn: GraphqlLambdaFunction
+      Properties:
+        ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
+        WebACLArn: ${self:custom.appApiWafAclArn}
   Outputs:
     ApiAuthMode:
       Value: ${self:custom.reactAppAuthMode}

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -294,13 +294,7 @@ resources:
   Resources:
     ApiGwWebAclAssociation:
       Type: AWS::WAFv2::WebACLAssociation
-      DependsOn:
-        - GraphqlLambdaFunction
-        - HealthLambdaFunction
-        - HelloLambdaFunction
-        - ReportsLambdaFunction
-        - OtelLambdaFunction
-        - MigrateLambdaFunction
+      DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
       Properties:
         ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
         WebACLArn: ${self:custom.appApiWafAclArn}

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -22,7 +22,7 @@ custom:
   applicationEndpoint: ${env:APPLICATION_ENDPOINT, cf:ui-${sls:stage}.CloudFrontEndpointUrl}
   appApiGatewayId: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.ApiGatewayRestApiId}
   appApiGatewayRootResourceId: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.AppApiGatewayRootResourceId}
-  appApiWafAclArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.WafPluginAcl}
+  appApiWafAclArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:infra-api-${sls:stage}.WafPluginAclArn}
   emailerMode: ${env:EMAILER_MODE, ssm:/configuration/emailer_mode}
   parameterStoreMode: ${env:PARAMETER_STORE_MODE, ssm:/configuration/parameterStoreMode}
   auroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:postgres-${sls:stage}.PostgresAuroraArn }

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -294,7 +294,13 @@ resources:
   Resources:
     ApiGwWebAclAssociation:
       Type: AWS::WAFv2::WebACLAssociation
-      DependsOn: GraphqlLambdaFunction
+      DependsOn:
+        - GraphqlLambdaFunction
+        - HealthLambdaFunction
+        - HelloLambdaFunction
+        - ReportsLambdaFunction
+        - OtelLambdaFunction
+        - MigrateLambdaFunction
       Properties:
         ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
         WebACLArn: ${self:custom.appApiWafAclArn}

--- a/services/infra-api/package.json
+++ b/services/infra-api/package.json
@@ -8,6 +8,7 @@
     "author": "",
     "license": "CC0-1.0",
     "devDependencies": {
+        "@enterprise-cmcs/serverless-waf-plugin": "^1.3.0",
         "serverless": "^3.19.0",
         "serverless-iam-helper": "CMSgov/serverless-iam-helper",
         "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper",

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -261,5 +261,8 @@ resources:
         Fn::GetAtt:
           - AppApiGateway
           - RootResourceId
-    WafPluginAcl:
-      Value: !Ref WafPluginAcl
+    WafPluginAclArn:
+      Value:
+        Fn::GetAtt:
+          - WafPluginAcl
+          - Arn

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -8,6 +8,7 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-s3-bucket-helper
   - serverless-iam-helper
+  - serverless-waf-plugin
 
 custom:
   stage: ${opt:stage, self:provider.stage}
@@ -15,6 +16,7 @@ custom:
   nrMetricStreamName: 'NewRelic-Metric-Stream'
   nrFirehoseStreamName: 'NewRelic-Delivery-Stream'
   nrExternalId: '3407984'
+  webAclName: ${self:custom.stage}-${self:service}-webacl
   serverless-offline-ssm:
     stages:
       - local
@@ -248,16 +250,16 @@ resources:
     #       SampledRequestsEnabled: true
     #       MetricName: ${sls:stage}-webacl
 
-    # ApiGwWebAclAssociation:
-    #   Type: AWS::WAFv2::WebACLAssociation
-    #   DependsOn:
-    #     - AppApiGateway
-    #     - AppApiGatewayAcl
-    #   Properties:
-    #     ResourceArn: !Sub
-    #       - arn:aws:apigateway:${self:provider.region}::/restapis/${GatewayRef}/stages/${sls:stage}
-    #       - { GatewayRef: !Ref AppApiGateway }
-    #     WebACLArn: !GetAtt AppApiGatewayAcl.Arn
+    ApiGwWebAclAssociation:
+      Type: AWS::WAFv2::WebACLAssociation
+      DependsOn:
+        - AppApiGateway
+        - AppApiGatewayAcl
+      Properties:
+        ResourceArn: !Sub
+          - arn:aws:apigateway:${self:provider.region}::/restapis/${GatewayRef}/stages/${sls:stage}
+          - { GatewayRef: !Ref AppApiGateway }
+        WebACLArn: !GetAtt WafPluginAcl.Arn
 
   Outputs:
     ApiGatewayRestApiId:

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -8,7 +8,7 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-s3-bucket-helper
   - serverless-iam-helper
-  - serverless-waf-plugin
+  - '@enterprise-cmcs/serverless-waf-plugin'
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -250,17 +250,6 @@ resources:
     #       SampledRequestsEnabled: true
     #       MetricName: ${sls:stage}-webacl
 
-    ApiGwWebAclAssociation:
-      Type: AWS::WAFv2::WebACLAssociation
-      DependsOn:
-        - AppApiGateway
-        - AppApiGatewayAcl
-      Properties:
-        ResourceArn: !Sub
-          - arn:aws:apigateway:${self:provider.region}::/restapis/${GatewayRef}/stages/${sls:stage}
-          - { GatewayRef: !Ref AppApiGateway }
-        WebACLArn: !GetAtt WafPluginAcl.Arn
-
   Outputs:
     ApiGatewayRestApiId:
       Value:
@@ -272,3 +261,5 @@ resources:
         Fn::GetAtt:
           - AppApiGateway
           - RootResourceId
+    WafPluginAcl:
+      Value: !Ref WafPluginAcl

--- a/yarn.lock
+++ b/yarn.lock
@@ -4522,6 +4522,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
+"@enterprise-cmcs/serverless-waf-plugin@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@enterprise-cmcs/serverless-waf-plugin/-/serverless-waf-plugin-1.3.0.tgz#b2f241f68218b94b62987596888730975c99b019"
+  integrity sha512-Xysp8ejNhkrxCMQ4CximHmphKO1vGt3JGKKzGs0tLX1r4yK8BdobmauX/GmDwAfrzqlHVGDRsdvvY1Grv1W0yw==
+
 "@eslint/eslintrc@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.2.tgz#58b69582f3b7271d8fa67fe5251767a5b38ea356"


### PR DESCRIPTION
## Summary

This adds the serverless waf setup that the macpro-quickstart team asked us to add. We are not using the external plugin that does the [auto association](https://github.com/MikeSouza/serverless-associate-waf), which is how CMS was suggesting we implement this, as that would require us to change our API Gateway names (they are not customizable in the plugin). Instead, we're using a regular CF associate stanza in `app-api`.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2593
