### PR TITLE
[MD-2685] Add label and link to related submissions PackageSelect on Rate Details page 

### DIFF
--- a/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
+++ b/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
@@ -12,7 +12,7 @@ export type PackageSelectPropType = {
     error?: boolean
 }
 
-type PackageOptionType = {
+export type PackageOptionType = {
     readonly label: string
     readonly value: string
     readonly isFixed?: boolean

--- a/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.tsx
+++ b/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.tsx
@@ -9,7 +9,7 @@ export type ProgramSelectPropType = {
     programIDs: string[]
 }
 
-interface ProgramOption {
+export interface ProgramOptionType {
     readonly value: string
     readonly label: string
     readonly isFixed?: boolean
@@ -21,12 +21,12 @@ export const ProgramSelect = ({
     statePrograms,
     programIDs,
     ...selectProps
-}: ProgramSelectPropType & Props<ProgramOption, true>) => {
-    const programOptions: ProgramOption[] = statePrograms.map((program) => {
+}: ProgramSelectPropType & Props<ProgramOptionType, true>) => {
+    const programOptions: ProgramOptionType[] = statePrograms.map((program) => {
         return { value: program.id, label: program.name }
     })
 
-    const onFocus: AriaOnFocus<ProgramOption> = ({
+    const onFocus: AriaOnFocus<ProgramOptionType> = ({
         focused,
         isDisabled,
     }): string => {

--- a/services/app-web/src/components/Select/index.ts
+++ b/services/app-web/src/components/Select/index.ts
@@ -3,3 +3,5 @@ export { PackageSelect } from './PackageSelect/PackageSelect'
 
 export type { ProgramSelectPropType } from './ProgramSelect/ProgramSelect'
 export type { PackageSelectPropType } from './PackageSelect/PackageSelect'
+export type { ProgramOptionType } from './ProgramSelect/ProgramSelect'
+export type { PackageOptionType } from './PackageSelect/PackageSelect'

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -1204,7 +1204,17 @@ describe('RateDetails', () => {
             )
             expect(firstRateCertSharedCheckBox).toBeChecked()
             expect(firstRateCert.getAllByRole('combobox')).toHaveLength(2)
+            expect(
+                firstRateCert.getByText(
+                    /Please select the submissions that also contain this rate/
+                )
+            ).toBeInTheDocument()
             expect(secondRateCertSharedCheckBox).not.toBeChecked()
+            expect(
+                secondRateCert.queryByText(
+                    /Please select the submissions that also contain this rate/
+                )
+            ).toBeNull()
             expect(secondRateCert.getAllByRole('combobox')).toHaveLength(1)
 
             //Both rate cert check boxes are unchecked and only programs combobox present

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -36,6 +36,7 @@ import {
     ProgramSelect,
     PackageSelect,
 } from '../../../components'
+import type { PackageOptionType } from '../../../components/Select'
 import {
     formatForForm,
     isDateRangeEmpty,
@@ -101,13 +102,6 @@ export interface RateInfoFormType {
 
 type FormError =
     FormikErrors<RateInfoFormType>[keyof FormikErrors<RateInfoFormType>]
-
-type PackageOptionType = {
-    readonly label: string
-    readonly value: string
-    readonly isFixed?: boolean
-    readonly isDisabled?: boolean
-}
 
 export const rateErrorHandling = (
     error: string | FormikErrors<RateInfoFormType> | undefined
@@ -732,100 +726,127 @@ export const RateDetails = ({
                                                             />
                                                         </FormGroup>
                                                         {showRatesAcrossSubs && (
-                                                            <FormGroup>
-                                                                <Checkbox
-                                                                    id={`hasSharedRateCheckBox-${rateInfo.key}`}
-                                                                    name={`rateInfos.${index}.hasSharedRateCert`}
-                                                                    label="This rate certification was uploaded to another submission."
-                                                                    aria-required={
-                                                                        false
-                                                                    }
-                                                                    checked={
-                                                                        rateInfo.hasSharedRateCert
-                                                                    }
-                                                                    onChange={(
-                                                                        e
-                                                                    ) =>
-                                                                        setFieldValue(
-                                                                            e
-                                                                                .target
-                                                                                .name,
-                                                                            !rateInfo.hasSharedRateCert
-                                                                        )
-                                                                    }
-                                                                />
-                                                            </FormGroup>
-                                                        )}
-                                                        {showRatesAcrossSubs &&
-                                                            rateInfo.hasSharedRateCert && (
-                                                                <FormGroup
-                                                                    error={showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.packagesWithSharedRateCerts
-                                                                    )}
-                                                                >
-                                                                    {showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.packagesWithSharedRateCerts
-                                                                    ) && (
-                                                                        <PoliteErrorMessage>
-                                                                            {getIn(
-                                                                                errors,
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`
-                                                                            )}
-                                                                        </PoliteErrorMessage>
-                                                                    )}
-                                                                    <PackageSelect
-                                                                        //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
-                                                                        // causes issues with the default value when reloading the page
-                                                                        key={`${packageOptions}-${rateInfo.key}`}
-                                                                        inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        name={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        statePrograms={
-                                                                            statePrograms
+                                                            <Fieldset>
+                                                                <FormGroup>
+                                                                    <Checkbox
+                                                                        id={`hasSharedRateCheckBox-${rateInfo.key}`}
+                                                                        name={`rateInfos.${index}.hasSharedRateCert`}
+                                                                        label="This rate certification was uploaded to another submission."
+                                                                        aria-required={
+                                                                            false
                                                                         }
-                                                                        initialValues={
-                                                                            rateInfo?.packagesWithSharedRateCerts
-                                                                        }
-                                                                        packageOptions={
-                                                                            packageOptions
-                                                                        }
-                                                                        draftSubmissionId={
-                                                                            draftSubmission.id
-                                                                        }
-                                                                        isLoading={
-                                                                            loading
-                                                                        }
-                                                                        error={
-                                                                            error instanceof
-                                                                            Error
+                                                                        checked={
+                                                                            rateInfo.hasSharedRateCert
                                                                         }
                                                                         onChange={(
-                                                                            selectedOption
+                                                                            e
                                                                         ) =>
                                                                             setFieldValue(
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`,
-                                                                                selectedOption.map(
-                                                                                    (item: {
-                                                                                        value: string
-                                                                                    }) =>
-                                                                                        item.value
-                                                                                )
+                                                                                e
+                                                                                    .target
+                                                                                    .name,
+                                                                                !rateInfo.hasSharedRateCert
                                                                             )
                                                                         }
                                                                     />
                                                                 </FormGroup>
-                                                            )}
+                                                                {rateInfo.hasSharedRateCert && (
+                                                                    <FormGroup
+                                                                        error={showFieldErrors(
+                                                                            rateErrorHandling(
+                                                                                errors
+                                                                                    ?.rateInfos?.[
+                                                                                    index
+                                                                                ]
+                                                                            )
+                                                                                ?.packagesWithSharedRateCerts
+                                                                        )}
+                                                                    >
+                                                                        <Label
+                                                                            htmlFor={`rateInfos.${index}.rateProgramIDs`}
+                                                                        >
+                                                                            Please
+                                                                            select
+                                                                            the
+                                                                            submissions
+                                                                            that
+                                                                            also
+                                                                            contain
+                                                                            this
+                                                                            rate
+                                                                            certification.
+                                                                        </Label>
+                                                                        <Link
+                                                                            aria-label="View all submissions (opens in new window)"
+                                                                            href={
+                                                                                '/dashboard'
+                                                                            }
+                                                                            variant="external"
+                                                                            target="_blank"
+                                                                        >
+                                                                            View
+                                                                            all
+                                                                            submissions
+                                                                        </Link>
+                                                                        {showFieldErrors(
+                                                                            rateErrorHandling(
+                                                                                errors
+                                                                                    ?.rateInfos?.[
+                                                                                    index
+                                                                                ]
+                                                                            )
+                                                                                ?.packagesWithSharedRateCerts
+                                                                        ) && (
+                                                                            <PoliteErrorMessage>
+                                                                                {getIn(
+                                                                                    errors,
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`
+                                                                                )}
+                                                                            </PoliteErrorMessage>
+                                                                        )}
+                                                                        <PackageSelect
+                                                                            //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
+                                                                            // causes issues with the default value when reloading the page
+                                                                            key={`${packageOptions}-${rateInfo.key}`}
+                                                                            inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            name={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            statePrograms={
+                                                                                statePrograms
+                                                                            }
+                                                                            initialValues={
+                                                                                rateInfo?.packagesWithSharedRateCerts
+                                                                            }
+                                                                            packageOptions={
+                                                                                packageOptions
+                                                                            }
+                                                                            draftSubmissionId={
+                                                                                draftSubmission.id
+                                                                            }
+                                                                            isLoading={
+                                                                                loading
+                                                                            }
+                                                                            error={
+                                                                                error instanceof
+                                                                                Error
+                                                                            }
+                                                                            onChange={(
+                                                                                selectedOptions
+                                                                            ) =>
+                                                                                setFieldValue(
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`,
+                                                                                    selectedOptions.map(
+                                                                                        (item: {
+                                                                                            value: string
+                                                                                        }) =>
+                                                                                            item.value
+                                                                                    )
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    </FormGroup>
+                                                                )}
+                                                            </Fieldset>
+                                                        )}
                                                         <FormGroup
                                                             error={showFieldErrors(
                                                                 rateErrorHandling(
@@ -880,11 +901,11 @@ export const RateDetails = ({
                                                                         }
                                                                         aria-label="programs (required)"
                                                                         onChange={(
-                                                                            selectedOption
+                                                                            selectedOptions
                                                                         ) =>
                                                                             form.setFieldValue(
                                                                                 `rateInfos.${index}.rateProgramIDs`,
-                                                                                selectedOption.map(
+                                                                                selectedOptions.map(
                                                                                     (item: {
                                                                                         value: string
                                                                                     }) =>
@@ -930,7 +951,7 @@ export const RateDetails = ({
                                                                     </PoliteErrorMessage>
                                                                 )}
                                                                 <Link
-                                                                    aria-label="Rate certification type defintions (opens in new window)"
+                                                                    aria-label="Rate certification type definitions (opens in new window)"
                                                                     href={
                                                                         '/help#rate-cert-type-definitions'
                                                                     }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -726,42 +726,41 @@ export const RateDetails = ({
                                                             />
                                                         </FormGroup>
                                                         {showRatesAcrossSubs && (
-                                                            <Fieldset>
-                                                                <FormGroup>
-                                                                    <Checkbox
-                                                                        id={`hasSharedRateCheckBox-${rateInfo.key}`}
-                                                                        name={`rateInfos.${index}.hasSharedRateCert`}
-                                                                        label="This rate certification was uploaded to another submission."
-                                                                        aria-required={
-                                                                            false
-                                                                        }
-                                                                        checked={
-                                                                            rateInfo.hasSharedRateCert
-                                                                        }
-                                                                        onChange={(
+                                                            <FormGroup
+                                                                error={showFieldErrors(
+                                                                    rateErrorHandling(
+                                                                        errors
+                                                                            ?.rateInfos?.[
+                                                                            index
+                                                                        ]
+                                                                    )
+                                                                        ?.packagesWithSharedRateCerts
+                                                                )}
+                                                            >
+                                                                <Checkbox
+                                                                    id={`hasSharedRateCheckBox-${rateInfo.key}`}
+                                                                    name={`rateInfos.${index}.hasSharedRateCert`}
+                                                                    label="This rate certification was uploaded to another submission."
+                                                                    aria-required={
+                                                                        false
+                                                                    }
+                                                                    checked={
+                                                                        rateInfo.hasSharedRateCert
+                                                                    }
+                                                                    onChange={(
+                                                                        e
+                                                                    ) =>
+                                                                        setFieldValue(
                                                                             e
-                                                                        ) =>
-                                                                            setFieldValue(
-                                                                                e
-                                                                                    .target
-                                                                                    .name,
-                                                                                !rateInfo.hasSharedRateCert
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                </FormGroup>
+                                                                                .target
+                                                                                .name,
+                                                                            !rateInfo.hasSharedRateCert
+                                                                        )
+                                                                    }
+                                                                />
+
                                                                 {rateInfo.hasSharedRateCert && (
-                                                                    <FormGroup
-                                                                        error={showFieldErrors(
-                                                                            rateErrorHandling(
-                                                                                errors
-                                                                                    ?.rateInfos?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.packagesWithSharedRateCerts
-                                                                        )}
-                                                                    >
+                                                                    <>
                                                                         <Label
                                                                             htmlFor={`rateInfos.${index}.rateProgramIDs`}
                                                                         >
@@ -843,9 +842,9 @@ export const RateDetails = ({
                                                                                 )
                                                                             }
                                                                         />
-                                                                    </FormGroup>
+                                                                    </>
                                                                 )}
-                                                            </Fieldset>
+                                                            </FormGroup>
                                                         )}
                                                         <FormGroup
                                                             error={showFieldErrors(


### PR DESCRIPTION
## Summary
 - Add label and  "View all submissions" link to the PackageSelect'
 - Wrap the related fields in same Form Group - so error styles show for the entire block
- Export types for select options

#### Related issues
Add on to #1332 
https://qmacbis.atlassian.net/browse/MR-2685

### Screenshots
Here's how error styling will look now that both related fields are in same parent element. 
![Screen Shot 2022-11-21 at 10 55 24 AM](https://user-images.githubusercontent.com/10750442/203114154-eb864a8a-3751-4462-9705-2b7ef598eac5.png)

