### PR TITLE
MR-2881: Add count text for filters

### DIFF
--- a/services/app-web/src/common-code/formatters/pluralizer.ts
+++ b/services/app-web/src/common-code/formatters/pluralizer.ts
@@ -1,11 +1,11 @@
 export const pluralize = (word: string, count: number): string => {
-    const isPlural = count !== 1;
+    const isPlural = count !== 1
     switch (word) {
-        case "do":
-            return isPlural ? "do" : "does";
-        case "does":
-            return isPlural ? "do" : "does";
+        case 'do':
+            return isPlural ? 'do' : 'does'
+        case 'does':
+            return isPlural ? 'do' : 'does'
         default:
-            return isPlural ? word + "s" : word;
+            return isPlural ? word + 's' : word
     }
 }

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.module.scss
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.module.scss
@@ -2,21 +2,21 @@
 @import '../../styles/custom.scss';
 
 .panelEmptyNoFilteredResults {
-  margin-top: units(8);
+    margin-top: units(8);
 
-  h3 {
-    font-size: 1rem;
-    font-weight: font-weight('bold');
-    text-align: center;
-  }
-  p {
-    font-weight: font-weight('normal');
-    font-size: .875rem;
-    text-align: center;
-  }
+    h3 {
+        font-size: 1rem;
+        font-weight: font-weight('bold');
+        text-align: center;
+    }
+    p {
+        font-weight: font-weight('normal');
+        font-size: 0.875rem;
+        text-align: center;
+    }
 }
 
-.panelEmptyNoSubmissionsYet{
+.panelEmptyNoSubmissionsYet {
     margin-top: units(8);
 
     h3 {
@@ -44,4 +44,10 @@
 .unlockedTag {
     background: #99deea;
     color: $theme-color-base-ink;
+}
+
+.filterCount {
+    font-weight: font-weight('bold');
+    color: $theme-color-base-ink;
+    padding-top: units(3);
 }

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -111,7 +111,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(screen.getByRole('table')).toBeInTheDocument()
         //Expect 5 rows. 4 data rows and 1 header row
         expect(rows).toHaveLength(5)
-        expect(screen.getByText('4 items')).toBeInTheDocument()
+        expect(screen.getByText('4 submissions')).toBeInTheDocument()
     })
 
     it('displays no submission text when no submitted packages exist', async () => {
@@ -342,7 +342,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(2)
         expect(rows[1]).toHaveTextContent('Ohio') // row[0] is the header
-        expect(screen.getByText('Displaying 1 of 4 items')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 1 of 4 submissions')
+        ).toBeInTheDocument()
     })
 
     it('can filter by state and submission type', async () => {
@@ -445,7 +447,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(rows[1]).toHaveTextContent(
             'Contract action and rate certification'
         ) // row[0] is the header
-        expect(screen.getByText('Displaying 1 of 3 items')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 1 of 3 submissions')
+        ).toBeInTheDocument()
     })
 
     it('should clear all filters when clear filter button is clicked', async () => {
@@ -534,7 +538,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         //Expect 3 data rows and 1 header row, total 4 rows
         await userEvent.click(clearFiltersButton)
         expect(await screen.findAllByRole('row')).toHaveLength(4)
-        expect(screen.getByText('3 items')).toBeInTheDocument()
+        expect(screen.getByText('3 submissions')).toBeInTheDocument()
     })
 
     it('displays no results found when filters return no results', async () => {
@@ -604,8 +608,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(1)
         expect(screen.getByText('No results found')).toBeInTheDocument()
-        // no filter count message when no results
-        expect(screen.queryByText('items')).not.toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 0 of 4 submissions')
+        ).toBeInTheDocument()
     })
 
     it('displays the total filters applied', async () => {
@@ -730,7 +735,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(rows).toHaveLength(4)
         //Expect 3 applied filters text
         expect(screen.getByText('Filters (3 applied)')).toBeInTheDocument()
-        expect(screen.getByText('Displaying 3 of 4 items')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 3 of 4 submissions')
+        ).toBeInTheDocument()
     })
 })
 

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -111,6 +111,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(screen.getByRole('table')).toBeInTheDocument()
         //Expect 5 rows. 4 data rows and 1 header row
         expect(rows).toHaveLength(5)
