### PR TITLE
fix: MR-2542 Ensure that trailing spaces in email address inputs do not trigger errors

### DIFF
--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.module.scss
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.module.scss
@@ -1,0 +1,5 @@
+.nestedField {
+    label {
+        font-weight: normal
+    }
+}

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.test.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.test.tsx
@@ -2,6 +2,7 @@ import { screen, render } from '@testing-library/react'
 import { FieldTextInput } from './FieldTextInput'
 
 const mockOnChange = jest.fn()
+const mockOnBlur = jest.fn()
 const mockSetValue = jest.fn()
 
 // mock out formik hook as we are not testing formik
@@ -14,6 +15,7 @@ jest.mock('formik', () => {
         useField: () => [
             {
                 onChange: mockOnChange,
+                onBlur: mockOnBlur,
             },
             {
                 touched: true,

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
@@ -3,6 +3,8 @@ import { useField } from 'formik'
 import { Label, TextInput, FormGroup } from '@trussworks/react-uswds'
 import { PoliteErrorMessage } from '../../'
 
+import styles from './FieldTextInput.module.scss'
+import classNames from 'classnames'
 /**
  * This component renders a ReactUSWDS TextInput component inside of a FormGroup,
  * with a Label and ErrorMessage.
@@ -16,16 +18,19 @@ import { PoliteErrorMessage } from '../../'
 
 export type TextInputProps = {
     label: string
+    variant?: 'TOPLEVEL' | 'SUBHEAD' // subhead used for forms where fields could be nested under a larger heading or label
     id: string
     hint?: React.ReactNode
     error?: string
     showError: boolean
     name: string
     type: 'text' | 'email' | 'number' | 'password' | 'search' | 'tel' | 'url'
-} & JSX.IntrinsicElements['input']
+} & React.ComponentProps<typeof TextInput>
 
 export const FieldTextInput = ({
+    className,
     label,
+    variant = 'TOPLEVEL',
     id,
     hint,
     error,
@@ -35,8 +40,16 @@ export const FieldTextInput = ({
     ...inputProps
 }: TextInputProps): React.ReactElement => {
     const [field, meta] = useField({ name })
+
+    const classes = classNames(
+        {
+            [styles.nestedField]: variant === 'SUBHEAD',
+        },
+        className
+    )
+
     return (
-        <FormGroup error={showError}>
+        <FormGroup error={showError} className={classes}>
             <Label htmlFor={id} error={showError}>
                 {label}
             </Label>
@@ -44,7 +57,11 @@ export const FieldTextInput = ({
                 <PoliteErrorMessage>{meta.error}</PoliteErrorMessage>
             )}
             {hint && (
-                <div role="note" aria-labelledby={id} className="usa-hint margin-top-1">
+                <div
+                    role="note"
+                    aria-labelledby={id}
+                    className="usa-hint margin-top-1"
+                >
                     {hint}
                 </div>
             )}

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
@@ -40,7 +40,7 @@ export const FieldTextInput = ({
     onBlur,
     ...inputProps
 }: TextInputProps): React.ReactElement => {
-    const [field, meta, helpers] = useField({ name })
+    const [field, meta] = useField({ name })
 
     const classes = classNames(
         {
@@ -53,7 +53,7 @@ export const FieldTextInput = ({
     // Initial use case is to trim away trailing whitespace in email addresses
     const customOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
         if (!e) return
-        helpers.setValue(field.value.trim())
+        e.currentTarget.value = field.value.trim()
         if (onBlur) onBlur(e)
     }
 

--- a/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
+++ b/services/app-web/src/components/Form/FieldTextInput/FieldTextInput.tsx
@@ -37,9 +37,10 @@ export const FieldTextInput = ({
     showError,
     name,
     type,
+    onBlur,
     ...inputProps
 }: TextInputProps): React.ReactElement => {
-    const [field, meta] = useField({ name })
+    const [field, meta, helpers] = useField({ name })
 
     const classes = classNames(
         {
@@ -47,6 +48,14 @@ export const FieldTextInput = ({
         },
         className
     )
+
+    // Latch into onBlur to do any input cleaning
+    // Initial use case is to trim away trailing whitespace in email addresses
+    const customOnBlur = (e: React.FocusEvent<HTMLInputElement, Element>) => {
+        if (!e) return
+        helpers.setValue(field.value.trim())
+        if (onBlur) onBlur(e)
+    }
 
     return (
         <FormGroup error={showError} className={classes}>
@@ -72,6 +81,7 @@ export const FieldTextInput = ({
                 name={name}
                 error={showError}
                 type={type}
+                onBlur={customOnBlur}
             />
         </FormGroup>
     )

--- a/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.tsx
+++ b/services/app-web/src/components/Form/FieldTextarea/FieldTextarea.tsx
@@ -30,9 +30,21 @@ export const FieldTextarea = ({
     error,
     showError,
     name,
+    onBlur,
     ...inputProps
 }: TextAreaProps): React.ReactElement => {
     const [field, meta] = useField({ name })
+
+    // Latch into onBlur to do any input cleaning
+    // Initial use case is to trim away trailing whitespace in email addresses
+    const customOnBlur = (
+        e: React.FocusEvent<HTMLTextAreaElement, Element>
+    ) => {
+        if (!e) return
+        e.currentTarget.value = field.value.trim()
+        if (onBlur) onBlur(e)
+    }
+
     return (
         <FormGroup error={showError}>
             <Label htmlFor={id} error={showError}>
@@ -42,7 +54,11 @@ export const FieldTextarea = ({
                 <PoliteErrorMessage>{meta.error}</PoliteErrorMessage>
             )}
             {hint && (
-                <div role="note" aria-labelledby={id} className="usa-hint margin-top-1">
+                <div
+                    role="note"
+                    aria-labelledby={id}
+                    className="usa-hint margin-top-1"
+                >
                     {hint}
                 </div>
             )}
@@ -52,6 +68,7 @@ export const FieldTextarea = ({
                 id={id}
                 name={name}
                 error={showError}
+                onBlur={customOnBlur}
             />
         </FormGroup>
     )

--- a/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.stories.tsx
+++ b/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.stories.tsx
@@ -28,7 +28,7 @@ const Template: Story<YesNoStoryParams> = (args) => {
         <Formik
             initialValues={args.initialValues}
             validationSchema={storyFormikSchema}
-            onSubmit={(values) => console.log('submitted', values)}
+            onSubmit={(values) => console.info('submitted', values)}
             validateOnMount={true}
         >
             <form>
@@ -48,7 +48,7 @@ Default.args = {
             name: 'modifiedBenefitsProvided',
             id: 'modifiedBenefitsProvided',
             label: 'Benefits provided have been modified',
-            variant: 'PRIMARY',
+            variant: 'TOPLEVEL',
         },
     ],
     initialValues: {
@@ -81,21 +81,21 @@ SecondaryVariantWithMultipleFields.args = {
             id: 'modifiedBenefitsProvided',
             label: 'Benefits provided by the managed care plans',
             showError: false,
-            variant: 'SECONDARY',
+            variant: 'SUBHEAD',
         },
         {
             name: 'modifiedGeoArea',
             id: 'modifiedGeoArea',
             label: 'Geographic areas served by the managed care plans',
             showError: true,
-            variant: 'SECONDARY',
+            variant: 'SUBHEAD',
         },
         {
             name: 'modifiedSomething',
             id: 'modifiedSomething',
             label: 'Medicaid beneficiaries served by the managed care plans (e.g. eligibility or enrollment criteria)',
             showError: true,
-            variant: 'SECONDARY',
+            variant: 'SUBHEAD',
         },
     ],
     initialValues: {

--- a/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
+++ b/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
@@ -23,7 +23,7 @@ export type FieldYesNoProps = {
     hint?: React.ReactNode
     showError?: boolean
     id: string
-    variant?: 'PRIMARY' | 'SECONDARY' // secondary variant used for nested fields yes/no fields under an overarching heading
+    variant?: 'TOPLEVEL' | 'SUBHEAD' // subhead variant used for nested fields yes/no fields under an overarching heading
 } & JSX.IntrinsicElements['input']
 
 export type FieldYesNoFormValue = 'YES' | 'NO' | undefined // Use for formik string value
@@ -48,7 +48,7 @@ export const FieldYesNo = ({
     label,
     hint,
     showError = false,
-    variant = 'PRIMARY',
+    variant = 'TOPLEVEL',
     id,
     className,
     ...inputProps
@@ -57,7 +57,7 @@ export const FieldYesNo = ({
 
     const classes = classNames(
         {
-            [styles.yesnofieldsecondary]: variant === 'SECONDARY',
+            [styles.yesnofieldsecondary]: variant === 'SUBHEAD',
         },
         className
     )

--- a/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/ActuaryContactFields.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ActuaryContact } from '../../../common-code/healthPlanFormDataType'
 import { Field, FormikErrors, FormikValues, getIn } from 'formik'
 import { Fieldset, FormGroup } from '@trussworks/react-uswds'
-import { FieldRadio } from '../../../components/Form'
+import { FieldRadio, FieldTextInput } from '../../../components/Form'
 import { RateInfoFormType } from '../RateDetails/RateDetails'
 import { PoliteErrorMessage } from '../../../components/PoliteErrorMessage'
 
@@ -15,7 +15,7 @@ type ActuaryFormPropType = {
     shouldValidate: boolean
     fieldNamePrefix: string
     fieldSetLegend?: string
-    innerRef?: (el: HTMLElement) => void
+    inputRef?: React.MutableRefObject<HTMLInputElement | null>
 }
 
 export const ActuaryContactFields = ({
@@ -24,7 +24,7 @@ export const ActuaryContactFields = ({
     shouldValidate,
     fieldNamePrefix,
     fieldSetLegend = 'Actuary Contact',
-    innerRef,
+    inputRef,
 }: ActuaryFormPropType) => {
     const showFieldErrors = (error?: FormError) =>
         shouldValidate && Boolean(error)
@@ -35,70 +35,44 @@ export const ActuaryContactFields = ({
 
     return (
         <Fieldset legend={fieldSetLegend}>
-            <FormGroup
-                error={showFieldErrors(
-                    getIn(errors, `${fieldNamePrefix}.name`)
+            <FieldTextInput
+                name={`${fieldNamePrefix}.name`}
+                id={`${fieldNamePrefix}.name`}
+                label="Name"
+                aria-required={false}
+                showError={Boolean(
+                    showFieldErrors(getIn(errors, `${fieldNamePrefix}.name`))
                 )}
-            >
-                <label htmlFor={`${fieldNamePrefix}.name`}>Name</label>
-                {showFieldErrors(getIn(errors, `${fieldNamePrefix}.name`)) && (
-                    <PoliteErrorMessage>
-                        {getIn(errors, `${fieldNamePrefix}.name`)}
-                    </PoliteErrorMessage>
-                )}
-                <Field
-                    name={`${fieldNamePrefix}.name`}
-                    id={`${fieldNamePrefix}.name`}
-                    aria-required
-                    type="text"
-                    className="usa-input"
-                    innerRef={innerRef}
-                />
-            </FormGroup>
+                type="text"
+                inputRef={inputRef}
+                variant="SUBHEAD"
+            />
 
-            <FormGroup
-                error={showFieldErrors(
-                    getIn(errors, `${fieldNamePrefix}.titleRole`)
+            <FieldTextInput
+                name={`${fieldNamePrefix}.titleRole`}
+                id={`${fieldNamePrefix}.titleRole`}
+                label="Title/Role"
+                aria-required={false}
+                showError={Boolean(
+                    showFieldErrors(
+                        getIn(errors, `${fieldNamePrefix}.titleRole`)
+                    )
                 )}
-            >
-                <label htmlFor={`${fieldNamePrefix}.titleRole`}>
-                    Title/Role
-                </label>
-                {showFieldErrors(
-                    getIn(errors, `${fieldNamePrefix}.titleRole`)
-                ) && (
-                    <PoliteErrorMessage>
-                        {getIn(errors, `${fieldNamePrefix}.titleRole`)}
-                    </PoliteErrorMessage>
-                )}
-                <Field
-                    name={`${fieldNamePrefix}.titleRole`}
-                    id={`${fieldNamePrefix}.titleRole`}
-                    aria-required
-                    type="text"
-                    className="usa-input"
-                />
-            </FormGroup>
+                type="text"
+                variant="SUBHEAD"
+            />
 
-            <FormGroup
-                error={showFieldErrors(
-                    getIn(errors, `${fieldNamePrefix}.email`)
+            <FieldTextInput
+                name={`${fieldNamePrefix}.email`}
+                id={`${fieldNamePrefix}.email`}
+                label="Email"
+                aria-required={false}
+                showError={Boolean(
+                    showFieldErrors(getIn(errors, `${fieldNamePrefix}.email`))
                 )}
-            >
-                <label htmlFor={`${fieldNamePrefix}.email`}>Email</label>
-                {showFieldErrors(getIn(errors, `${fieldNamePrefix}.email`)) && (
-                    <PoliteErrorMessage>
-                        {getIn(errors, `${fieldNamePrefix}.email`)}
-                    </PoliteErrorMessage>
-                )}
-                <Field
-                    name={`${fieldNamePrefix}.email`}
-                    id={`${fieldNamePrefix}.email`}
-                    aria-required
-                    type="text"
-                    className="usa-input"
-                />
-            </FormGroup>
+                type="email"
+                variant="SUBHEAD"
+            />
 
             <FormGroup
                 error={showFieldErrors(

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
@@ -118,6 +118,42 @@ describe('Contacts', () => {
         expect(screen.getByLabelText('Email')).toHaveValue('test@test.com')
     })
 
+    it('should not error if whitespace added to email addresses', async () => {
+        const mock = mockDraft()
+        const mockUpdateDraftFn = jest.fn()
+
+        renderWithProviders(
+            <Contacts draftSubmission={mock} updateDraft={mockUpdateDraftFn} />,
+            {
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        screen.getAllByLabelText('Name')[0].focus()
+        await userEvent.paste('State Contact Person')
+
+        screen.getAllByLabelText('Title/Role')[0].focus()
+        await userEvent.paste('State Contact Title')
+
+        screen.getAllByLabelText('Email')[0].focus()
+        await userEvent.paste('statecontactwithtrailingwhitespace@test.com  ')
+
+        const continueButton = screen.getByRole('button', {
+            name: 'Continue',
+        })
+
+        continueButton.click()
+
+        await waitFor(() => {
+            expect(screen.queryAllByTestId('errorMessage')).toHaveLength(0)
+            expect(
+                screen.queryByText(/You must enter a valid email address/)
+            ).toBeNull()
+        })
+    })
+
     it('should error and not continue if state contacts are not filled out', async () => {
         const mock = mockDraft()
         const mockUpdateDraftFn = jest.fn()

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.test.tsx
@@ -147,10 +147,23 @@ describe('Contacts', () => {
         continueButton.click()
 
         await waitFor(() => {
+            // check that validations won't error
             expect(screen.queryAllByTestId('errorMessage')).toHaveLength(0)
             expect(
                 screen.queryByText(/You must enter a valid email address/)
             ).toBeNull()
+
+            // check that display value is trimmed which is default behavior for FieldTextInput
+            expect(
+                screen.queryByDisplayValue(
+                    'statecontactwithtrailingwhitespace@test.com  '
+                )
+            ).toBeNull()
+            expect(
+                screen.getByDisplayValue(
+                    'statecontactwithtrailingwhitespace@test.com'
+                )
+            ).toBeInTheDocument()
         })
     })
 

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -10,9 +10,10 @@ import {
     Formik,
     FormikErrors,
     FormikHelpers,
-    Field,
     FieldArray,
+    Field,
     ErrorMessage,
+    getIn,
 } from 'formik'
 import { useNavigate } from 'react-router-dom'
 
@@ -23,12 +24,17 @@ import {
     ActuaryCommunicationType,
 } from '../../../common-code/healthPlanFormDataType'
 
-import { ErrorSummary, FieldRadio } from '../../../components/Form'
+import {
+    ErrorSummary,
+    FieldRadio,
+    FieldTextInput,
+} from '../../../components/Form'
 
 import { useFocus } from '../../../hooks/useFocus'
 import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { ActuaryContactFields } from './ActuaryContactFields'
+import { PoliteErrorMessage } from '../../../components'
 
 export interface ContactsFormValues {
     stateContacts: stateContactValue[]
@@ -103,19 +109,6 @@ const yupValidation = (submissionType: string) => {
 type FormError =
     FormikErrors<ContactsFormValues>[keyof FormikErrors<ContactsFormValues>]
 
-// We want to make sure we are returning the specific error
-// for a given field when we pass it through showFieldErrors
-// so this makes sure we return the actual error and if its
-// anything else we return undefined to not show it
-const stateContactErrorHandling = (
-    error: string | FormikErrors<stateContactValue> | undefined
-): FormikErrors<stateContactValue> | undefined => {
-    if (typeof error === 'string') {
-        return undefined
-    }
-    return error
-}
-
 // Convert the formik errors into a shape that can be passed to ErrorSummary
 const flattenErrors = (
     errors: FormikErrors<ContactsFormValues>
@@ -169,7 +162,7 @@ export const Contacts = ({
         React.useState(false)
 
     const redirectToDashboard = React.useRef(false)
-    const newStateContactNameRef = React.useRef<HTMLElement | null>(null) // This ref.current is reset to the newest contact name field each time new contact is added
+    const newStateContactNameRef = React.useRef<HTMLInputElement | null>(null) // This ref.current is reset to the newest contact name field each time new contact is added
     const [newStateContactButtonRef, setNewStateContactButtonFocus] = useFocus() // This ref.current is always the same element
 
     const newActuaryContactNameRef = React.useRef<HTMLElement | null>(null)
@@ -264,9 +257,7 @@ export const Contacts = ({
         values: ContactsFormValues,
         formikHelpers: FormikHelpers<ContactsFormValues>
     ) => {
-        // const updatedDraft = updatesFromSubmission(draftSubmission)
         draftSubmission.stateContacts = values.stateContacts
-
         if (includeActuaryContacts) {
             draftSubmission.addtlActuaryContacts = values.addtlActuaryContacts
             draftSubmission.addtlActuaryCommunicationPreference =
@@ -352,119 +343,64 @@ export const Contacts = ({
                                                                 'State'
                                                             )}
                                                         >
-                                                            <FormGroup
-                                                                error={showFieldErrors(
-                                                                    stateContactErrorHandling(
-                                                                        errors
-                                                                            ?.stateContacts?.[
-                                                                            index
-                                                                        ]
-                                                                    )?.name
-                                                                )}
-                                                            >
-                                                                <label
-                                                                    htmlFor={`stateContacts.${index}.name`}
-                                                                >
-                                                                    Name
-                                                                </label>
-                                                                {showFieldErrors(
-                                                                    `True`
-                                                                ) && (
-                                                                    <ErrorMessage
-                                                                        name={`stateContacts.${index}.name`}
-                                                                        component="div"
-                                                                        className="usa-error-message"
-                                                                    />
-                                                                )}
-                                                                <Field
-                                                                    name={`stateContacts.${index}.name`}
-                                                                    id={`stateContacts.${index}.name`}
-                                                                    aria-required={
-                                                                        index ===
-                                                                        0
-                                                                    }
-                                                                    type="text"
-                                                                    className="usa-input"
-                                                                    innerRef={(
-                                                                        el: HTMLElement
-                                                                    ) =>
-                                                                        (newStateContactNameRef.current =
-                                                                            el)
-                                                                    }
-                                                                />
-                                                            </FormGroup>
 
-                                                            <FormGroup
-                                                                error={showFieldErrors(
-                                                                    stateContactErrorHandling(
-                                                                        errors
-                                                                            ?.stateContacts?.[
-                                                                            index
-                                                                        ]
-                                                                    )?.titleRole
+                                                            <FieldTextInput
+                                                                id={`stateContacts.${index}.name`}
+                                                                label="Title/Role"
+                                                                name={`stateContacts.${index}.name`}
+                                                                aria-required={
+                                                                    index === 0
+                                                                }
+                                                                showError={Boolean(
+                                                                    showFieldErrors(
+                                                                        getIn(
+                                                                            errors,
+                                                                            `stateContacts.${index}.name`
+                                                                        )
+                                                                    )
                                                                 )}
-                                                            >
-                                                                <label
-                                                                    htmlFor={`stateContacts.${index}.titleRole`}
-                                                                >
-                                                                    Title/Role
-                                                                </label>
-                                                                {showFieldErrors(
-                                                                    `True`
-                                                                ) && (
-                                                                    <ErrorMessage
-                                                                        name={`stateContacts.${index}.titleRole`}
-                                                                        component="div"
-                                                                        className="usa-error-message"
-                                                                    />
-                                                                )}
-                                                                <Field
-                                                                    name={`stateContacts.${index}.titleRole`}
-                                                                    id={`stateContacts.${index}.titleRole`}
-                                                                    aria-required={
-                                                                        index ===
-                                                                        0
-                                                                    }
-                                                                    type="text"
-                                                                    className="usa-input"
-                                                                />
-                                                            </FormGroup>
+                                                                type="text"
+                                                                inputRef={newStateContactNameRef}
+                                                                variant="SUBHEAD"
+                                                            />
 
-                                                            <FormGroup
-                                                                error={showFieldErrors(
-                                                                    stateContactErrorHandling(
-                                                                        errors
-                                                                            ?.stateContacts?.[
-                                                                            index
-                                                                        ]
-                                                                    )?.email
+                                                            <FieldTextInput
+                                                                id={`stateContacts.${index}.titleRole`}
+                                                                label="Title/Role"
+                                                                name={`stateContacts.${index}.titleRole`}
+                                                                aria-required={
+                                                                    index === 0
+                                                                }
+                                                                showError={Boolean(
+                                                                    showFieldErrors(
+                                                                        getIn(
+                                                                            errors,
+                                                                            `stateContacts.${index}.titleRole`
+                                                                        )
+                                                                    )
                                                                 )}
-                                                            >
-                                                                <label
-                                                                    htmlFor={`stateContacts.${index}.email`}
-                                                                >
-                                                                    Email
-                                                                </label>
-                                                                {showFieldErrors(
-                                                                    `True`
-                                                                ) && (
-                                                                    <ErrorMessage
-                                                                        name={`stateContacts.${index}.email`}
-                                                                        component="div"
-                                                                        className="usa-error-message"
-                                                                    />
+                                                                type="text"
+                                                                variant="SUBHEAD"
+                                                            />
+
+                                                            <FieldTextInput
+                                                                id={`stateContacts.${index}.email`}
+                                                                label="Email"
+                                                                name={`stateContacts.${index}.email`}
+                                                                aria-required={
+                                                                    index === 0
+                                                                }
+                                                                showError={Boolean(
+                                                                    showFieldErrors(
+                                                                        getIn(
+                                                                            errors,
+                                                                            `stateContacts.${index}.email`
+                                                                        )
+                                                                    )
                                                                 )}
-                                                                <Field
-                                                                    name={`stateContacts.${index}.email`}
-                                                                    id={`stateContacts.${index}.email`}
-                                                                    aria-required={
-                                                                        index ===
-                                                                        0
-                                                                    }
-                                                                    type="text"
-                                                                    className="usa-input"
-                                                                />
-                                                            </FormGroup>
+                                                                type="email"
+                                                                variant="SUBHEAD"
+                                                            />
 
                                                             {index > 0 && (
                                                                 <Button

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -60,6 +60,7 @@ const yupValidation = (submissionType: string) => {
                 ),
                 email: Yup.string()
                     .email('You must enter a valid email address')
+                    .trim()
                     .required('You must provide an email address'),
             })
         ),
@@ -76,6 +77,7 @@ const yupValidation = (submissionType: string) => {
                 ),
                 email: Yup.string()
                     .email('You must enter a valid email address')
+                    .trim()
                     .required('You must provide an email address'),
                 actuarialFirm: Yup.string()
                     .required('You must select an actuarial firm')

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -11,7 +11,6 @@ import {
     FormikErrors,
     FormikHelpers,
     FieldArray,
-    Field,
     ErrorMessage,
     getIn,
 } from 'formik'
@@ -34,7 +33,6 @@ import { useFocus } from '../../../hooks/useFocus'
 import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { ActuaryContactFields } from './ActuaryContactFields'
-import { PoliteErrorMessage } from '../../../components'
 
 export interface ContactsFormValues {
     stateContacts: stateContactValue[]
@@ -165,7 +163,7 @@ export const Contacts = ({
     const newStateContactNameRef = React.useRef<HTMLInputElement | null>(null) // This ref.current is reset to the newest contact name field each time new contact is added
     const [newStateContactButtonRef, setNewStateContactButtonFocus] = useFocus() // This ref.current is always the same element
 
-    const newActuaryContactNameRef = React.useRef<HTMLElement | null>(null)
+    const newActuaryContactNameRef = React.useRef<HTMLInputElement | null>(null)
     const [newActuaryContactButtonRef, setNewActuaryContactButtonFocus] =
         useFocus()
 
@@ -343,7 +341,6 @@ export const Contacts = ({
                                                                 'State'
                                                             )}
                                                         >
-
                                                             <FieldTextInput
                                                                 id={`stateContacts.${index}.name`}
                                                                 label="Title/Role"
@@ -360,7 +357,9 @@ export const Contacts = ({
                                                                     )
                                                                 )}
                                                                 type="text"
-                                                                inputRef={newStateContactNameRef}
+                                                                inputRef={
+                                                                    newStateContactNameRef
+                                                                }
                                                                 variant="SUBHEAD"
                                                             />
 
@@ -492,11 +491,8 @@ export const Contacts = ({
                                                                         index,
                                                                         'Actuary'
                                                                     )}
-                                                                    innerRef={(
-                                                                        el: HTMLElement
-                                                                    ) =>
-                                                                        (newActuaryContactNameRef.current =
-                                                                            el)
+                                                                    inputRef={
+                                                                        newActuaryContactNameRef
                                                                     }
                                                                 />
                                                                 <Button

--- a/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
+++ b/services/app-web/src/pages/StateSubmission/Contacts/Contacts.tsx
@@ -343,7 +343,7 @@ export const Contacts = ({
                                                         >
                                                             <FieldTextInput
                                                                 id={`stateContacts.${index}.name`}
-                                                                label="Title/Role"
+                                                                label="Name"
                                                                 name={`stateContacts.${index}.name`}
                                                                 aria-required={
                                                                     index === 0

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -836,7 +836,7 @@ export const ContractDetails = ({
                                                                     modifiedProvisionName
                                                                 ]
                                                             )}
-                                                            variant="SECONDARY"
+                                                            variant="SUBHEAD"
                                                         />
                                                     )
                                                 )}


### PR DESCRIPTION
## Summary
Looking for feedback on the approach. I tried addressing the bug in two ways
- Using `.trim` in yup validations. This ensures validation error is simply not raised. See 482e326ea69c9bc0f161dbfe9ab047410aca1fe5 
- Direct remove leading and trailing whitespace from the input value itself `onBlur` to prevent this class of issue from arising, at least where our app-wide components are used . See 6ccda52dc6f5825503d1c6d447da43b887eaad4d 

Other change in this PR is slimming contacts and actuary contacts JSX by using `<FieldTextInput />` to remove extraneous markdown. 

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2542

#### Test cases covered


## QA guidance
- Besides testing bugfix to email address inputs, worth running through contacts and actuary contacts UI, make sure I didn't cause a regression here. Seems like we are testing with unit tests and Cypress pretty thoroughly here which is good to see. 
