### PR TITLE
Add ability to control IP allowlist on WAF

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -281,6 +281,18 @@ resources:
       Properties:
         ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
         WebACLArn: ${self:custom.appApiWafAclArn}
+
+    WafIPRuleSet:
+      Type: AWS::WAFv2::IPSet
+      DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
+      Properties:
+        Addresses:
+          - 172.160.0.0/11
+        Description: 'An allowlist for IP addresses to access our application'
+        IPAddressVersion: IPV4
+        Name: gha-allow-list-${sls:stage}
+        Scope: REGIONAL
+
   Outputs:
     ApiAuthMode:
       Value: ${self:custom.reactAppAuthMode}

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -282,17 +282,6 @@ resources:
         ResourceArn: arn:aws:apigateway:${self:provider.region}::/restapis/${self:custom.appApiGatewayId}/stages/${sls:stage}
         WebACLArn: ${self:custom.appApiWafAclArn}
 
-    WafIPRuleSet:
-      Type: AWS::WAFv2::IPSet
-      DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
-      Properties:
-        Addresses:
-          - 172.160.0.0/11
-        Description: 'An allowlist for IP addresses to access our application'
-        IPAddressVersion: IPV4
-        Name: gha-allow-list-${sls:stage}
-        Scope: REGIONAL
-
   Outputs:
     ApiAuthMode:
       Value: ${self:custom.reactAppAuthMode}

