### PR TITLE
Address bug with promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -164,7 +164,7 @@ jobs:
           config: baseUrl=https://mc-review-dev.onemac.cms.gov
           spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
           record: true
-          parallel: false,
+          parallel: false
           browser: chrome
           group: 'Chrome - dev'
           ci-build-id: 'dev'

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -166,7 +166,7 @@ jobs:
           record: true
           parallel: false,
           browser: chrome
-          group: 'Chrome'
+          group: 'Chrome - dev'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -228,7 +228,7 @@ jobs:
           record: true
           parallel: false
           browser: chrome
-          group: 'Chrome'
+          group: 'Chrome - val'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -290,7 +290,7 @@ jobs:
           record: true
           parallel: false
           browser: chrome
-          group: 'Chrome'
+          group: 'Chrome - prod'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -167,6 +167,7 @@ jobs:
           parallel: false,
           browser: chrome
           group: 'Chrome - dev'
+          ci-build-id: 'dev'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -229,6 +230,7 @@ jobs:
           parallel: false
           browser: chrome
           group: 'Chrome - val'
+          ci-build-id: 'val'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -291,6 +293,7 @@ jobs:
           parallel: false
           browser: chrome
           group: 'Chrome - prod'
+          ci-build-id: 'prod'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
## Summary
Trying to address this [issue](https://docs.cypress.io/guides/references/error-messages#Run-is-not-accepting-any-new-groups) which cropped up when we removed parallelization on promote runs. This is currently blocking deploy to prod. 