+        expect(screen.getByText('4 items')).toBeInTheDocument()
     })
 
     it('displays no submission text when no submitted packages exist', async () => {
@@ -341,6 +342,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(2)
         expect(rows[1]).toHaveTextContent('Ohio') // row[0] is the header
+        expect(screen.getByText('Displaying 1 of 4 items')).toBeInTheDocument()
     })
 
     it('can filter by state and submission type', async () => {
@@ -443,6 +445,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(rows[1]).toHaveTextContent(
             'Contract action and rate certification'
         ) // row[0] is the header
+        expect(screen.getByText('Displaying 1 of 3 items')).toBeInTheDocument()
     })
 
     it('should clear all filters when clear filter button is clicked', async () => {
@@ -531,6 +534,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         //Expect 3 data rows and 1 header row, total 4 rows
         await userEvent.click(clearFiltersButton)
         expect(await screen.findAllByRole('row')).toHaveLength(4)
+        expect(screen.getByText('3 items')).toBeInTheDocument()
     })
 
     it('displays no results found when filters return no results', async () => {
@@ -600,6 +604,8 @@ describe('HealthPlanPackageTable cms user tests', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(1)
         expect(screen.getByText('No results found')).toBeInTheDocument()
+        // no filter count message when no results
+        expect(screen.queryByText('items')).not.toBeInTheDocument()
     })
 
     it('displays the total filters applied', async () => {
@@ -724,6 +730,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(rows).toHaveLength(4)
         //Expect 3 applied filters text
         expect(screen.getByText('Filters (3 applied)')).toBeInTheDocument()
+        expect(screen.getByText('Displaying 3 of 4 items')).toBeInTheDocument()
     })
 })
 

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -18,6 +18,7 @@ import dayjs from 'dayjs'
 import { SubmissionStatusRecord } from '../../constants/healthPlanPackages'
 import { FilterAccordion, FilterSelect } from '../FilterAccordion'
 import { InfoTag, TagProps } from '../InfoTag/InfoTag'
+import { pluralize } from '../../common-code/formatters'
 
 declare module '@tanstack/table-core' {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -267,10 +268,16 @@ export const HealthPlanPackageTable = ({
                     {
                         <div className={styles.filterCount}>
                             {!hasAppliedFilters
-                                ? `${tableData.length} items`
-                                : hasFilteredRows
-                                ? `Displaying ${filteredRows.length} of ${tableData.length} items`
-                                : undefined}
+                                ? `${tableData.length} ${pluralize(
+                                      'submission',
+                                      tableData.length
+                                  )}`
+                                : `Displaying ${filteredRows.length} of ${
+                                      tableData.length
+                                  } ${pluralize(
+                                      'submission',
+                                      tableData.length
+                                  )}`}
                         </div>
                     }
                     <Table fullWidth>

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -204,6 +204,10 @@ export const HealthPlanPackageTable = ({
         getSortedRowModel: getSortedRowModel(),
     })
 
+    const hasAppliedFilters = columnFilters.length > 0
+    const filteredRows = reactTable.getRowModel().rows
+    const hasFilteredRows = filteredRows.length > 0
+
     const stateColumn = reactTable.getColumn('stateName')
     const submissionTypeColumn = reactTable.getColumn('submissionType')
 
@@ -216,7 +220,7 @@ export const HealthPlanPackageTable = ({
     }))
 
     const filterTitle = `Filters ${
-        columnFilters.length
+        hasAppliedFilters
             ? `(${
                   columnFilters.flatMap((filter) => filter.value).length
               } applied)`
@@ -260,6 +264,15 @@ export const HealthPlanPackageTable = ({
                             />
                         </FilterAccordion>
                     )}
+                    {
+                        <div className={styles.filterCount}>
+                            {!hasAppliedFilters
+                                ? `${tableData.length} items`
+                                : hasFilteredRows
+                                ? `Displaying ${filteredRows.length} of ${tableData.length} items`
+                                : undefined}
+                        </div>
+                    }
                     <Table fullWidth>
                         <thead>
                             {reactTable.getHeaderGroups().map((headerGroup) => (
@@ -279,7 +292,7 @@ export const HealthPlanPackageTable = ({
                             ))}
                         </thead>
                         <tbody>
-                            {reactTable.getRowModel().rows.map((row) => (
+                            {filteredRows.map((row) => (
                                 <tr
                                     key={row.id}
                                     data-testid={`row-${row.original.id}`}
@@ -302,7 +315,7 @@ export const HealthPlanPackageTable = ({
                             ))}
                         </tbody>
                     </Table>
-                    {!reactTable.getRowModel().rows.length && (
+                    {!hasFilteredRows && (
                         <div
                             data-testid="dashboard-table"
                             className={styles.panelEmptyNoFilteredResults}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15010,7 +15010,7 @@ cacache@^15.0.5:
     tar "^6.0.2"
     unique-filename "^1.1.1"
 
-cacache@^16.0.0, cacache@^16.0.6:
+cacache@^16.0.0, cacache@^16.0.6, cacache@^16.1.0:
   version "16.1.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-16.1.3.tgz#a02b9f34ecfaf9a78c9f4bc16fceb94d5d67a38e"
   integrity sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==


### PR DESCRIPTION
## Summary

We want to display a bit of text when users are using filters, so that they either see a total count of submissions, when no filters are applied, or a x of y count, when some are.  There should be no message when filters are applied but don't return anything.


#### Screenshots

<img width="206" alt="image" src="https://user-images.githubusercontent.com/8964335/210651873-17c06871-0ccf-4a85-8d97-787dfe517a14.png">
<img width="228" alt="image" src="https://user-images.githubusercontent.com/8964335/210651899-3d64a1ad-9bea-4121-8124-d1970353aa7f.png">
<img width="767" alt="image" src="https://user-images.githubusercontent.com/8964335/210651940-68d9979a-593e-4a56-9212-5ed382a74ade.png">


#### Test cases covered

Added lines to existing filter tests to also check the text when we filter.
