### PR TITLE
[MR-2587] Only return 5 packages in dropdown list. Also add re-useable utilities.

### DIFF
--- a/services/app-graphql/src/queries/fetchHealthPlanPackage.graphql
+++ b/services/app-graphql/src/queries/fetchHealthPlanPackage.graphql
@@ -17,6 +17,7 @@ query fetchHealthPlanPackage($input: FetchHealthPlanPackageInput!) {
             revisions {
                 node {
                     id
+                    createdAt
                     unlockInfo {
                         updatedAt
                         updatedBy
@@ -27,7 +28,6 @@ query fetchHealthPlanPackage($input: FetchHealthPlanPackageInput!) {
                         updatedBy
                         updatedReason
                     }
-                    createdAt
                     formDataProto
                 }
             }

--- a/services/app-graphql/src/queries/indexHealthPlanPackages.graphql
+++ b/services/app-graphql/src/queries/indexHealthPlanPackages.graphql
@@ -22,9 +22,13 @@ query indexHealthPlanPackages {
                         createdAt
                         unlockInfo {
                             updatedAt
+                            updatedBy
+                            updatedReason
                         }
                         submitInfo {
                             updatedAt
+                            updatedBy
+                            updatedReason
                         }
                         formDataProto
                     }


### PR DESCRIPTION
## Summary

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2687

#### Test cases covered

I did not add tests for this specifically and relied on existing test.

 This could be a Cypress assertion (check in E2E tests when many submissions are present that only 5 are displayed in dropdown) but considering what is also going on cypress decided to let things be. 

## QA guidance
- Check that we only display contract and rate submission and of these 5 appear in list 
