### PR TITLE
Memoize column data in reactTable to avoid re-mounting table cells

### DIFF
--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -100,90 +100,93 @@ export const HealthPlanPackageTable = ({
         React.useState<ColumnFiltersState>([])
     const columnHelper = createColumnHelper<PackageInDashboardType>()
 
-    const tableColumns = [
-        columnHelper.accessor((row) => row, {
-            header: 'ID',
-            cell: (info) => (
-                <Link
-                    key={`submission-id-${info.getValue().id}`}
-                    asCustom={NavLink}
-                    to={submissionURL(
-                        info.getValue().id,
-                        info.getValue().status,
-                        user.__typename
-                    )}
-                >
-                    {info.getValue().name}
-                </Link>
-            ),
-            meta: {
-                dataTestID: 'submission-id',
-            },
-        }),
-        columnHelper.accessor('stateName', {
-            id: 'stateName',
-            header: 'State',
-            cell: (info) => <span>{info.getValue()}</span>,
-            meta: {
-                dataTestID: 'submission-stateName',
-            },
-            filterFn: `arrIncludesSome`,
-        }),
-        columnHelper.accessor('submissionType', {
-            id: 'submissionType',
-            header: 'Submission type',
-            cell: (info) => <span>{info.getValue()}</span>,
-            meta: {
-                dataTestID: 'submission-type',
-            },
-            filterFn: `arrIncludesSome`,
-        }),
-        columnHelper.accessor('programs', {
-            header: 'Programs',
-            cell: (info) =>
-                info.getValue().map((program) => {
-                    return (
-                        <Tag
-                            data-testid="program-tag"
-                            key={program.id}
-                            className={`radius-pill ${styles.programTag}`}
-                        >
-                            {program.name}
-                        </Tag>
-                    )
-                }),
-            meta: {
-                dataTestID: 'submission-programs',
-            },
-        }),
-        columnHelper.accessor('submittedAt', {
-            header: 'Submission date',
-            cell: (info) =>
-                info.getValue()
-                    ? dayjs(info.getValue()).format('MM/DD/YYYY')
-                    : '',
-            meta: {
-                dataTestID: 'submission-date',
-            },
-        }),
-        columnHelper.accessor('updatedAt', {
-            header: 'Last updated',
-            cell: (info) =>
-                info.getValue()
-                    ? dayjs(info.getValue()).format('MM/DD/YYYY')
-                    : '',
-            meta: {
-                dataTestID: 'submission-last-updated',
-            },
-        }),
-        columnHelper.accessor('status', {
-            header: 'Status',
-            cell: (info) => <StatusTag status={info.getValue()} />,
-            meta: {
-                dataTestID: 'submission-status',
-            },
-        }),
-    ]
+    const tableColumns = React.useMemo(
+        () => [
+            columnHelper.accessor((row) => row, {
+                header: 'ID',
+                cell: (info) => (
+                    <Link
+                        key={`submission-id-${info.getValue().id}`}
+                        asCustom={NavLink}
+                        to={submissionURL(
+                            info.getValue().id,
+                            info.getValue().status,
+                            user.__typename
+                        )}
+                    >
+                        {info.getValue().name}
+                    </Link>
+                ),
+                meta: {
+                    dataTestID: 'submission-id',
+                },
+            }),
+            columnHelper.accessor('stateName', {
+                id: 'stateName',
+                header: 'State',
+                cell: (info) => <span>{info.getValue()}</span>,
+                meta: {
+                    dataTestID: 'submission-stateName',
+                },
+                filterFn: `arrIncludesSome`,
+            }),
+            columnHelper.accessor('submissionType', {
+                id: 'submissionType',
+                header: 'Submission type',
+                cell: (info) => <span>{info.getValue()}</span>,
+                meta: {
+                    dataTestID: 'submission-type',
+                },
+                filterFn: `arrIncludesSome`,
+            }),
+            columnHelper.accessor('programs', {
+                header: 'Programs',
+                cell: (info) =>
+                    info.getValue().map((program) => {
+                        return (
+                            <Tag
+                                data-testid="program-tag"
+                                key={program.id}
+                                className={`radius-pill ${styles.programTag}`}
+                            >
+                                {program.name}
+                            </Tag>
+                        )
+                    }),
+                meta: {
+                    dataTestID: 'submission-programs',
+                },
+            }),
+            columnHelper.accessor('submittedAt', {
+                header: 'Submission date',
+                cell: (info) =>
+                    info.getValue()
+                        ? dayjs(info.getValue()).format('MM/DD/YYYY')
+                        : '',
+                meta: {
+                    dataTestID: 'submission-date',
+                },
+            }),
+            columnHelper.accessor('updatedAt', {
+                header: 'Last updated',
+                cell: (info) =>
+                    info.getValue()
+                        ? dayjs(info.getValue()).format('MM/DD/YYYY')
+                        : '',
+                meta: {
+                    dataTestID: 'submission-last-updated',
+                },
+            }),
+            columnHelper.accessor('status', {
+                header: 'Status',
+                cell: (info) => <StatusTag status={info.getValue()} />,
+                meta: {
+                    dataTestID: 'submission-status',
+                },
+            }),
+        ],
+        [columnHelper, user]
+    )
 
     const reactTable = useReactTable({
         data: tableData.sort((a, b) =>

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.tsx
@@ -66,7 +66,7 @@ export const StateDashboard = (): React.ReactElement => {
                 getCurrentRevisionFromHealthPlanPackage(sub)
 
             if (currentRevisionDataOrError instanceof Error) {
-                return null
+                return
             }
             const [_, currentSubmissionData] = currentRevisionDataOrError
 


### PR DESCRIPTION
## Summary

This should fix our flakey Cypress click in the unlockResubmit test.

Without memozing the column data structure, it’s re-creating it on every render, and I _think_ since that includes all the cell() functions that is causing react to re-mount all our cells on every render. By memoizing, react won’t lose track of the elements
