### PR TITLE
Make User.id mandatory, resolve local login error

### DIFF
--- a/services/app-api/src/authn/cognitoAuthn.test.ts
+++ b/services/app-api/src/authn/cognitoAuthn.test.ts
@@ -45,6 +45,8 @@ describe('cognitoAuthn', () => {
                 expectedResult: Result<UserType, Error>
             }
 
+            const testID = 'foobar'
+
             const tests: samlAttrTest[] = [
                 {
                     attributes: {
@@ -55,6 +57,7 @@ describe('cognitoAuthn', () => {
                         email: 'gp@example.com',
                     },
                     expectedResult: ok({
+                        id: testID,
                         role: 'STATE_USER',
                         email: 'gp@example.com',
                         stateCode: 'VA',
@@ -70,6 +73,7 @@ describe('cognitoAuthn', () => {
                         email: 'gp@example.com',
                     },
                     expectedResult: ok({
+                        id: testID,
                         role: 'CMS_USER',
                         email: 'gp@example.com',
                         familyName: 'Person',
@@ -87,6 +91,7 @@ describe('cognitoAuthn', () => {
                         email: 'gp@example.com',
                     },
                     expectedResult: ok({
+                        id: testID,
                         role: 'STATE_USER',
                         email: 'gp@example.com',
                         stateCode: 'FL',
@@ -103,6 +108,7 @@ describe('cognitoAuthn', () => {
                         email: 'gp@example.com',
                     },
                     expectedResult: ok({
+                        id: testID,
                         role: 'STATE_USER',
                         email: 'gp@example.com',
                         stateCode: 'FL',
@@ -136,7 +142,10 @@ describe('cognitoAuthn', () => {
             ]
 
             tests.forEach((test) => {
-                const actualResult = userTypeFromAttributes(test.attributes)
+                const actualResult = userTypeFromAttributes(
+                    testID,
+                    test.attributes
+                )
 
                 expect(actualResult).toEqual(test.expectedResult)
             })

--- a/services/app-api/src/authn/cognitoAuthn.ts
+++ b/services/app-api/src/authn/cognitoAuthn.ts
@@ -81,9 +81,12 @@ async function fetchUserFromCognito(
 const CMS_ROLE_ATTRIBUTE = 'macmcrrs-cms-user'
 const STATE_ROLE_ATTRIBUTE = 'macmcrrs-state-user'
 
-export function userTypeFromAttributes(attributes: {
-    [key: string]: string
-}): Result<UserType, Error> {
+export function userTypeFromAttributes(
+    id: string,
+    attributes: {
+        [key: string]: string
+    }
+): Result<UserType, Error> {
     // check for all the shared attrs here
     if (
         !(
@@ -117,6 +120,7 @@ export function userTypeFromAttributes(attributes: {
             )
         }
         return ok({
+            id,
             role: 'STATE_USER',
             email: attributes.email,
             stateCode: attributes['custom:state_code'],
@@ -127,6 +131,7 @@ export function userTypeFromAttributes(attributes: {
 
     if (roles.includes(CMS_ROLE_ATTRIBUTE)) {
         return ok({
+            id,
             role: 'CMS_USER',
             email: attributes.email,
             givenName: attributes.given_name,
@@ -218,7 +223,7 @@ async function lookupUserCognito(
     // we lose some type safety here...
     const attributes = userAttrDict(currentUser)
 
-    return userTypeFromAttributes(attributes)
+    return userTypeFromAttributes(userId, attributes)
 }
 
 async function lookupUserAurora(

--- a/services/app-api/src/domain-models/UserType.d.ts
+++ b/services/app-api/src/domain-models/UserType.d.ts
@@ -3,7 +3,7 @@ import { StateType } from './StateType'
 type UserType = StateUserType | CMSUserType | AdminUserType
 
 type StateUserType = {
-    id?: string
+    id: string
     role: 'STATE_USER'
     email: string
     stateCode: string
@@ -12,7 +12,7 @@ type StateUserType = {
 }
 
 type CMSUserType = {
-    id?: string
+    id: string
     role: 'CMS_USER'
     email: string
     givenName: string
@@ -21,7 +21,7 @@ type CMSUserType = {
 }
 
 type AdminUserType = {
-    id?: string
+    id: string
     role: 'ADMIN_USER'
     email: string
     givenName: string

--- a/services/app-api/src/resolvers/healthPlanPackage/createHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/createHealthPlanPackage.test.ts
@@ -64,6 +64,7 @@ describe('createHealthPlanPackage', () => {
         const server = await constructTestPostgresServer({
             context: {
                 user: {
+                    id: 'foobar',
                     role: 'CMS_USER',
                     email: 'aang@va.gov',
                     givenName: 'Prince',

--- a/services/app-web/src/localAuth/LocalLogin.tsx
+++ b/services/app-web/src/localAuth/LocalLogin.tsx
@@ -23,21 +23,28 @@ import { LocalUserType } from './LocalUserType'
 
 const localUsers: LocalUserType[] = [
     {
+        id: 'user1',
         email: 'aang@example.com',
-        name: 'Aang',
+        givenName: 'Aang',
+        familyName: 'Avatar',
         role: 'STATE_USER',
         stateCode: 'MN',
     },
     {
+        id: 'user2',
         email: 'toph@example.com',
-        name: 'Toph',
+        givenName: 'Toph',
+        familyName: 'Beifong',
         role: 'STATE_USER',
         stateCode: 'VA',
     },
     {
+        id: 'user3',
         email: 'zuko@example.com',
-        name: 'Zuko',
+        givenName: 'Zuko',
+        familyName: 'Hotman',
         role: 'CMS_USER',
+        stateAssignments: [],
     },
 ]
 
@@ -80,12 +87,12 @@ export function LocalLogin(): React.ReactElement {
                             <CardMedia>
                                 <img
                                     src={userAvatars[user.email]}
-                                    alt={user.name}
+                                    alt={user.givenName}
                                 />
                             </CardMedia>
                             <CardHeader>
                                 <h2 className="usa-card__heading">
-                                    {user.name}
+                                    {user.givenName}
                                 </h2>
                             </CardHeader>
                             <CardBody>
@@ -93,7 +100,7 @@ export function LocalLogin(): React.ReactElement {
                             </CardBody>
                             <CardFooter>
                                 <Button
-                                    data-testid={`${user.name}Button`}
+                                    data-testid={`${user.givenName}Button`}
                                     type="submit"
                                     disabled={loginStatus === 'LOADING'}
                                     onClick={() => login(user)}

--- a/services/app-web/src/localAuth/LocalUserType.ts
+++ b/services/app-web/src/localAuth/LocalUserType.ts
@@ -1,16 +1,31 @@
-type LocalUserType = LocalStateUserType | LocalCMSUserType
+import { StateType } from '../common-code/healthPlanFormDataType'
+
+type LocalUserType = LocalStateUserType | LocalCMSUserType | LocalAdminUserType
 
 type LocalStateUserType = {
+    id: string
     role: 'STATE_USER'
     email: string
-    name: string
     stateCode: string
+    givenName: string
+    familyName: string
 }
 
 type LocalCMSUserType = {
+    id: string
     role: 'CMS_USER'
     email: string
-    name: string
+    givenName: string
+    familyName: string
+    stateAssignments: StateType[]
+}
+
+type LocalAdminUserType = {
+    id: string
+    role: 'ADMIN_USER'
+    email: string
+    givenName: string
+    familyName: string
 }
 
 function isLocalUser(user: unknown): user is LocalUserType {

--- a/services/app-web/src/localAuth/localAuth.test.ts
+++ b/services/app-web/src/localAuth/localAuth.test.ts
@@ -8,8 +8,10 @@ describe('localLogin', () => {
 
     it('loads as expected', async () => {
         const testUser: LocalUserType = {
+            id: 'foo-bar',
             email: 'toph@dmas.virginia.gov',
-            name: 'Toph',
+            givenName: 'Toph',
+            familyName: 'Earth',
             role: 'STATE_USER',
             stateCode: 'VA',
         }
@@ -21,8 +23,10 @@ describe('localLogin', () => {
 
     it('logs out correctly', async () => {
         const testUser: LocalUserType = {
+            id: 'foo-bar',
             email: 'toph@dmas.virginia.gov',
-            name: 'Toph',
+            givenName: 'Toph',
+            familyName: 'Earth',
             role: 'STATE_USER',
             stateCode: 'VA',
         }


### PR DESCRIPTION
## Summary

Local Login failed after merging in the new User work. There was a type mismatch between the graphQL type which required ID and the domain type which did not. In trying to return a user without a type we got a graphql error. 

It’s not clear to me exactly why this is working fine for non-local users, but this fix makes me think it should work all the time.

## QA guidance

Pull this branch and try and log in locally
also try and log in to the review app
