### PR TITLE
MR-2872: filters applied announced in screenreader

### DIFF
--- a/services/app-web/src/components/FilterAccordion/FilterAccordion.tsx
+++ b/services/app-web/src/components/FilterAccordion/FilterAccordion.tsx
@@ -5,7 +5,7 @@ import { FilterSelectPropType } from './FilterSelect/FilterSelect'
 
 export interface FilterAccordionPropType {
     onClearFilters?: () => void
-    filterTitle: string
+    filterTitle: string | React.ReactNode
     children:
         | React.ReactElement<FilterSelectPropType>
         | Array<React.ReactElement<FilterSelectPropType>>
@@ -32,7 +32,7 @@ export const FilterAccordion = ({
 
     const accordionItems = [
         {
-            title: <div className={styles.filterTitle}>{filterTitle}</div>,
+            title: filterTitle,
             content: (
                 <>
                     <div className={styles.filters}>

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -695,7 +695,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         })
 
         //Expect 1 filter applied
-        expect(screen.getByText('Filters (1 applied)')).toBeInTheDocument()
+        expect(screen.getByText('1 filter applied')).toBeInTheDocument()
 
         //Open state combobox and select Ohio option
         await selectEvent.openMenu(stateCombobox)
@@ -707,7 +707,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         })
 
         //Expect 2 filter applied
-        expect(screen.getByText('Filters (2 applied)')).toBeInTheDocument()
+        expect(screen.getByText('2 filters applied')).toBeInTheDocument()
 
         //Open submission type combobox and select contact and rate option
         await selectEvent.openMenu(submissionTypeCombobox)
@@ -734,7 +734,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
         const rows = await screen.findAllByRole('row')
         expect(rows).toHaveLength(4)
         //Expect 3 applied filters text
-        expect(screen.getByText('Filters (3 applied)')).toBeInTheDocument()
+        expect(screen.getByText('3 filters applied')).toBeInTheDocument()
         expect(
             screen.getByText('Displaying 3 of 4 submissions')
         ).toBeInTheDocument()

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -111,7 +111,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         expect(screen.getByRole('table')).toBeInTheDocument()
         //Expect 5 rows. 4 data rows and 1 header row
         expect(rows).toHaveLength(5)
-        expect(screen.getByText('4 submissions')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 4 of 4 submissions')
+        ).toBeInTheDocument()
     })
 
     it('displays no submission text when no submitted packages exist', async () => {
@@ -538,7 +540,9 @@ describe('HealthPlanPackageTable cms user tests', () => {
         //Expect 3 data rows and 1 header row, total 4 rows
         await userEvent.click(clearFiltersButton)
         expect(await screen.findAllByRole('row')).toHaveLength(4)
-        expect(screen.getByText('3 submissions')).toBeInTheDocument()
+        expect(
+            screen.getByText('Displaying 3 of 3 submissions')
+        ).toBeInTheDocument()
     })
 
     it('displays no results found when filters return no results', async () => {

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -50,9 +50,9 @@ const isSubmitted = (status: HealthPlanPackageStatus) =>
 function submissionURL(
     id: PackageInDashboardType['id'],
     status: PackageInDashboardType['status'],
-    userType: User['__typename']
+    isCMSUser: boolean
 ): string {
-    if (userType === 'CMSUser') {
+    if (isCMSUser) {
         return `/submissions/${id}`
     } else if (status === 'DRAFT') {
         return `/submissions/${id}/edit/type`
@@ -104,6 +104,8 @@ export const HealthPlanPackageTable = ({
     const [columnFilters, setColumnFilters] =
         React.useState<ColumnFiltersState>([])
 
+    const isCMSUser = user.__typename === 'CMSUser'
+
     const tableColumns = React.useMemo(
         () => [
             columnHelper.accessor((row) => row, {
@@ -115,7 +117,7 @@ export const HealthPlanPackageTable = ({
                         to={submissionURL(
                             info.getValue().id,
                             info.getValue().status,
-                            user.__typename
+                            isCMSUser
                         )}
                     >
                         {info.getValue().name}
@@ -189,7 +191,7 @@ export const HealthPlanPackageTable = ({
                 },
             }),
         ],
-        [user]
+        [isCMSUser]
     )
 
     const reactTable = useReactTable({
@@ -201,8 +203,8 @@ export const HealthPlanPackageTable = ({
         state: {
             columnFilters,
             columnVisibility: {
-                stateName: user.__typename !== 'StateUser',
-                submissionType: user.__typename !== 'StateUser',
+                stateName: isCMSUser,
+                submissionType: isCMSUser,
             },
         },
         onColumnFiltersChange: setColumnFilters,
@@ -231,9 +233,12 @@ export const HealthPlanPackageTable = ({
         filterLength
     )} applied`
 
-    const resultCount = `Displaying ${filteredRows.length} of ${
-        tableData.length
-    } ${pluralize('submission', tableData.length)}`
+    const submissionCount = !isCMSUser
+        ? `${tableData.length} ${pluralize('submission', tableData.length)}`
+        : `Displaying ${filteredRows.length} of ${tableData.length} ${pluralize(
+              'submission',
+              tableData.length
+          )}`
 
     return (
         <>
@@ -273,10 +278,14 @@ export const HealthPlanPackageTable = ({
                         </FilterAccordion>
                     )}
                     <div aria-live="polite" aria-atomic>
+                        {isCMSUser && (
+                            <div className={styles.filterCount}>
+                                {filtersApplied}
+                            </div>
+                        )}
                         <div className={styles.filterCount}>
-                            {filtersApplied}
+                            {submissionCount}
                         </div>
-                        <div className={styles.filterCount}>{resultCount}</div>
                     </div>
                     <Table fullWidth>
                         <thead>

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -226,13 +226,9 @@ export const HealthPlanPackageTable = ({
         label: state,
     }))
 
-    const filterTitle = `Filters ${
-        hasAppliedFilters
-            ? `(${
-                  columnFilters.flatMap((filter) => filter.value).length
-              } applied)`
-            : ''
-    }`
+    const filterTitle = `Filters (${
+        columnFilters.flatMap((filter) => filter.value).length
+    } applied)`
 
     return (
         <>
@@ -243,7 +239,7 @@ export const HealthPlanPackageTable = ({
                             onClearFilters={() => {
                                 setColumnFilters([])
                             }}
-                            filterTitle={filterTitle}
+                            filterTitle="Filters"
                         >
                             <FilterSelect
                                 name="state"
@@ -271,7 +267,8 @@ export const HealthPlanPackageTable = ({
                             />
                         </FilterAccordion>
                     )}
-                    {
+                    <div aria-live="polite" aria-atomic>
+                        <div className={styles.filterCount}>{filterTitle}</div>
                         <div className={styles.filterCount}>
                             {!hasAppliedFilters
                                 ? `${tableData.length} ${pluralize(
@@ -285,7 +282,7 @@ export const HealthPlanPackageTable = ({
                                       tableData.length
                                   )}`}
                         </div>
-                    }
+                    </div>
                     <Table fullWidth>
                         <thead>
                             {reactTable.getHeaderGroups().map((headerGroup) => (

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -226,9 +226,9 @@ export const HealthPlanPackageTable = ({
         label: state,
     }))
 
-    const filterTitle = `Filters (${
+    const filterTitle = `${
         columnFilters.flatMap((filter) => filter.value).length
-    } applied)`
+    } filters applied`
 
     return (
         <>

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -211,7 +211,6 @@ export const HealthPlanPackageTable = ({
         getSortedRowModel: getSortedRowModel(),
     })
 
-    const hasAppliedFilters = columnFilters.length > 0
     const filteredRows = reactTable.getRowModel().rows
     const hasFilteredRows = filteredRows.length > 0
 
@@ -226,9 +225,15 @@ export const HealthPlanPackageTable = ({
         label: state,
     }))
 
-    const filterTitle = `${
-        columnFilters.flatMap((filter) => filter.value).length
-    } filters applied`
+    const filterLength = columnFilters.flatMap((filter) => filter.value).length
+    const filtersApplied = `${filterLength} ${pluralize(
+        'filter',
+        filterLength
+    )} applied`
+
+    const resultCount = `Displaying ${filteredRows.length} of ${
+        tableData.length
+    } ${pluralize('submission', tableData.length)}`
 
     return (
         <>
@@ -268,20 +273,10 @@ export const HealthPlanPackageTable = ({
                         </FilterAccordion>
                     )}
                     <div aria-live="polite" aria-atomic>
-                        <div className={styles.filterCount}>{filterTitle}</div>
                         <div className={styles.filterCount}>
-                            {!hasAppliedFilters
-                                ? `${tableData.length} ${pluralize(
-                                      'submission',
-                                      tableData.length
-                                  )}`
-                                : `Displaying ${filteredRows.length} of ${
-                                      tableData.length
-                                  } ${pluralize(
-                                      'submission',
-                                      tableData.length
-                                  )}`}
+                            {filtersApplied}
                         </div>
+                        <div className={styles.filterCount}>{resultCount}</div>
                     </div>
                     <Table fullWidth>
                         <thead>


### PR DESCRIPTION
## Summary
[MR-2872](https://qmacbis.atlassian.net/browse/MR-2872)
CMS dashboard page
   - Screen reader reads filter applied and submission displayed on CMS dashboard page. 
      - Reads on page load.
      - Reads on filter change.
   - Moved filter applied text to outside filter accordion, above submission count.
   - Edit text for filter applied and submission count
   
State dashboard page
   - Screen reader reads submission displayed on state dashboard page.
      - Reads on page load

#### Related slack conversations
[Slack](https://cmsgov.slack.com/archives/C014CRU197U/p1673366114809069)
[Slack](https://cmsgov.slack.com/archives/C014CRU197U/p1673368036654629)

#### Related issues

#### Screenshots

![Screenshot 2023-01-11 at 5 07 30 PM](https://user-images.githubusercontent.com/98117700/211928224-f1515c4d-1451-41ce-aba4-bc2650904325.png)

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
