### PR TITLE
fix: MR-2962 MR-314 for product acceptance

### DIFF
--- a/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
+++ b/services/app-web/src/components/Form/FieldYesNo/FieldYesNo.tsx
@@ -26,23 +26,6 @@ export type FieldYesNoProps = {
     variant?: 'TOPLEVEL' | 'SUBHEAD' // subhead variant used for nested fields yes/no fields under an overarching heading
 } & JSX.IntrinsicElements['input']
 
-export type FieldYesNoFormValue = 'YES' | 'NO' | undefined // Use for formik string value
-export type FieldYesNoUserValue = 'Yes' | 'No' | undefined // Use for user facing display
-
-// Helpers used for reading and writing from db boolean types to formik string type of YES and NO
-export const booleanAsYesNoFormValue = (bool?: boolean): FieldYesNoFormValue =>
-    bool ? 'YES' : bool === false ? 'NO' : undefined
-
-export const booleanAsYesNoUserValue = (bool?: boolean): FieldYesNoUserValue =>
-    bool ? 'Yes' : bool === false ? 'No' : undefined
-
-// Use for db stored value
-export const yesNoFormValueAsBoolean = (
-    maybeString: FieldYesNoFormValue | string
-) => {
-    return maybeString === 'YES' ? true : false
-}
-
 export const FieldYesNo = ({
     name,
     label,
@@ -104,4 +87,25 @@ export const FieldYesNo = ({
             </span>
         </Fieldset>
     )
+}
+
+// HELPERS
+export type FieldYesNoFormValue = 'YES' | 'NO' | undefined // Use for formik string value
+export type FieldYesNoUserValue = 'Yes' | 'No' | undefined // Use for user facing display
+export type FieldYesNoBoolean = true | false | undefined // Use for sending to backend
+
+export const booleanAsYesNoFormValue = (bool?: boolean): FieldYesNoFormValue =>
+    bool ? 'YES' : bool === false ? 'NO' : undefined
+
+export const booleanAsYesNoUserValue = (bool?: boolean): FieldYesNoUserValue =>
+    bool ? 'Yes' : bool === false ? 'No' : undefined
+
+export const yesNoFormValueAsBoolean = (
+    maybeString: FieldYesNoFormValue | string
+): FieldYesNoBoolean => {
+    return maybeString === 'YES'
+        ? true
+        : maybeString === 'NO'
+        ? false
+        : undefined
 }

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -336,4 +336,64 @@ describe('ContractDetailsSummarySection', () => {
             'modifiedLengthOfContract',
         ])
     })
+
+    it('shows missing field error on amended provisions when expected', () => {
+        const contractWithUnansweredProvisions = {
+            ...mockContractAndRatesDraft(),
+            contractAmendmentInfo: {
+                modifiedProvisions: [],
+                unmodifiedProvisions: [],
+            },
+        }
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={contractWithUnansweredProvisions}
+                submissionName="MN-PMAP-0001"
+            />
+        )
+
+        const modifiedProvisions = screen.getByLabelText(
+            'This contract action includes new or modified provisions related to the following'
+        )
+        expect(
+            within(modifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeInTheDocument()
+
+        const unmodifiedProvisions = screen.getByLabelText(
+            'This contract action does NOT include new or modified provisions related to the following'
+        )
+        expect(
+            within(unmodifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeInTheDocument()
+    })
+    it('does not show missing field error on amended provisions when expected when valid fields present', () => {
+        renderWithProviders(
+            <ContractDetailsSummarySection
+                submission={mockContractAndRatesDraft()}
+                submissionName="MN-PMAP-0001"
+            />
+        )
+
+        const modifiedProvisions = screen.getByLabelText(
+            'This contract action includes new or modified provisions related to the following'
+        )
+        expect(
+            within(modifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeNull()
+
+        const unmodifiedProvisions = screen.getByLabelText(
+            'This contract action does NOT include new or modified provisions related to the following'
+        )
+        expect(
+            within(unmodifiedProvisions).queryByText(
+                /You must provide this information/
+            )
+        ).toBeNull()
+    })
 })

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -111,6 +111,9 @@ export const ContractDetailsSummarySection = ({
         submission.contractAmendmentInfo?.modifiedProvisions
     )
 
+    const amendmentProvisionsUnanswered =
+        modifiedProvisions.length === 0 && unmodifiedProvisions.length === 0
+
     return (
         <section id="contractDetailsSection" className={styles.summarySection}>
             <SectionHeader header="Contract details" navigateTo={navigateTo}>
@@ -182,7 +185,9 @@ export const ContractDetailsSummarySection = ({
                         <DataDetail
                             id="modifiedProvisions"
                             label="This contract action includes new or modified provisions related to the following"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={
+                                amendmentProvisionsUnanswered && !isSubmitted
+                            }
                             children={
                                 <DataDetailCheckboxList
                                     list={modifiedProvisions}
@@ -194,7 +199,9 @@ export const ContractDetailsSummarySection = ({
                         <DataDetail
                             id="unmodifiedProvisions"
                             label="This contract action does NOT include new or modified provisions related to the following"
-                            explainMissingData={!isSubmitted}
+                            explainMissingData={
+                                amendmentProvisionsUnanswered && !isSubmitted
+                            }
                             children={
                                 <DataDetailCheckboxList
                                     list={unmodifiedProvisions}


### PR DESCRIPTION
## Summary
Small bugfix from product acceptance. See conversation on each ticket and commit history for context.

#### Related issues

- https://qmacbis.atlassian.net/browse/MR-314
- https://qmacbis.atlassian.net/browse/MR-2962

#### Test cases covered

- shows missing field error on amended provisions when expected
- does now show missing field error on amended provisions when fields are valid

## QA guidance
Manual QA for MR-314 steps
- Log in as a state user and view the review/submit page on an unlocked submission where this field was not filled out on initial submission (you can get here by turning flag off, adding sub, unlocking, then turning flag on).
-  As expected, there is an error message shown on the review and submit page indicating this field is required. 
- Click edit on the submission type section and navigate to submission type page. 
- Leave the risk-based question as blank and select “save as draft”. 
- You are navigated back to the dashboard. From dashboard, click back into the submission you just edited.
- You should notice that the risk-based question is still empty and be able to fill out