### PR TITLE
Add error handling if LD provider fails

### DIFF
--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -134,7 +134,7 @@ if (ldClientId === undefined) {
     )
 })().catch((e) => {
     recordJSException(
-        'LDProvider failed, could not initialized application' + e
+        'LDProvider failed, could not initialize the application' + e
     )
     throw new Error('Could not initialize the application: ' + e)
 })

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -12,6 +12,7 @@ import { localGQLFetch, fakeAmplifyFetch } from './api'
 import { assertIsAuthMode } from './common-code/config'
 import { S3ClientT, newAmplifyS3Client, newLocalS3Client } from './s3'
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
+import { recordJSException } from './otelHelpers'
 
 const gqlSchema = loader('../../app-web/src/gen/schema.graphql')
 
@@ -132,6 +133,9 @@ if (ldClientId === undefined) {
         </React.StrictMode>
     )
 })().catch((e) => {
+    recordJSException(
+        'LDProvider failed, could not initialized application' + e
+    )
     throw new Error('Could not initialize the application: ' + e)
 })
 


### PR DESCRIPTION
## Summary
This is coming out of today's pairing session around Cypress. We should be logging any error that would crash the app even if its unlikely to happen 🌟 