### PR TITLE
Replace cypress debugger with console.trace in uncaughtException helper

### DIFF
--- a/tests/cypress/support/e2e.ts
+++ b/tests/cypress/support/e2e.ts
@@ -2,6 +2,6 @@ Cypress.on('uncaught:exception', (err, runnable) => {
     // returning false here prevents Cypress from
     // failing the test
     console.error(err)
-     debugger
+    console.trace()
     return false
 })


### PR DESCRIPTION
## Summary
Follow up from eng sync. Use console trace to have a better chance of actually returning a useful stack trace here. Cypress debugger is more used for debugging cypress but we know we have JS issues if we land in this helper. 