### PR TITLE
Fix SES email sending

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -145,6 +145,8 @@ layers:
 functions:
   email_submit:
     handler: src/handlers/email_submit.main
+    layers:
+      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-2-0:1
 
   health:
     handler: src/handlers/health_check.main

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -145,8 +145,6 @@ layers:
 functions:
   email_submit:
     handler: src/handlers/email_submit.main
-    layers:
-      - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-2-0:1
 
   health:
     handler: src/handlers/health_check.main

--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -4,7 +4,6 @@ import {
     SendEmailRequest,
     SendEmailResponse,
     SendEmailCommand,
-    SendEmailCommandInput,
 } from '@aws-sdk/client-ses'
 import { EmailData } from './'
 
@@ -67,13 +66,11 @@ class AWSResponseError extends Error {
 }
 
 async function sendSESEmail(
-    params: SendEmailCommandInput
+    params: SendEmailRequest
 ): Promise<SendEmailResponse | SESServiceException> {
     try {
-        console.log(`sendSESEMAIL: ${JSON.stringify(params)}`)
         const command = new SendEmailCommand(params)
-        const response = await ses.send(command)
-        return response
+        return await ses.send(command)
     } catch (err) {
         console.error(JSON.stringify(err))
         const { requestId, cfId, extendedRequestId } = err.$$metadata

--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -74,6 +74,7 @@ async function sendSESEmail(
         const response = await ses.send(command)
         return response
     } catch (err) {
+        console.error(JSON.stringify(err))
         const { requestId, cfId, extendedRequestId } = err.$$metadata
         console.log({ requestId, cfId, extendedRequestId })
         return err

--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -4,6 +4,7 @@ import {
     SendEmailRequest,
     SendEmailResponse,
     SendEmailCommand,
+    SendEmailCommandInput,
 } from '@aws-sdk/client-ses'
 import { EmailData } from './'
 
@@ -66,10 +67,10 @@ class AWSResponseError extends Error {
 }
 
 async function sendSESEmail(
-    params: SendEmailRequest
+    params: SendEmailCommandInput
 ): Promise<SendEmailResponse | SESServiceException> {
     try {
-        console.log(JSON.stringify(params))
+        console.log(`sendSESEMAIL: ${JSON.stringify(params)}`)
         const command = new SendEmailCommand(params)
         const response = await ses.send(command)
         return response

--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -69,6 +69,7 @@ async function sendSESEmail(
     params: SendEmailRequest
 ): Promise<SendEmailResponse | SESServiceException> {
     try {
+        console.log(JSON.stringify(params))
         const command = new SendEmailCommand(params)
         const response = await ses.send(command)
         return response

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -2,6 +2,7 @@ import {
     InvokeCommandInput,
     LambdaClient,
     InvokeCommand,
+    LambdaClientConfig,
 } from '@aws-sdk/client-lambda'
 
 import {
@@ -83,7 +84,10 @@ type Emailer = {
 }
 
 function newSESEmailer(config: EmailConfiguration): Emailer {
-    const lambda = new LambdaClient({ region: 'us-east-1' })
+    const lambdaClientConfig: LambdaClientConfig = {
+        region: 'us-east-1',
+    }
+    const lambda = new LambdaClient(lambdaClientConfig)
     return {
         sendEmail: async (emailData: EmailData): Promise<void | Error> => {
             const emailRequestParams = getSESEmailParams(emailData)
@@ -103,9 +107,7 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
 
             try {
                 const command = new InvokeCommand(lambdaParams)
-                const lambdaresult = await lambda.send(command)
-                console.log(`lambda result: ${JSON.stringify(lambdaresult)}`)
-
+                await lambda.send(command)
                 return
             } catch (err) {
                 return new Error('SES email send failed. ' + err)

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -103,7 +103,7 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
                 ),
             }
 
-            console.log(JSON.stringify(lambdaParams))
+            console.log(`lambdaParams: ${JSON.stringify(lambdaParams)}`)
 
             try {
                 const command = new InvokeCommand(lambdaParams)
@@ -118,7 +118,6 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
             stateAnalystsEmails,
             statePrograms
         ) {
-            console.log(`submission: ${JSON.stringify(submission)}`)
             const emailData = await newPackageCMSEmail(
                 submission,
                 config,

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -103,7 +103,9 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
 
             try {
                 const command = new InvokeCommand(lambdaParams)
-                await lambda.send(command)
+                const lambdaresult = await lambda.send(command)
+                console.log(`lambda result: ${JSON.stringify(lambdaresult)}`)
+
                 return
             } catch (err) {
                 return new Error('SES email send failed. ' + err)
@@ -114,14 +116,14 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
             stateAnalystsEmails,
             statePrograms
         ) {
-            console.log(`submission: ${submission}`)
+            console.log(`submission: ${JSON.stringify(submission)}`)
             const emailData = await newPackageCMSEmail(
                 submission,
                 config,
                 stateAnalystsEmails,
                 statePrograms
             )
-            console.log(`emailData: ${emailData}`)
+            console.log(`emailData: ${JSON.stringify(emailData)}`)
             if (emailData instanceof Error) {
                 return emailData
             } else {

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -114,12 +114,14 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
             stateAnalystsEmails,
             statePrograms
         ) {
+            console.log(`submission: ${submission}`)
             const emailData = await newPackageCMSEmail(
                 submission,
                 config,
                 stateAnalystsEmails,
                 statePrograms
             )
+            console.log(`emailData: ${emailData}`)
             if (emailData instanceof Error) {
                 return emailData
             } else {

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -1,9 +1,4 @@
-import {
-    InvokeCommandInput,
-    LambdaClient,
-    InvokeCommand,
-    LambdaClientConfig,
-} from '@aws-sdk/client-lambda'
+import { sendSESEmail } from '../emailer'
 
 import {
     getSESEmailParams,
@@ -84,14 +79,17 @@ type Emailer = {
 }
 
 function newSESEmailer(config: EmailConfiguration): Emailer {
+    /*
     const lambdaClientConfig: LambdaClientConfig = {
         region: 'us-east-1',
     }
     const lambda = new LambdaClient(lambdaClientConfig)
+    */
     return {
         sendEmail: async (emailData: EmailData): Promise<void | Error> => {
             const emailRequestParams = getSESEmailParams(emailData)
 
+            /*
             const lambdaParams: InvokeCommandInput = {
                 FunctionName: `app-api-${config.stage}-email_submit`,
                 Payload: JSON.parse(
@@ -104,10 +102,12 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
             }
 
             console.log(`lambdaParams: ${JSON.stringify(lambdaParams)}`)
+            */
 
             try {
-                const command = new InvokeCommand(lambdaParams)
-                await lambda.send(command)
+                //const command = new InvokeCommand(lambdaParams)
+                //await lambda.send(command)
+                await sendSESEmail(emailRequestParams)
                 return
             } catch (err) {
                 return new Error('SES email send failed. ' + err)

--- a/services/app-api/src/emailer/emailer.ts
+++ b/services/app-api/src/emailer/emailer.ts
@@ -79,34 +79,11 @@ type Emailer = {
 }
 
 function newSESEmailer(config: EmailConfiguration): Emailer {
-    /*
-    const lambdaClientConfig: LambdaClientConfig = {
-        region: 'us-east-1',
-    }
-    const lambda = new LambdaClient(lambdaClientConfig)
-    */
     return {
         sendEmail: async (emailData: EmailData): Promise<void | Error> => {
             const emailRequestParams = getSESEmailParams(emailData)
 
-            /*
-            const lambdaParams: InvokeCommandInput = {
-                FunctionName: `app-api-${config.stage}-email_submit`,
-                Payload: JSON.parse(
-                    Buffer.from(
-                        JSON.stringify({
-                            body: emailRequestParams,
-                        })
-                    ).toString() // Payload must be type of Uint8Array
-                ),
-            }
-
-            console.log(`lambdaParams: ${JSON.stringify(lambdaParams)}`)
-            */
-
             try {
-                //const command = new InvokeCommand(lambdaParams)
-                //await lambda.send(command)
                 await sendSESEmail(emailRequestParams)
                 return
             } catch (err) {
@@ -124,7 +101,6 @@ function newSESEmailer(config: EmailConfiguration): Emailer {
                 stateAnalystsEmails,
                 statePrograms
             )
-            console.log(`emailData: ${JSON.stringify(emailData)}`)
             if (emailData instanceof Error) {
                 return emailData
             } else {

--- a/services/app-api/src/handlers/email_submit.ts
+++ b/services/app-api/src/handlers/email_submit.ts
@@ -17,6 +17,7 @@ export const main: Handler = async (event) => {
         }
     }
     console.log('INFO: Sending SES Email: ', event.body)
+
     const sesResult = await sendSESEmail(event.body)
 
     if (sesResult instanceof SESServiceException) {


### PR DESCRIPTION
## Summary

This fixes a bug where sending email notifications through SES was throwing an error. This likely cropped up due to moving from the AWS v2 SDK to the newer v3 SDK and a change on how lambdas are invoked.

Instead of invoking a lambda handler to do the SES sending, this just uses SES on it's own.

### Related Issues
https://qmacbis.atlassian.net/browse/MR-2867
