### PR TITLE
Remove excessive console logs

### DIFF
--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toLatestVersion.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toLatestVersion.ts
@@ -55,9 +55,9 @@ const toLatestProtoVersion = (proto: mcreviewproto.HealthPlanFormData) => {
         return proto
     } else {
         // if the proto is an outdated version convert it to the latest
-        console.log(
-            `Trying to open outdated proto. State: ${proto.stateCode}, Package ID: ${proto.id}, Outdated proto version: ${protoVersion}`
-        )
+        // console.log(
+        //     `Trying to open outdated proto. State: ${proto.stateCode}, Package ID: ${proto.id}, Outdated proto version: ${protoVersion}`
+        // )
 
         const v3Compatible = updateToVersion3(proto)
 


### PR DESCRIPTION
## Summary
Comment out the console log here. I do think it would be nice to have OTEL know when an old proto is opened (if we had to debug unexpected behavior with toLatestVersion) but not sure right now where that should connect into the active spans. 

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2761
