### PR TITLE
Fix cognitoAuth with Aurora inserts

### DIFF
--- a/services/app-api/src/authn/cognitoAuthn.ts
+++ b/services/app-api/src/authn/cognitoAuthn.ts
@@ -233,11 +233,15 @@ export async function userFromCognitoAuthProvider(
         try {
             const result = await store.insertUser(userToInsert)
             if (isStoreError(result)) {
-                throw new Error(`Could not insert user: ${result}`)
+                console.error(
+                    `Could not insert user: ${JSON.stringify(result)}`
+                )
+                return cognitoUserResult
             }
             return userTypeFromUser(result)
         } catch (e) {
-            throw new Error(`Could not insert user: ${e}`)
+            console.error(`Could not insert user: ${JSON.stringify(e)}`)
+            return cognitoUserResult
         }
     }
 

--- a/services/app-api/src/postgres/insertUser.ts
+++ b/services/app-api/src/postgres/insertUser.ts
@@ -23,7 +23,7 @@ export async function insertUser(
                 familyName: user.familyName,
                 email: user.email,
                 role: user.role,
-                stateCode: user.stateCode,
+                stateCode: user.stateCode ?? '',
             },
         })
         console.log('insert user return: ' + val)


### PR DESCRIPTION
## Summary

When testing out the newly merged Users table work in #1321 , the shared CMS dev user seems to be having issues with inserting into Aurora. This is due to a difference in attributes for a state vs CMS user. 

This adds a default value to the insert for a CMS user (state is empty), and will return the user from cognito if there is a failure in this code path (so as to not bring down the application fully).
