### PR TITLE
Move all actions/setup-node to v3

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -9,7 +9,7 @@ runs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/setup-node@v2.5.0
+    - uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
         cache: 'yarn'


### PR DESCRIPTION
## Summary
Cleanup task after seeing warning in Github about using outdated Node versions in CI. Bring setup_env workflow setup-node  action to current major version - v3 This matches deploy and promote workflows.