### PR TITLE
Remove new Prisma query engines for debian

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -335,7 +335,7 @@ jobs:
     permissions:
       deployments: write
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         # run copies of the current job in parallel
         containers: [1, 2, 3, 4, 5, 6]

--- a/services/app-api/scripts/prepare-prisma-layer.sh
+++ b/services/app-api/scripts/prepare-prisma-layer.sh
@@ -52,8 +52,10 @@ function preparePrismaLayer() {
 
     echo "Remove non-RHEL bins to save space ..."
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node
+    rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-3.0.x.so.node
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/engines
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/libquery_engine-debian-openssl-1.1.x.so.node
+    rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/libquery_engine-debian-openssl-3.0.x.so.node
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/introspection-engine-debian-openssl-1.1.x 
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/libquery_engine-debian-openssl-1.1.x.so.node 
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/@prisma/migration-engine-debian-openssl-1.1.x
@@ -61,8 +63,10 @@ function preparePrismaLayer() {
     rm -rf lambda-layers-prisma-client-migration/nodejs/node_modules/prisma/libquery_engine-rhel-openssl-1.0.x.so.node
 
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node
+    rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/.prisma/client/libquery_engine-debian-openssl-3.0.x.so.node
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/prisma/engines
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/prisma/libquery_engine-debian-openssl-1.1.x.so.node
+    rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/prisma/libquery_engine-debian-openssl-3.0.x.so.node
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/introspection-engine-debian-openssl-1.1.x 
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/libquery_engine-debian-openssl-1.1.x.so.node 
     rm -rf lambda-layers-prisma-client-engine/nodejs/node_modules/@prisma/migration-engine-debian-openssl-1.1.x


### PR DESCRIPTION
## Summary

Promote failed when #1349 merged due to a total package size for the `app-api` lambdas becoming larger than the max size AWS allows. It turns out that the migration and query engine Prisma layers that we build for the environment started getting a lib built for a Debian environment which we weren't excluding (`libquery_engine-debian-openssl-3.0.x.so.node`). I'm guessing this happened from a Prisma upgrade or from the CI environment's underlying OS having lib changes that went unnoticed in our CI layer builds.

This removes the unneeded lib for our AWS deployed layer to save space.
