### PR TITLE
Remove Cypress checks for dev/val on promote to prod workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -142,49 +142,8 @@ jobs:
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
-<<<<<<< Updated upstream
-  dev-cypress:
-    name: dev - cypress
-    needs: [promote-app-dev]
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup env
-        uses: ./.github/actions/setup_env
-
-      - name: Cypress on Dev -- Chrome
-        id: cypressdev
-        uses: cypress-io/github-action@v4
-        with:
-          install: false
-          config: baseUrl=https://mc-review-dev.onemac.cms.gov
-          spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
-          record: true
-          parallel: false
-          browser: chrome
-          group: 'Chrome - dev'
-          ci-build-id: 'dev'
-        env:
-          REACT_APP_AUTH_MODE: IDM
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload cypress video
-        uses: actions/upload-artifact@v3
-        if: failure() && steps.cypressdev.outcome == 'failure'
-        with:
-          name: cypress-videos
-          path: tests/cypress/videos
-
-=======
->>>>>>> Stashed changes
   promote-infra-val:
-    needs: [ promote-app-dev, unit-tests]
+    needs: [promote-app-dev, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       stage_name: val
@@ -195,7 +154,7 @@ jobs:
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   promote-app-val:
-    needs: [ promote-app-dev, promote-infra-val, unit-tests]
+    needs: [promote-app-dev, promote-infra-val, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: val
@@ -208,47 +167,6 @@ jobs:
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
-<<<<<<< Updated upstream
-  cypress-val:
-    name: val - cypress
-    needs: [promote-app-val]
-    runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome91-ff89
-    strategy:
-      fail-fast: false
-  
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup env
-        uses: ./.github/actions/setup_env
-
-      - name: Cypress on Val -- Chrome
-        id: cypressval
-        uses: cypress-io/github-action@v4
-        with:
-          install: false
-          config: baseUrl=https://mc-review-val.onemac.cms.gov
-          spec: tests/cypress/integration/promoteWorkflow/promote.spec.ts
-          record: true
-          parallel: false
-          browser: chrome
-          group: 'Chrome - val'
-          ci-build-id: 'val'
-        env:
-          REACT_APP_AUTH_MODE: IDM
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload cypress video
-        uses: actions/upload-artifact@v3
-        if: failure() && steps.cypressval.outcome == 'failure'
-        with:
-          name: cypress-videos
-          path: tests/cypress/videos
-
-=======
->>>>>>> Stashed changes
   promote-infra-prod:
     needs: [promote-app-val, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
@@ -299,7 +217,7 @@ jobs:
           parallel: false
           browser: chrome
           group: 'Chrome - prod'
-          ci-build-id: 'prod'
+          ci-build-id: 'cypress-prod'
         env:
           REACT_APP_AUTH_MODE: IDM
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -142,6 +142,7 @@ jobs:
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
+<<<<<<< Updated upstream
   dev-cypress:
     name: dev - cypress
     needs: [promote-app-dev]
@@ -180,8 +181,10 @@ jobs:
           name: cypress-videos
           path: tests/cypress/videos
 
+=======
+>>>>>>> Stashed changes
   promote-infra-val:
-    needs: [dev-cypress, unit-tests]
+    needs: [ promote-app-dev, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       stage_name: val
@@ -192,7 +195,7 @@ jobs:
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   promote-app-val:
-    needs: [dev-cypress, promote-infra-val, unit-tests]
+    needs: [ promote-app-dev, promote-infra-val, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: val
@@ -205,6 +208,7 @@ jobs:
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
+<<<<<<< Updated upstream
   cypress-val:
     name: val - cypress
     needs: [promote-app-val]
@@ -243,8 +247,10 @@ jobs:
           name: cypress-videos
           path: tests/cypress/videos
 
+=======
+>>>>>>> Stashed changes
   promote-infra-prod:
-    needs: [cypress-val, unit-tests]
+    needs: [promote-app-val, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       stage_name: prod
@@ -255,7 +261,7 @@ jobs:
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   promote-app-prod:
-    needs: [cypress-val, promote-infra-prod, unit-tests]
+    needs: [promote-app-val, promote-infra-prod, unit-tests]
     uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       stage_name: prod
@@ -309,7 +315,7 @@ jobs:
   slack:
     name: Slack notification on failure
     runs-on: ubuntu-latest
-    needs: [cypress-prod, cypress-val]
+    needs: [cypress-prod, promote-app-val]
     if: always()
     steps:
       # this action sets env.WORKFLOW_CONCLUSION so we can call a
@@ -318,7 +324,7 @@ jobs:
 
       - name: Alert Slack On Failure
         uses: rtCamp/action-slack-notify@v2
-        if: (env.WORKFLOW_CONCLUSION == 'failure' || needs.cypress-prod.result == 'skipped' || needs.cypress-val.result == 'skipped')
+        if: (env.WORKFLOW_CONCLUSION == 'failure' || needs.cypress-prod.result == 'skipped' || needs.promote-app-val.result == 'skipped')
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: Deploy Alerts


### PR DESCRIPTION
## Summary
This came out of today's engineering sync - I took the AI to further simplifying our promote workflow and chance of flakes by removing Cypress from steps. 

Welcome reviews or adjustments to the PR, not sure how I feel about skipping val when I see it in code. Maybe we just skip dev. 

#### Related issues
Follow on to #1337 and #1341 after more discussion
