### PR TITLE
Fix CI skipping script when sha can't be found

### DIFF
--- a/scripts/get-changed-services/index.ts
+++ b/scripts/get-changed-services/index.ts
@@ -135,7 +135,7 @@ async function getChangedServicesSinceSha(
 
     const lernaList: LernaListItem[] = JSON.parse(stdout)
     if (stderr) {
-        console.info(stderr)
+        console.error(stderr)
         return new Error(`Lerna could not find a viable sha`)
     }
 

--- a/scripts/get-changed-services/index.ts
+++ b/scripts/get-changed-services/index.ts
@@ -50,6 +50,7 @@ async function main() {
     // if lerna can't find the sha, run everything
     if (lernaChangedServices instanceof Error) {
         core.setOutput('changed-services', deployAllServices)
+        return
     }
 
     const jobsToSkip = await getJobsToSkip(

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "module": "commonjs",
-        "lib": ["es2021"],
+        "lib": ["es2021", "dom.iterable"],
         "target": "es2021",
         "moduleResolution": "node",
 


### PR DESCRIPTION
## Summary

Occasionally the CI skipping script will throw an error that the git sha that it is comparing against can't be found. This adds a check for that and will run CI deploys for all services if it encounters that error.


#### Related issues
https://qmacbis.atlassian.net/browse/MR-100

