### PR TITLE
Add additional IAM properties to cleanup task

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -118,6 +118,8 @@ provider:
             - rds:CreateDBSnapshot
             - rds:CopyDBClusterSnapshot
             - rds:CopyDBSnapshot
+            - rds:DescribeDBClusterSnapshots
+            - rds:DeleteDBClusterSnapshot
           Resource: '*'
 
   environment:


### PR DESCRIPTION
## Summary

There are a couple IAM permissions that need to be added to our lambda in order for RDS snapshot deletion to occur. This adds the attributes.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2589
