### PR TITLE
Rates across submissions (issue numbers in description)

### DIFF
--- a/services/app-proto/src/health_plan_form_data.proto
+++ b/services/app-proto/src/health_plan_form_data.proto
@@ -165,7 +165,10 @@ enum ManagedCareEntity {
   MANAGED_CARE_ENTITY_PCCM = 4;
 }
 
-
+message SharedRateCertDisplay {
+  string package_id = 1;
+  string package_name = 2;
+}
 
 
 /// Rate Info subtypes
@@ -181,7 +184,7 @@ message RateInfo {
   optional RateCapitationType rate_capitation_type = 9;
   repeated string rate_program_ids = 10;
   optional string rate_certification_name = 11;
-  repeated string packages_with_shared_rate_certs = 12;
+  repeated SharedRateCertDisplay packages_with_shared_rate_certs = 12;
 
   optional RateAmendmentInfo rate_amendment_info = 50;
 

--- a/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
+++ b/services/app-web/src/common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType.d.ts
@@ -60,6 +60,11 @@ type ActuaryContact = {
     actuarialFirmOther?: string
 }
 
+type SharedRateCertDisplay = {
+    packageId?: string
+    packageName?: string
+}
+
 type RateType = 'NEW' | 'AMENDMENT'
 
 type RateCapitationType = 'RATE_CELL' | 'RATE_RANGE'
@@ -79,7 +84,7 @@ type RateInfoType = {
     rateCertificationName?: string
     actuaryContacts: ActuaryContact[]
     actuaryCommunicationPreference?: ActuaryCommunicationType
-    packagesWithSharedRateCerts: string[]
+    packagesWithSharedRateCerts?: SharedRateCertDisplay[]
 }
 
 // MAIN
@@ -125,4 +130,5 @@ export type {
     ContractExecutionStatus,
     RateCapitationType,
     RateInfoType,
+    SharedRateCertDisplay,
 }

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/toDomain.ts
@@ -189,6 +189,15 @@ function parseProtoDocuments(
     }))
 }
 
+function parseSharedRateCerts(
+    certs: mcreviewproto.ISharedRateCertDisplay[] | null | undefined
+): RateInfoType['packagesWithSharedRateCerts'] {
+    if (certs === null || certs === undefined) {
+        return undefined
+    }
+    return replaceNullsWithUndefineds(certs)
+}
+
 function parseContractAmendment(
     amendment: mcreviewproto.IContractInfo['contractAmendmentInfo']
 ): UnlockedHealthPlanFormDataType['contractAmendmentInfo'] {
@@ -355,7 +364,9 @@ function parseRateInfos(
                     rateInfo?.actuaryCommunicationPreference
                 ),
                 packagesWithSharedRateCerts:
-                    rateInfo.packagesWithSharedRateCerts ?? [],
+                    parseSharedRateCerts(
+                        rateInfo.packagesWithSharedRateCerts
+                    ) ?? [],
             }
             rates.push(rate)
         })

--- a/services/app-web/src/common-code/proto/healthPlanFormDataProto/unlockedHealthPlanFormDataSchema.ts
+++ b/services/app-web/src/common-code/proto/healthPlanFormDataProto/unlockedHealthPlanFormDataSchema.ts
@@ -107,6 +107,11 @@ const actuaryContactSchema = z.object({
     actuarialFirmOther: z.string().optional(),
 })
 
