### PR TITLE
Add Cypress monitor hack for Chrome in Linux

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -343,6 +343,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cypress hack
+        run: |
+          export DISPLAY=:1
+          Xvfb :1 -screen 0 1024x768x16 2>/dev/null &
+          unset DISPLAY
+          kill %1
+
       - name: Cypress -- Chrome
         id: cypress
         uses: cypress-io/github-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -347,8 +347,6 @@ jobs:
         run: |
           export DISPLAY=:1
           Xvfb :1 -screen 0 1024x768x16 2>/dev/null &
-          unset DISPLAY
-          kill %1
 
       - name: Cypress -- Chrome
         id: cypress


### PR DESCRIPTION
## Summary
 Some of our Cypress runs were throwing an error like this:
```
libva error: vaGetDriverNameByIndex() failed with unknown libva error, driver_name = (null)
```

After some searching I [found a fix](https://repo1.dso.mil/platform-one/big-bang/apps/library-charts/gluon/-/issues/7) that creates a virtual monitor so that Cypress will run there, as there is an issue with Chrome on Linux that this works around.
