### PR TITLE
Adjust promote, deploy workflows for Cypress flakes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -326,6 +326,28 @@ jobs:
           state: 'success'
           deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}
 
+  cypress-install:
+    name: cypress-install
+    needs: [deploy-app, finishing-prep]
+    if: always() && needs.finishing-prep.result == 'success'
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node14.17.0-chrome91-ff89
+    permissions:
+      deployments: write
+    steps:
+      - name: Cypress install
+        id: cypress
+        uses: cypress-io/github-action@4.2.0 #use the explicit version
+        with: 
+          runTests: false
+
+      - name: Save build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          if-no-files-found: error
+          path: build
+
   cypress:
     name: cypress-run
     needs: [deploy-app, finishing-prep]
@@ -340,13 +362,22 @@ jobs:
         # run copies of the current job in parallel
         containers: [1, 2, 3, 4, 5, 6]
     steps:
-      - uses: actions/checkout@v3
-
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Download the build folders
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: build
+            
       - name: Cypress -- Chrome
         id: cypress
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@4.2.0 #use explicit version
         with:
+          install: false
           config: baseUrl=${{ needs.finishing-prep.outputs.application-endpoint }}
+          wait-on-timeout: 120
           record: true
           parallel: true
           browser: chrome

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -326,28 +326,6 @@ jobs:
           state: 'success'
           deployment-id: ${{ needs.begin-deployment.outputs.deploy-id }}
 
-  cypress-install:
-    name: cypress-install
-    needs: [deploy-app, finishing-prep]
-    if: always() && needs.finishing-prep.result == 'success'
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
-    permissions:
-      deployments: write
-    steps:
-      - name: Cypress install
-        id: cypress
-        uses: cypress-io/github-action@4.2.0 # use the explicit version
-        with: 
-          runTests: false
-
-      - name: Save build folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          if-no-files-found: error
-          path: build
-
   cypress:
     name: cypress-run
     needs: [deploy-app, finishing-prep]
@@ -362,22 +340,13 @@ jobs:
         # run copies of the current job in parallel
         containers: [1, 2, 3, 4, 5, 6]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      
-      - name: Download the build folders
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: build
-            
+      - uses: actions/checkout@v3
+
       - name: Cypress -- Chrome
         id: cypress
-        uses: cypress-io/github-action@4.2.0 # use explicit version
+        uses: cypress-io/github-action@v4
         with:
-          install: false # we already installed in previous version
           config: baseUrl=${{ needs.finishing-prep.outputs.application-endpoint }}
-          wait-on-timeout: 120
           record: true
           parallel: true
           browser: chrome

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,7 +337,7 @@ jobs:
     steps:
       - name: Cypress install
         id: cypress
-        uses: cypress-io/github-action@4.2.0 #use the explicit version
+        uses: cypress-io/github-action@4.2.0 # use the explicit version
         with: 
           runTests: false
 
@@ -373,9 +373,9 @@ jobs:
             
       - name: Cypress -- Chrome
         id: cypress
-        uses: cypress-io/github-action@4.2.0 #use explicit version
+        uses: cypress-io/github-action@4.2.0 # use explicit version
         with:
-          install: false
+          install: false # we already installed in previous version
           config: baseUrl=${{ needs.finishing-prep.outputs.application-endpoint }}
           wait-on-timeout: 120
           record: true

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Cypress on Dev -- Chrome
         id: cypressdev
-        uses: cypress-io/github-action@v4.2.0
+        uses: cypress-io/github-action@v4
         with:
           install: false
           config: baseUrl=https://mc-review-dev.onemac.cms.gov

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -213,9 +213,7 @@ jobs:
     container: cypress/browsers:node14.17.0-chrome91-ff89
     strategy:
       fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+  
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -160,13 +160,13 @@ jobs:
 
       - name: Cypress on Dev -- Chrome
         id: cypressdev
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v4.2.0
         with:
           install: false
           config: baseUrl=https://mc-review-dev.onemac.cms.gov
           spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
           record: true
-          parallel: true
+          parallel: false,
           browser: chrome
           group: 'Chrome'
         env:
@@ -230,7 +230,7 @@ jobs:
           config: baseUrl=https://mc-review-val.onemac.cms.gov
           spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
           record: true
-          parallel: true
+          parallel: false
           browser: chrome
           group: 'Chrome'
         env:
@@ -294,7 +294,7 @@ jobs:
           config: baseUrl=https://mc-review.onemac.cms.gov
           spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
           record: true
-          parallel: true
+          parallel: false
           browser: chrome
           group: 'Chrome'
         env:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -149,9 +149,7 @@ jobs:
     container: cypress/browsers:node14.17.0-chrome91-ff89
     strategy:
       fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+
     steps:
       - uses: actions/checkout@v3
 
@@ -275,9 +273,7 @@ jobs:
     container: cypress/browsers:node14.17.0-chrome91-ff89
     strategy:
       fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers: [1, 2, 3, 4]
+   
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Summary
- Run promote in single thread
- Adjust deploy workflow to follow [docs](https://docs.cypress.io/guides/continuous-integration/github-actions#Using-Cypress-Cloud-with-GitHub-Actions) more closely  (seperate install step, share that build with parallelized tests) 

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2789 