### PR TITLE
Fix OTEL endpoint requests from React

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -189,6 +189,7 @@ functions:
               - x-amzn-trace-id
               - b3
               - traceparent
+          authorizer: aws_iam
 
   graphql:
     handler: src/handlers/apollo_gql.graphqlHandler

--- a/services/app-web/serverless.yml
+++ b/services/app-web/serverless.yml
@@ -72,7 +72,7 @@ custom:
         export REACT_APP_S3_REGION=${self:custom.s3_documents_bucket_region}
         export REACT_APP_S3_DOCUMENTS_BUCKET=${self:custom.s3_documents_bucket_name}
         export REACT_APP_STAGE_NAME=${sls:stage}
-        export REACT_APP_OTEL_COLLECTOR_URL=${self:custom.api_url}/otel
+        export REACT_APP_OTEL_COLLECTOR_URL=${self:custom.application_endpoint_url}/otel
         export REACT_APP_LD_CLIENT_ID=${self:custom.react_app_ld_client_id}
 
         yarn run build


### PR DESCRIPTION
## Summary

While working on the Cypress issues I noticed that requests from React to the OTEL endpoint were getting 403s. I'm not sure when this started, but switching to use the application endpoint with the authorizer instead of the api gateway endpoint clears those up it seems. This was working fine in the past, so I'm not sure what changed with the API gateway to make this start failing all of a sudden.
