### PR TITLE
API LaunchDarkly offline service

### DIFF
--- a/services/app-api/src/handlers/apollo_gql.ts
+++ b/services/app-api/src/handlers/apollo_gql.ts
@@ -287,7 +287,7 @@ async function initializeGQLHandler(): Promise<Handler> {
         launchDarkly = ldService(ldClient)
     } catch (err) {
         console.error(
-            `LaunchDarkly Error: ${err.message} Defaulting to LaunchDarkly offline service.`
+            `LaunchDarkly Error: ${err.message} Falling back to LaunchDarkly offline service.`
         )
         ldClient.close()
         launchDarkly = offlineLDService()

--- a/services/app-api/src/launchDarkly/launchDarkly.ts
+++ b/services/app-api/src/launchDarkly/launchDarkly.ts
@@ -1,28 +1,60 @@
-import { UserType } from '../domain-models'
 import {
+    featureFlagEnums,
+    featureFlags,
     FeatureFlagTypes,
     FlagValueTypes,
 } from '../../../app-web/src/common-code/featureFlags'
 import { LDClient } from 'launchdarkly-node-server-sdk'
+import { Context } from '../handlers/apollo_gql'
+import { logError } from '../logger'
+import { setErrorAttributesOnActiveSpan } from '../resolvers/attributeHelper'
+
+type FeatureFlagObject = Record<FeatureFlagTypes, FlagValueTypes>
+
+//Set up default feature flag values used to returned data
+const defaultFeatureFlags: FeatureFlagObject = featureFlagEnums.reduce(
+    (a, c) => {
+        const flag = featureFlags[c].flag
+        const defaultValue = featureFlags[c].defaultValue
+        return Object.assign(a, { [flag]: defaultValue })
+    },
+    {} as FeatureFlagObject
+)
 
 type LDService = {
     getFeatureFlag: (
-        user: UserType,
+        context: Context,
         flag: FeatureFlagTypes
     ) => Promise<FlagValueTypes>
 }
 
 function ldService(ldClient: LDClient): LDService {
     return {
-        getFeatureFlag: async (user, flag) => {
-            const context = {
+        getFeatureFlag: async (context, flag) => {
+            const ldContext = {
                 kind: 'user',
-                key: user.email,
+                key: context.user.email,
             }
-            return await ldClient.variation(flag, context, false)
+            return await ldClient.variation(flag, ldContext, false)
         },
     }
 }
 
-export { ldService }
-export type { LDService }
+function offlineLDService(): LDService {
+    return {
+        getFeatureFlag: async (context, flag) => {
+            logError(
+                'getFeatureFlag',
+                `No connection to LaunchDarkly, fallback to offlineLDService with default value for ${flag}`
+            )
+            setErrorAttributesOnActiveSpan(
+                `No connection to LaunchDarkly, fallback to offlineLDService with default value for ${flag}`,
+                context.span
+            )
+            return defaultFeatureFlags[flag]
+        },
+    }
+}
+
+export { ldService, offlineLDService, defaultFeatureFlags }
+export type { LDService, FeatureFlagObject }

--- a/services/app-api/src/resolvers/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/submitHealthPlanPackage.ts
@@ -144,7 +144,7 @@ export function submitHealthPlanPackageResolver(
         span?.setAttribute('mcreview.package_id', pkgID)
 
         const rateCertAssuranceFlag = await launchDarkly.getFeatureFlag(
-            user,
+            context,
             'rate-cert-assurance'
         )
 

--- a/services/app-api/src/testHelpers/launchDarklyHelpers.ts
+++ b/services/app-api/src/testHelpers/launchDarklyHelpers.ts
@@ -1,22 +1,13 @@
 import { LDService } from '../launchDarkly/launchDarkly'
 import {
-    featureFlags,
-    featureFlagEnums,
     FeatureFlagTypes,
     FlagValueTypes,
 } from 'app-web/src/common-code/featureFlags'
 
-type FeatureFlagObject = Record<FeatureFlagTypes, FlagValueTypes>
-
-//Set up default feature flag values used to returned data
-const defaultFeatureFlags: FeatureFlagObject = featureFlagEnums.reduce(
-    (a, c) => {
-        const flag = featureFlags[c].flag
-        const defaultValue = featureFlags[c].defaultValue
-        return Object.assign(a, { [flag]: defaultValue })
-    },
-    {} as FeatureFlagObject
-)
+import {
+    defaultFeatureFlags,
+    FeatureFlagObject,
+} from '../launchDarkly/launchDarkly'
 
 function testLDService(
     mockFeatureFlags?: Partial<FeatureFlagObject>


### PR DESCRIPTION
## Summary

API was originally throwing an error when LaunchDarkly client failed initialization and stopping `initializeGQLHandler()` from finishing. This stops the API meaning the app will not function without LaunchDarkly client initialization, which does not follow the pattern of using a fallback when LaunchDarkly is not available. 

This PR is to add a LaunchDarkly offline service if  LaunchDarkly client failed initialization. The offline service `offlineLDService` will use default values in `featureFlags.ts` to generate default flags values for use and log to NR indicating no connection to LaunchDarkly and using the fallback `offlineLDService`.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