--- a/services/infra-api/package.json
+++ b/services/infra-api/package.json
@@ -8,7 +8,6 @@
     "author": "",
     "license": "CC0-1.0",
     "devDependencies": {
-        "@enterprise-cmcs/serverless-waf-plugin": "^1.3.0",
         "serverless": "^3.19.0",
         "serverless-iam-helper": "CMSgov/serverless-iam-helper",
         "serverless-s3-bucket-helper": "CMSgov/serverless-s3-bucket-helper",

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -175,7 +175,7 @@ resources:
 
     WafIPRuleSet:
       Type: AWS::WAFv2::IPSet
-      DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
+      DependsOn: AppApiGateway
       Properties:
         Addresses:
           - 172.160.0.0/11

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -185,7 +185,7 @@ resources:
           - 172.160.0.0/11
         Description: 'An allowlist for IP addresses to access our application'
         IPAddressVersion: IPV4
-        Name: gha-allow-list-${sls:stage}
+        Name: ip-allow-list-${sls:stage}
         Scope: REGIONAL
 
     # NewRelic exporting configs

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -8,7 +8,6 @@ plugins:
   - serverless-stack-termination-protection
   - serverless-s3-bucket-helper
   - serverless-iam-helper
-  - '@enterprise-cmcs/serverless-waf-plugin'
 
 custom:
   stage: ${opt:stage, self:provider.stage}
@@ -83,6 +82,109 @@ resources:
         ResponseType: DEFAULT_5XX
         RestApiId: !Ref AppApiGateway
 
+    CMSWafAcl:
+      Type: 'AWS::WAFv2::WebACL'
+      DependsOn: 'WafIPRuleSet'
+      Properties:
+        Name: ${sls:stage}-infra-api-webacl
+        DefaultAction:
+          Block: {}
+        Scope: REGIONAL
+        VisibilityConfig:
+          CloudWatchMetricsEnabled: true
+          SampledRequestsEnabled: true
+          MetricName: ${sls:stage}-infra-api-webacl-webacl
+        Rules:
+          - Name: ${sls:stage}-infra-api-webacl-DDOSRateLimitRule
+            Priority: 0
+            Action:
+              Block: {}
+            Statement:
+              RateBasedStatement:
+                Limit: 5000
+                AggregateKeyType: IP
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: ${sls:stage}-infra-api-webacl-DDOSRateLimitRuleMetric
+          - Name: ${sls:stage}-infra-api-webacl-AWSCommonRule
+            Priority: 1
+            OverrideAction:
+              None: {}
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesCommonRuleSet
+                ExcludedRules: []
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: ${sls:stage}-infra-api-webacl-AWSCommonRuleMetric
+          - Name: ${sls:stage}-infra-api-webacl-AWSManagedRulesAmazonIpReputationList
+            Priority: 2
+            OverrideAction:
+              None: {}
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesAmazonIpReputationList
+                ExcludedRules: []
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: >-
+                ${sls:stage}-infra-api-webacl-AWSManagedRulesAmazonIpReputationListMetric
+          - Name: ${sls:stage}-infra-api-webacl-AWSManagedRulesKnownBadInputsRuleSet
+            Priority: 3
+            OverrideAction:
+              None: {}
+            Statement:
+              ManagedRuleGroupStatement:
+                VendorName: AWS
+                Name: AWSManagedRulesKnownBadInputsRuleSet
+                ExcludedRules: []
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: >-
+                ${sls:stage}-infra-api-webacl-AWSManagedRulesKnownBadInputsRuleSetMetric
+          - Name: ${sls:stage}-infra-api-webacl-allow-usa-plus-territories
+            Priority: 5
+            Action:
+              Allow: {}
+            Statement:
+              GeoMatchStatement:
+                CountryCodes:
+                  - GU
+                  - PR
+                  - US
+                  - UM
+                  - VI
+                  - MP
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: ${sls:stage}-infra-api-webacl-allow-usa-plus-territories-metric
+          - Name: ${sls:stage}-infra-api-webacl-allow-ips
+            Priority: 6
+            Action:
+              Allow: {}
+            Statement:
+              IPSetReferenceStatement:
+                Arn: !GetAtt WafIPRuleSet.Arn
+
+    WafIPRuleSet:
+      Type: AWS::WAFv2::IPSet
+      DependsOn: 'ApiGatewayDeployment${sls:instanceId}'
+      Properties:
+        Addresses:
+          - 172.160.0.0/11
+        Description: 'An allowlist for IP addresses to access our application'
+        IPAddressVersion: IPV4
+        Name: gha-allow-list-${sls:stage}
+        Scope: REGIONAL
+
+    # NewRelic exporting configs
     NewRelicInfraIntegrations:
       Type: AWS::IAM::Role
       Condition: CreateNRInfraMonitoring
@@ -221,35 +323,6 @@ resources:
         RoleArn: !GetAtt MetricStreamRole.Arn
         OutputFormat: 'opentelemetry0.7'
 
-    # AppApiGatewayAcl:
-    #   Type: AWS::WAFv2::WebACL
-    #   Properties:
-    #     DefaultAction:
-    #       Block: {}
-    #     Rules:
-    #       - Action:
-    #           Allow: {}
-    #         Name: ${sls:stage}-allow-usa-plus-territories
-    #         Priority: 0
-    #         Statement:
-    #           GeoMatchStatement:
-    #             CountryCodes:
-    #               - GU # Guam
-    #               - PR # Puerto Rico
-    #               - US # USA
-    #               - UM # US Minor Outlying Islands
-    #               - VI # US Virgin Islands
-    #               - MP # Northern Mariana Islands
-    #         VisibilityConfig:
-    #           SampledRequestsEnabled: true
-    #           CloudWatchMetricsEnabled: true
-    #           MetricName: WafWebAcl
-    #     Scope: REGIONAL
-    #     VisibilityConfig:
-    #       CloudWatchMetricsEnabled: true
-    #       SampledRequestsEnabled: true
-    #       MetricName: ${sls:stage}-webacl
-
   Outputs:
     ApiGatewayRestApiId:
       Value:
@@ -264,5 +337,5 @@ resources:
     WafPluginAclArn:
       Value:
         Fn::GetAtt:
-          - WafPluginAcl
+          - CMSWafAcl
           - Arn

--- a/services/infra-api/serverless.yml
+++ b/services/infra-api/serverless.yml
@@ -172,6 +172,10 @@ resources:
             Statement:
               IPSetReferenceStatement:
                 Arn: !GetAtt WafIPRuleSet.Arn
+            VisibilityConfig:
+              CloudWatchMetricsEnabled: true
+              MetricName: ${sls:stage}-infra-api-webacl-allow-ips
+              SampledRequestsEnabled: true
 
     WafIPRuleSet:
       Type: AWS::WAFv2::IPSet

--- a/yarn.lock
+++ b/yarn.lock
@@ -6962,11 +6962,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.0.tgz#ea89004119dc42db2e1dba0f97d553f7372f6fcb"
   integrity sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==
 
-"@enterprise-cmcs/serverless-waf-plugin@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@enterprise-cmcs/serverless-waf-plugin/-/serverless-waf-plugin-1.3.0.tgz#b2f241f68218b94b62987596888730975c99b019"
-  integrity sha512-Xysp8ejNhkrxCMQ4CximHmphKO1vGt3JGKKzGs0tLX1r4yK8BdobmauX/GmDwAfrzqlHVGDRsdvvY1Grv1W0yw==
-
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"


### PR DESCRIPTION
## Summary

Since we were seeing issues with IP addresses being geo-ip'd inconsistently, and therefore traffic blocked by the CMS WAF geo-restriction rules, this add the ability to add IPs to an allowlist rule on the API gateway. This will likely be used mainly for allowing IP blocks from GitHub Actions access to `dev`. In order to accomplish this, we have to drop the WAF plugin and use the rules directly in our CloudFormation configs.

Open question: do we want this to merge into the higher environments, or do we want this to be restricted only to the dev environment (do we see the need to add IPs to an allowlist in higher environments)?

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2874

