### PR TITLE
Remove enable-health-endpoint and app-api-graphql-errors from codebase

### DIFF
--- a/services/app-api/src/handlers/health_check.ts
+++ b/services/app-api/src/handlers/health_check.ts
@@ -1,5 +1,4 @@
 import { APIGatewayProxyHandler } from 'aws-lambda'
-import LaunchDarkly from 'launchdarkly-node-server-sdk'
 
 const ldClientKey = process.env.LD_SDK_KEY ?? ''
 if (ldClientKey === '') {
@@ -7,45 +6,13 @@ if (ldClientKey === '') {
 }
 
 export const main: APIGatewayProxyHandler = async () => {
-    const ldClient = LaunchDarkly.init(ldClientKey)
-    try {
-        await ldClient.waitForInitialization()
-    } catch (err) {
-        return {
-            statusCode: 500,
-            body: JSON.stringify({
-                code: 'LD_SDK_INIT_FAILED',
-                message: err.message,
-            }),
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Credentials': true,
-            },
-        }
-    }
-
     // returns stage and version
     const health = {
         stage: process.env.stage,
         version: process.env.appVersion,
-        ld: '',
     }
 
     console.log({ name: 'healthcheck' }) // eslint-disable-line no-console
-
-    const changeHealthResponse = await ldClient.variation(
-        'enable-health-endpoint',
-        { key: 'mc-review-team@truss.works' },
-        false
-    )
-
-    if (changeHealthResponse) {
-        health.ld = 'enabled'
-    } else {
-        health.ld = 'disabled'
-    }
-
-    ldClient.close()
 
     return {
         statusCode: 200,

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -15,13 +15,6 @@ export const featureFlags = {
         defaultValue: false,
     },
     /**
-     Toggles the /health api endpoint
-    */
-    API_ENABLE_HEALTH_ENDPOINT: {
-        flag: 'enable-health-endpoint',
-        defaultValue: true,
-    },
-    /**
      Enables the modal that alerts the user to an expiring session
     */
     SESSION_EXPIRING_MODAL: {
@@ -41,13 +34,6 @@ export const featureFlags = {
     MODAL_COUNTDOWN_DURATION: {
         flag: 'modal-countdown-duration',
         defaultValue: 2,
-    },
-    /**
-     * Graphql resolver returns 500 errors. Used for testing alerting in OTEL/New Relic
-     */
-    API_GRAPHQL_ERRORS: {
-        flag: 'app-api-graphql-errors',
-        defaultValue: false,
     },
     /**
      * Enables multi-rate submission UI


### PR DESCRIPTION
## Summary
Remove two flags from codebase that are no longer used. `app-api-graphql-errors` had no remaining code references so its just a constant change for that flag. 

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2630
 