### PR TITLE
Add caption prop, scope tag to HealthPlanPackageTable

### DIFF
--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.stories.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.stories.tsx
@@ -111,8 +111,8 @@ WithCaption.args = {
     caption: 'Table Data',
 }
 
+// CMS User experience
 export const WithFilters = Template.bind({})
-
 WithFilters.decorators = [(Story) => ProvidersDecorator(Story, {})]
 WithFilters.args = {
     tableData,

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.stories.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.stories.tsx
@@ -101,5 +101,21 @@ Default.decorators = [(Story) => ProvidersDecorator(Story, {})]
 Default.args = {
     tableData,
     user: mockCMSUser,
+}
+
+export const WithCaption = Template.bind({})
+WithCaption.decorators = [(Story) => ProvidersDecorator(Story, {})]
+WithCaption.args = {
+    tableData,
+    user: mockCMSUser,
+    caption: 'Table Data',
+}
+
+export const WithFilters = Template.bind({})
+
+WithFilters.decorators = [(Story) => ProvidersDecorator(Story, {})]
+WithFilters.args = {
+    tableData,
+    user: mockCMSUser,
     showFilters: true,
 }

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -100,6 +100,18 @@ describe('HealthPlanPackageTable cms user tests', () => {
         name: 'Bob it user',
     }
 
+    it('renders table and caption if passed in', async () => {
+        renderWithProviders(
+            <HealthPlanPackageTable
+                tableData={submissions}
+                user={mockCMSUser}
+                caption="Table 1"
+            />
+        )
+        expect(screen.getByRole('table')).toBeInTheDocument()
+        expect(screen.getByText('Table 1')).toBeInTheDocument()
+    })
+
     it('renders table with expected number of submissions', async () => {
         renderWithProviders(
             <HealthPlanPackageTable

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -92,7 +92,7 @@ const submissions: PackageInDashboardType[] = [
     },
 ]
 
-describe('HealthPlanPackageTable cms user tests', () => {
+describe('HealthPlanPackageTable for CMS User (with filters)', () => {
     const mockCMSUser: User = {
         __typename: 'CMSUser' as const,
         role: 'CMS User',
@@ -106,6 +106,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
                 tableData={submissions}
                 user={mockCMSUser}
                 caption="Table 1"
+                showFilters
             />
         )
         expect(screen.getByRole('table')).toBeInTheDocument()
@@ -117,6 +118,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
             <HealthPlanPackageTable
                 tableData={submissions}
                 user={mockCMSUser}
+                showFilters
             />
         )
         const rows = await screen.findAllByRole('row')
@@ -130,7 +132,11 @@ describe('HealthPlanPackageTable cms user tests', () => {
 
     it('displays no submission text when no submitted packages exist', async () => {
         renderWithProviders(
-            <HealthPlanPackageTable tableData={[]} user={mockCMSUser} />,
+            <HealthPlanPackageTable
+                tableData={[]}
+                user={mockCMSUser}
+                showFilters
+            />,
             {
                 apolloProvider: {
                     mocks: [
@@ -155,6 +161,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
             <HealthPlanPackageTable
                 tableData={submissions}
                 user={mockCMSUser}
+                showFilters
             />
         )
         const submissionsInTable = await screen.getAllByTestId(`submission-id`)
@@ -174,6 +181,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
             <HealthPlanPackageTable
                 tableData={submissions}
                 user={mockCMSUser}
+                showFilters
             />
         )
 
@@ -205,6 +213,7 @@ describe('HealthPlanPackageTable cms user tests', () => {
             <HealthPlanPackageTable
                 tableData={stateSubmissions}
                 user={mockCMSUser}
+                showFilters
             />
         )
 

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -42,6 +42,7 @@ export type PackageTableProps = {
     tableData: PackageInDashboardType[]
     user: User
     showFilters?: boolean
+    caption?: string
 }
 
 const isSubmitted = (status: HealthPlanPackageStatus) =>
@@ -97,6 +98,7 @@ const submissionTypeOptions = [
 const columnHelper = createColumnHelper<PackageInDashboardType>()
 
 export const HealthPlanPackageTable = ({
+    caption,
     tableData,
     user,
     showFilters = false,
@@ -233,7 +235,7 @@ export const HealthPlanPackageTable = ({
         filterLength
     )} applied`
 
-    const submissionCount = !isCMSUser
+    const submissionCount = !showFilters
         ? `${tableData.length} ${pluralize('submission', tableData.length)}`
         : `Displaying ${filteredRows.length} of ${tableData.length} ${pluralize(
               'submission',
@@ -278,7 +280,7 @@ export const HealthPlanPackageTable = ({
                         </FilterAccordion>
                     )}
                     <div aria-live="polite" aria-atomic>
-                        {isCMSUser && (
+                        {showFilters && (
                             <div className={styles.filterCount}>
                                 {filtersApplied}
                             </div>
@@ -288,11 +290,12 @@ export const HealthPlanPackageTable = ({
                         </div>
                     </div>
                     <Table fullWidth>
+                        {caption && <caption>{caption}</caption>}
                         <thead>
                             {reactTable.getHeaderGroups().map((headerGroup) => (
                                 <tr key={headerGroup.id}>
                                     {headerGroup.headers.map((header) => (
-                                        <th key={header.id}>
+                                        <th scope="col" key={header.id}>
                                             {header.isPlaceholder
                                                 ? null
                                                 : flexRender(


### PR DESCRIPTION
## Summary
Add a11y handling tweaks to table
- optional caption prop 
- `scope` attribute to specify that th header cell is a header for a column
- Use `showFilters` prop to determine if filtering language used in aria-live so its not possible to get into state where filters are off but text announces as if filters in place. 

See https://github.com/trussworks/accessibility/wiki/Tables

#### Related issues
related to #1436 

#### Test cases covered
- Added new test for caption. Had to edit several tests to pass filters prop for when we are testing filters

## QA guidance
Running through table in screenreader. 