### PR TITLE
Remove `unique` constraint on User emails

### DIFF
--- a/services/app-api/prisma/migrations/20221206000520_remove_email_unique/migration.sql
+++ b/services/app-api/prisma/migrations/20221206000520_remove_email_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "User_email_key";

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -45,7 +45,7 @@ model User {
   id         String  @id
   givenName  String
   familyName String
-  email      String  @unique
+  email      String
   role       Role
   states     State[]
   stateCode  String?


### PR DESCRIPTION
## Summary

In our dev environment we can have user accounts that have non-unique email addresses. Since we aren't really gaining anything from this constraint (and have unique IDs from IDM), we'll drop this for now.