### PR TITLE
Fix failing unlockResubmit cypress test.

### DIFF
--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -169,7 +169,9 @@ describe('CMS user', () => {
                 cy.get('table')
                     .findByRole('link', { name: submissionName })
                     .should('exist')
-                    .click()
+                    .as('submissionLink').click()
+
+                cy.get('@submissionLink').click()
 
                 cy.wait('@fetchHealthPlanPackageQuery', { timeout: 50000 })
                 cy.findByTestId('updatedSubmissionBanner').should('exist')


### PR DESCRIPTION
## Summary

`unlockResubmit.spec.ts` failing at the same spot with a different error message. Trying suggested fix.

![Screenshot 2023-01-04 at 11 43 24 AM](https://user-images.githubusercontent.com/98117700/210605780-4c4cc6e8-206a-4a9f-ac9d-640692554d9d.png)


#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