+const sharedRateCertDisplay = z.object({
+    packageName: z.string(),
+    packageId: z.string(),
+})
+
 const rateTypeSchema = z.union([z.literal('NEW'), z.literal('AMENDMENT')])
 
 const rateCapitationTypeSchema = z.union([
@@ -127,7 +132,7 @@ const rateInfosTypeSchema = z.object({
     rateCertificationName: z.string().optional(),
     actuaryContacts: z.array(actuaryContactSchema),
     actuaryCommunicationPreference: actuaryCommunicationTypeSchema.optional(),
-    packagesWithSharedRateCerts: z.array(z.string()),
+    packagesWithSharedRateCerts: z.array(sharedRateCertDisplay),
 })
 
 // Commenting out because this wasn't being used but was raising lint warning -hw

--- a/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
+++ b/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
@@ -84,6 +84,7 @@ export const PackageSelect = ({
             options={error || isLoading ? undefined : packageOptions}
             isSearchable
             isMulti
+            maxMenuHeight={200} // using this to limit size of the display to ~ 5 options with no font zooming
             aria-label="submission (required)"
             ariaLiveMessages={{
                 onFocus,

--- a/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
+++ b/services/app-web/src/components/Select/PackageSelect/PackageSelect.tsx
@@ -12,7 +12,7 @@ export type PackageSelectPropType = {
     error?: boolean
 }
 
-type PackageOptionType = {
+export type PackageOptionType = {
     readonly label: string
     readonly value: string
     readonly isFixed?: boolean

--- a/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.tsx
+++ b/services/app-web/src/components/Select/ProgramSelect/ProgramSelect.tsx
@@ -9,7 +9,7 @@ export type ProgramSelectPropType = {
     programIDs: string[]
 }
 
-interface ProgramOption {
+export interface ProgramOptionType {
     readonly value: string
     readonly label: string
     readonly isFixed?: boolean
@@ -21,12 +21,12 @@ export const ProgramSelect = ({
     statePrograms,
     programIDs,
     ...selectProps
-}: ProgramSelectPropType & Props<ProgramOption, true>) => {
-    const programOptions: ProgramOption[] = statePrograms.map((program) => {
+}: ProgramSelectPropType & Props<ProgramOptionType, true>) => {
+    const programOptions: ProgramOptionType[] = statePrograms.map((program) => {
         return { value: program.id, label: program.name }
     })
 
-    const onFocus: AriaOnFocus<ProgramOption> = ({
+    const onFocus: AriaOnFocus<ProgramOptionType> = ({
         focused,
         isDisabled,
     }): string => {

--- a/services/app-web/src/components/Select/index.ts
+++ b/services/app-web/src/components/Select/index.ts
@@ -3,3 +3,5 @@ export { PackageSelect } from './PackageSelect/PackageSelect'
 
 export type { ProgramSelectPropType } from './ProgramSelect/ProgramSelect'
 export type { PackageSelectPropType } from './PackageSelect/PackageSelect'
+export type { ProgramOptionType } from './ProgramSelect/ProgramSelect'
+export type { PackageOptionType } from './PackageSelect/PackageSelect'

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -91,7 +91,7 @@ export const RateDetailsSummarySection = ({
         )
     }
 
-    // Request updated packages and names for the state  -  used in rates across submissions feature
+    // Request updated rate packages and names for the state  -  used in rates across submissions feature
     const {
         error: indexPackagesError,
         data,
@@ -108,9 +108,8 @@ export const RateDetailsSummarySection = ({
                 )
                 return acc
             }
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const [currentRevision, currentSubmissionData] =
-                currentRevisionPackageOrError
+
+            const [_, currentSubmissionData] = currentRevisionPackageOrError
 
             acc[pkg.id] = {
                 packageName: packageName(currentSubmissionData, statePrograms),

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -350,7 +350,7 @@ export const RateDetailsSummarySection = ({
                                     </div>
                                 )}
                             </DoubleColumnGrid>
-                            {!loading && (
+                            {!loading ? (
                                 <UploadedDocumentsTable
                                     documents={rateInfo.rateDocuments}
                                     packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
@@ -363,6 +363,8 @@ export const RateDetailsSummarySection = ({
                                     caption="Rate certification"
                                     documentCategory="Rate certification"
                                 />
+                            ) : (
+                                <span className="srOnly">'LOADING...'</span>
                             )}
                         </React.Fragment>
                     )

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -256,6 +256,9 @@ export const RateDetailsSummarySection = ({
                             </DoubleColumnGrid>
                             <UploadedDocumentsTable
                                 documents={rateInfo.rateDocuments}
+                                packagesWithSharedRateCerts={
+                                    rateInfo.packagesWithSharedRateCerts
+                                }
                                 documentDateLookupTable={
                                     documentDateLookupTable
                                 }

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -91,7 +91,7 @@ export const RateDetailsSummarySection = ({
         )
     }
 
-    // Request updated rate packages and names for the state  -  used in rates across submissions feature
+    // Request updated packages and names for the state  -  used in rates across submissions feature
     const {
         error: indexPackagesError,
         data,
@@ -112,20 +112,11 @@ export const RateDetailsSummarySection = ({
             const [currentRevision, currentSubmissionData] =
                 currentRevisionPackageOrError
 
-            // Exclude active submission package and contract_only from list.
-            if (
-                currentSubmissionData.submissionType === 'CONTRACT_AND_RATES' &&
-                currentRevision.submitInfo?.updatedAt &&
-                pkg.id
-            ) {
-                acc[pkg.id] = {
-                    packageName: packageName(
-                        currentSubmissionData,
-                        statePrograms
-                    ),
-                    status: pkg.status,
-                }
+            acc[pkg.id] = {
+                packageName: packageName(currentSubmissionData, statePrograms),
+                status: pkg.status,
             }
+
             return acc
         },
         {} as PackageNamesLookupType

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.module.scss
@@ -49,3 +49,14 @@
     height: 18px;
     margin-right: 5px !important;
 }
+
+.sharedDocTag {
+    background-color: #ffbe2e;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: 2px;
+    height: 18px;
+    margin-right: 5px !important;
+}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -7,13 +7,14 @@ import { SubmissionDocument } from '../../../common-code/healthPlanFormDataType'
 import { DocumentDateLookupTable } from '../../../pages/SubmissionSummary/SubmissionSummary'
 import styles from './UploadedDocumentsTable.module.scss'
 import { usePreviousSubmission } from '../../../hooks'
+import { SharedRateCertDisplay } from '../../../common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType'
 
 export type UploadedDocumentsTableProps = {
     documents: SubmissionDocument[]
     caption: string | null
     documentCategory: string
     documentDateLookupTable?: DocumentDateLookupTable
-    packagesWithSharedRateCerts?: string[]
+    packagesWithSharedRateCerts?: SharedRateCertDisplay[]
     isSupportingDocuments?: boolean
     isEditing?: boolean
     isCMSUser?: boolean
@@ -186,17 +187,15 @@ export const UploadedDocumentsTable = ({
                             <td>{documentCategory}</td>
                             {showSharedInfo
                                 ? packagesWithSharedRateCerts &&
-                                  packagesWithSharedRateCerts.map(
-                                      (packageId) => (
-                                          <td>
-                                              <NavLink
-                                                  to={`/submissions/${packageId}`}
-                                              >
-                                                  {packageId}
-                                              </NavLink>
-                                          </td>
-                                      )
-                                  )
+                                  packagesWithSharedRateCerts.map((item) => (
+                                      <td>
+                                          <NavLink
+                                              to={`/submissions/${item.packageId}`}
+                                          >
+                                              {item.packageName}
+                                          </NavLink>
+                                      </td>
+                                  ))
                                 : null}
                         </tr>
                     ))}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -60,6 +60,10 @@ export const UploadedDocumentsTable = ({
     const supportingDocsTopMarginStyles = isSupportingDocuments
         ? styles.withMarginTop
         : ''
+
+    const linkedPackageIsDraft = (packageName?: string) =>
+        packageName && packageName.includes('(Draft)')
+
     const tableCaptionJSX = (
         <>
             <span>{caption}</span>
@@ -186,12 +190,19 @@ export const UploadedDocumentsTable = ({
                             {showSharedInfo
                                 ? packagesWithSharedRateCerts &&
                                   packagesWithSharedRateCerts.map((item) => (
-                                      <td>
-                                          <NavLink
-                                              to={`/submissions/${item.packageId}`}
-                                          >
-                                              {item.packageName}
-                                          </NavLink>
+                                      <td key={item.packageName}>
+                                          {isCMSUser &&
+                                          linkedPackageIsDraft(
+                                              item.packageName
+                                          ) ? (
+                                              <span>{item.packageName}</span>
+                                          ) : (
+                                              <NavLink
+                                                  to={`/submissions/${item.packageId}`}
+                                              >
+                                                  {item.packageName}
+                                              </NavLink>
+                                          )}
                                       </td>
                                   ))
                                 : null}

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -36,7 +36,6 @@ export const UploadedDocumentsTable = ({
     isEditing = false,
     isCMSUser,
 }: UploadedDocumentsTableProps): React.ReactElement => {
-    console.log('packagesWithSharedRateCerts', packagesWithSharedRateCerts)
     const { getURL, getKey } = useS3()
     const [refreshedDocs, setRefreshedDocs] = useState<DocumentWithLink[]>([])
     const shouldShowEditButton = isEditing && isSupportingDocuments
@@ -119,7 +118,6 @@ export const UploadedDocumentsTable = ({
             </div>
         )
     }
-    console.log('refreshedDocs', refreshedDocs)
     return (
         <>
             <table
@@ -136,7 +134,7 @@ export const UploadedDocumentsTable = ({
                         <th scope="col">Date added</th>
                         <th scope="col">Document category</th>
                         {showSharedInfo && (
-                            <th scope="col">Linked submission</th>
+                            <th scope="col">Linked submissions</th>
                         )}
                     </tr>
                 </thead>

--- a/services/app-web/src/gqlHelpers/healthPlanPackages.ts
+++ b/services/app-web/src/gqlHelpers/healthPlanPackages.ts
@@ -21,16 +21,8 @@ const getCurrentRevisionFromHealthPlanPackage = (
                 'Error fetching the latest revision. Please try again.'
             )
         }
-
-        const newestRev = submissionAndRevisions.revisions.reduce(
-            (acc, rev) => {
-                if (rev.node.createdAt > acc.node.createdAt) {
-                    return rev
-                } else {
-                    return acc
-                }
-            }
-        ).node
+        // rely entirely on server-side sorting of revisions by created-at descending (oldest first)
+        const newestRev = submissionAndRevisions.revisions[0].node
 
         // Decode form data submitted by the state
         const healthPlanPackageFormDataResult = base64ToDomain(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -1204,7 +1204,17 @@ describe('RateDetails', () => {
             )
             expect(firstRateCertSharedCheckBox).toBeChecked()
             expect(firstRateCert.getAllByRole('combobox')).toHaveLength(2)
+            expect(
+                firstRateCert.getByText(
+                    /Please select the submissions that also contain this rate/
+                )
+            ).toBeInTheDocument()
             expect(secondRateCertSharedCheckBox).not.toBeChecked()
+            expect(
+                secondRateCert.queryByText(
+                    /Please select the submissions that also contain this rate/
+                )
+            ).toBeNull()
             expect(secondRateCert.getAllByRole('combobox')).toHaveLength(1)
 
             //Both rate cert check boxes are unchecked and only programs combobox present

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -203,10 +203,10 @@ export const RateDetails = ({
                     }
                 })
 
-            const abbreviatedPackagesList = packagesWithUpdatedAt
-                .sort((a, b) => (a['updatedAt'] > b['updatedAt'] ? -1 : 1))
-                .slice(0, 5)
-            setPackageOptions(abbreviatedPackagesList)
+            const packagesList = packagesWithUpdatedAt.sort((a, b) =>
+                a['updatedAt'] > b['updatedAt'] ? -1 : 1
+            )
+            setPackageOptions(packagesList)
         },
         onError: (error) => {
             recordJSException(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -36,6 +36,7 @@ import {
     ProgramSelect,
     PackageSelect,
 } from '../../../components'
+import type { PackageOptionType } from '../../../components/Select'
 import {
     formatForForm,
     isDateRangeEmpty,
@@ -101,13 +102,6 @@ export interface RateInfoFormType {
 
 type FormError =
     FormikErrors<RateInfoFormType>[keyof FormikErrors<RateInfoFormType>]
-
-type PackageOptionType = {
-    readonly label: string
-    readonly value: string
-    readonly isFixed?: boolean
-    readonly isDisabled?: boolean
-}
 
 export const rateErrorHandling = (
     error: string | FormikErrors<RateInfoFormType> | undefined
@@ -732,7 +726,17 @@ export const RateDetails = ({
                                                             />
                                                         </FormGroup>
                                                         {showRatesAcrossSubs && (
-                                                            <FormGroup>
+                                                            <FormGroup
+                                                                error={showFieldErrors(
+                                                                    rateErrorHandling(
+                                                                        errors
+                                                                            ?.rateInfos?.[
+                                                                            index
+                                                                        ]
+                                                                    )
+                                                                        ?.packagesWithSharedRateCerts
+                                                                )}
+                                                            >
                                                                 <Checkbox
                                                                     id={`hasSharedRateCheckBox-${rateInfo.key}`}
                                                                     name={`rateInfos.${index}.hasSharedRateCert`}
@@ -754,78 +758,94 @@ export const RateDetails = ({
                                                                         )
                                                                     }
                                                                 />
+
+                                                                {rateInfo.hasSharedRateCert && (
+                                                                    <>
+                                                                        <Label
+                                                                            htmlFor={`rateInfos.${index}.rateProgramIDs`}
+                                                                        >
+                                                                            Please
+                                                                            select
+                                                                            the
+                                                                            submissions
+                                                                            that
+                                                                            also
+                                                                            contain
+                                                                            this
+                                                                            rate
+                                                                            certification.
+                                                                        </Label>
+                                                                        <Link
+                                                                            aria-label="View all submissions (opens in new window)"
+                                                                            href={
+                                                                                '/dashboard'
+                                                                            }
+                                                                            variant="external"
+                                                                            target="_blank"
+                                                                        >
+                                                                            View
+                                                                            all
+                                                                            submissions
+                                                                        </Link>
+                                                                        {showFieldErrors(
+                                                                            rateErrorHandling(
+                                                                                errors
+                                                                                    ?.rateInfos?.[
+                                                                                    index
+                                                                                ]
+                                                                            )
+                                                                                ?.packagesWithSharedRateCerts
+                                                                        ) && (
+                                                                            <PoliteErrorMessage>
+                                                                                {getIn(
+                                                                                    errors,
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`
+                                                                                )}
+                                                                            </PoliteErrorMessage>
+                                                                        )}
+                                                                        <PackageSelect
+                                                                            //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
+                                                                            // causes issues with the default value when reloading the page
+                                                                            key={`${packageOptions}-${rateInfo.key}`}
+                                                                            inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            name={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                            statePrograms={
+                                                                                statePrograms
+                                                                            }
+                                                                            initialValues={
+                                                                                rateInfo?.packagesWithSharedRateCerts
+                                                                            }
+                                                                            packageOptions={
+                                                                                packageOptions
+                                                                            }
+                                                                            draftSubmissionId={
+                                                                                draftSubmission.id
+                                                                            }
+                                                                            isLoading={
+                                                                                loading
+                                                                            }
+                                                                            error={
+                                                                                error instanceof
+                                                                                Error
+                                                                            }
+                                                                            onChange={(
+                                                                                selectedOptions
+                                                                            ) =>
+                                                                                setFieldValue(
+                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`,
+                                                                                    selectedOptions.map(
+                                                                                        (item: {
+                                                                                            value: string
+                                                                                        }) =>
+                                                                                            item.value
+                                                                                    )
+                                                                                )
+                                                                            }
+                                                                        />
+                                                                    </>
+                                                                )}
                                                             </FormGroup>
                                                         )}
-                                                        {showRatesAcrossSubs &&
-                                                            rateInfo.hasSharedRateCert && (
-                                                                <FormGroup
-                                                                    error={showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.packagesWithSharedRateCerts
-                                                                    )}
-                                                                >
-                                                                    {showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.packagesWithSharedRateCerts
-                                                                    ) && (
-                                                                        <PoliteErrorMessage>
-                                                                            {getIn(
-                                                                                errors,
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`
-                                                                            )}
-                                                                        </PoliteErrorMessage>
-                                                                    )}
-                                                                    <PackageSelect
-                                                                        //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
-                                                                        // causes issues with the default value when reloading the page
-                                                                        key={`${packageOptions}-${rateInfo.key}`}
-                                                                        inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        name={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        statePrograms={
-                                                                            statePrograms
-                                                                        }
-                                                                        initialValues={
-                                                                            rateInfo?.packagesWithSharedRateCerts
-                                                                        }
-                                                                        packageOptions={
-                                                                            packageOptions
-                                                                        }
-                                                                        draftSubmissionId={
-                                                                            draftSubmission.id
-                                                                        }
-                                                                        isLoading={
-                                                                            loading
-                                                                        }
-                                                                        error={
-                                                                            error instanceof
-                                                                            Error
-                                                                        }
-                                                                        onChange={(
-                                                                            selectedOption
-                                                                        ) =>
-                                                                            setFieldValue(
-                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`,
-                                                                                selectedOption.map(
-                                                                                    (item: {
-                                                                                        value: string
-                                                                                    }) =>
-                                                                                        item.value
-                                                                                )
-                                                                            )
-                                                                        }
-                                                                    />
-                                                                </FormGroup>
-                                                            )}
                                                         <FormGroup
                                                             error={showFieldErrors(
                                                                 rateErrorHandling(
@@ -880,11 +900,11 @@ export const RateDetails = ({
                                                                         }
                                                                         aria-label="programs (required)"
                                                                         onChange={(
-                                                                            selectedOption
+                                                                            selectedOptions
                                                                         ) =>
                                                                             form.setFieldValue(
                                                                                 `rateInfos.${index}.rateProgramIDs`,
-                                                                                selectedOption.map(
+                                                                                selectedOptions.map(
                                                                                     (item: {
                                                                                         value: string
                                                                                     }) =>
@@ -930,7 +950,7 @@ export const RateDetails = ({
                                                                     </PoliteErrorMessage>
                                                                 )}
                                                                 <Link
-                                                                    aria-label="Rate certification type defintions (opens in new window)"
+                                                                    aria-label="Rate certification type definitions (opens in new window)"
                                                                     href={
                                                                         '/help#rate-cert-type-definitions'
                                                                     }

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -160,7 +160,9 @@ export const RateDetails = ({
     const { loading, error } = useIndexHealthPlanPackagesQuery({
         skip: !showRatesAcrossSubs,
         onCompleted: async (data) => {
-            const packages: PackageOptionType[] = []
+            const packagesWithUpdatedAt: Array<
+                { updatedAt: Date } & PackageOptionType
+            > = []
             data?.indexHealthPlanPackages.edges
                 .map((edge) => edge.node)
                 .forEach((sub) => {
@@ -190,7 +192,8 @@ export const RateDetails = ({
                                   .format('MM/DD/YY')})`
                             : ` (Draft)`
 
-                        packages.push({
+                        packagesWithUpdatedAt.push({
+                            updatedAt: currentSubmissionData.updatedAt,
                             label: `${packageName(
                                 currentSubmissionData,
                                 statePrograms
@@ -199,7 +202,10 @@ export const RateDetails = ({
                         })
                     }
                 })
-            const abbreviatedPackagesList = packages.slice(0, 5)
+
+            const abbreviatedPackagesList = packagesWithUpdatedAt
+                .sort((a, b) => (a['updatedAt'] > b['updatedAt'] ? -1 : 1))
+                .slice(0, 5)
             setPackageOptions(abbreviatedPackagesList)
         },
         onError: (error) => {

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -62,6 +62,7 @@ import { useIndexHealthPlanPackagesQuery } from '../../../gen/gqlClient'
 import { base64ToDomain } from '../../../common-code/proto/healthPlanFormDataProto'
 import { recordJSException } from '../../../otelHelpers'
 import { dayjs } from '../../../common-code/dateHelpers'
+import { SharedRateCertDisplay } from '../../../common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType'
 
 const RateDatesErrorMessage = ({
     startDate,
@@ -96,7 +97,7 @@ export interface RateInfoFormType {
     rateDocuments: SubmissionDocument[]
     actuaryContacts: ActuaryContact[]
     actuaryCommunicationPreference?: ActuaryCommunicationType
-    packagesWithSharedRateCerts: string[]
+    packagesWithSharedRateCerts: SharedRateCertDisplay[]
     hasSharedRateCert: boolean
 }
 
@@ -276,7 +277,8 @@ export const RateDetails = ({
         packagesWithSharedRateCerts:
             rateInfo?.packagesWithSharedRateCerts ?? [],
         hasSharedRateCert: Boolean(
-            rateInfo?.packagesWithSharedRateCerts.length
+            rateInfo?.packagesWithSharedRateCerts &&
+                rateInfo?.packagesWithSharedRateCerts.length
         ),
     })
 
@@ -812,9 +814,14 @@ export const RateDetails = ({
                                                                             statePrograms={
                                                                                 statePrograms
                                                                             }
-                                                                            initialValues={
-                                                                                rateInfo?.packagesWithSharedRateCerts
-                                                                            }
+                                                                            initialValues={rateInfo.packagesWithSharedRateCerts.map(
+                                                                                (
+                                                                                    item
+                                                                                ) =>
+                                                                                    item.packageId
+                                                                                        ? item.packageId
+                                                                                        : ''
+                                                                            )}
                                                                             packageOptions={
                                                                                 packageOptions
                                                                             }
@@ -834,10 +841,19 @@ export const RateDetails = ({
                                                                                 setFieldValue(
                                                                                     `rateInfos.${index}.packagesWithSharedRateCerts`,
                                                                                     selectedOptions.map(
-                                                                                        (item: {
-                                                                                            value: string
-                                                                                        }) =>
-                                                                                            item.value
+                                                                                        (
+                                                                                            item: PackageOptionType
+                                                                                        ) => {
+                                                                                            return {
+                                                                                                packageName:
+                                                                                                    item.label.replace(
+                                                                                                        /\s\(.*?\)/g,
+                                                                                                        ''
+                                                                                                    ),
+                                                                                                packageId:
+                                                                                                    item.value,
+                                                                                            }
+                                                                                        }
                                                                                     )
                                                                                 )
                                                                             }

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.test.tsx
@@ -11,6 +11,7 @@ import {
     mockValidCMSUser,
     mockSubmittedHealthPlanPackageWithRevision,
     mockUnlockedHealthPlanPackageWithOldProtos,
+    indexHealthPlanPackagesMockSuccess,
 } from '../../testHelpers/apolloHelpers'
 import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { SubmissionSummary } from './SubmissionSummary'
@@ -420,6 +421,7 @@ describe('SubmissionSummary', () => {
                                             proto
                                         ),
                                 }),
+                                indexHealthPlanPackagesMockSuccess(),
                             ],
                         },
                         routerProvider: {
@@ -431,6 +433,10 @@ describe('SubmissionSummary', () => {
                 await waitFor(() => {
                     // there's an async rendering issue with the snapshots unless we run another test first
                     expect(document.body).toHaveTextContent(/Submission type/)
+                })
+                await waitFor(() => {
+                    // there's an async rendering issue with  UploadedDocsTable the snapshots unless we run another test first
+                    expect(document.body).not.toHaveTextContent(/LOADING/)
                     expect(document.body).toMatchSnapshot()
                 })
             }

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -119,11 +119,17 @@ export const SubmissionSummary = (): React.ReactElement => {
             )
 
             if (!currentRevision) {
-                recordJSException(
-                    `SubmissionSummary: submission in summary has no submitted revision. ID: ${submissionAndRevisions.id}`
-                )
-                // if state user goes to submission/:id for a draft submission, put them on the form
-                navigate(`/submissions/${id}/edit/type`)
+                if (isCMSUser) {
+                    recordJSException(
+                        `SubmissionSummary: submission in summary has no submitted revision. ID: ${submissionAndRevisions.id}`
+                    )
+                    setPageLevelAlert(
+                        'Error fetching the submission. This package may still be in draft mode.'
+                    )
+                } else {
+                    // if state user goes to submission/:id for a draft submission, put them on the form, this is an expected workflow
+                    navigate(`/submissions/${id}/edit/type`)
+                }
                 return
             }
 
@@ -179,6 +185,7 @@ export const SubmissionSummary = (): React.ReactElement => {
         setPageLevelAlert,
         navigate,
         id,
+        isCMSUser,
     ])
 
     // Update header with submission name

--- a/services/app-web/src/pages/SubmissionSummary/__snapshots__/SubmissionSummary.test.tsx.snap
+++ b/services/app-web/src/pages/SubmissionSummary/__snapshots__/SubmissionSummary.test.tsx.snap
@@ -94,6 +94,7 @@ exports[`SubmissionSummary Outdated submissions loads outdated health plan packa
             </h2>
             <div>
               <button
+                aria-controls="unlock"
                 class="usa-button usa-button--outline submitButton"
                 data-open-modal="true"
                 data-testid="form-submit"


### PR DESCRIPTION
MR-2587 replacement for #1338 
MR-2684
MR-2686

## Summary

Finishes up several of the rates across submissions tickets.  Incorporates @haworku's code for 2587.

We should now see a "SHARED" tag on documents that the user has told us are shared with other submissions.
We should see a "Linked submissions" column when such a document exists.
That column should contain the name of the other submission, and a link to it.

We should see the most recent 5 submissions in the dropdown in RateDetails where we can select the linked submission.

Includes a refactor of the `packagesWithSharedRateCerts` type to include both the name and the id of a package.  Since this is behind a feature flag and there are no prod submissions using the old type, this change doesn't require any migration work.

#### Screenshots

<img width="777" alt="image" src="https://user-images.githubusercontent.com/8964335/203473758-4f0379e3-fc19-4eec-aa9d-5a5874082638.png">


#### Test cases covered

New unit tests for when we show the shared rate info, and also for when we don't (when it's not the latest submission, and when there are no shared rates).

