### PR TITLE
fix: MR-2962 handle amended provisions empty state

### DIFF
--- a/services/app-web/src/components/DataDetail/DataDetail.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetail.tsx
@@ -5,7 +5,7 @@ import { DataDetailMissingField } from './DataDetailMissingField'
 export type DataDetailProps = {
     id: string
     label: string
-    children?: JSX.Element | string | string[]
+    children?: React.ReactNode | string[]
     explainMissingData?: boolean // Display fallback text when data is undefined or null. Should be true on review-and-submit
 }
 
@@ -19,7 +19,12 @@ export type DataDetailProps = {
     -  DataDetailContactField (used to display contact info in an address tag)
     -  DataDetailDateRange (used to display date ranges)
     -  DataDetailCheckBoxList (used to display checkbox field results, looking up enums in their associated dictionary)
+
+    Possible empty values that are handled includes:
+    undefined, null, empty string, empty array. A custom component that eventually renders null when called 
+    will NOT be handled. Data flow is handled one way from parent > children here.
 */
+
 export const DataDetail = ({
     id,
     label,
@@ -28,8 +33,8 @@ export const DataDetail = ({
 }: DataDetailProps): React.ReactElement | null => {
     const handleArray = Array.isArray(children)
     const noData =
-        !children || children === '' || (handleArray && children.length === 0) // These are all possible empty field values that could be passed as children
-    if (!explainMissingData && noData) return null // displays nothing - this is used for submission summary
+        !children || children === '' || (handleArray && children.length === 0)
+    if (!explainMissingData && noData) return null // displays nothing - this is generally used for submission summary page
 
     return (
         <div className={styles.dataDetail}>

--- a/services/app-web/src/components/DataDetail/DataDetail.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetail.tsx
@@ -35,7 +35,6 @@ export const DataDetail = ({
     const noData =
         !children || children === '' || (handleArray && children.length === 0)
     if (!explainMissingData && noData) return null // displays nothing - this is generally used for submission summary page
-
     return (
         <div className={styles.dataDetail}>
             <dt id={id}>{label}</dt>

--- a/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.test.tsx
@@ -43,7 +43,18 @@ describe('DataDetailCheckboxList', () => {
         expect(screen.getByText(/another important thing/)).toBeInTheDocument()
     })
 
-    it('renders null when list is empty by default', () => {
+    it('renders missing field error when list is empty by default', () => {
+        const ValuesLookup: Record<string, string> = {
+            THIS: 'this',
+            THAT: 'that',
+            THE_OTHER: 'the other',
+        }
+        render(<DataDetailCheckboxList list={[]} dict={ValuesLookup} />)
+        expect(
+            screen.getByText(/You must provide this information/)
+        ).toBeInTheDocument()
+    })
+    it('renders null when displayEmptyList and list is empty', () => {
         const ValuesLookup: Record<string, string> = {
             THIS: 'this',
             THAT: 'that',
@@ -51,7 +62,11 @@ describe('DataDetailCheckboxList', () => {
         }
         render(
             <div data-testid="container">
-                <DataDetailCheckboxList list={[]} dict={ValuesLookup} />
+                <DataDetailCheckboxList
+                    list={[]}
+                    dict={ValuesLookup}
+                    displayEmptyList
+                />
             </div>
         )
         expect(screen.getByTestId('container')).toBeEmptyDOMElement()

--- a/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.test.tsx
@@ -42,4 +42,18 @@ describe('DataDetailCheckboxList', () => {
         expect(screen.getByText(/etc/)).toBeInTheDocument()
         expect(screen.getByText(/another important thing/)).toBeInTheDocument()
     })
+
+    it('renders null when list is empty by default', () => {
+        const ValuesLookup: Record<string, string> = {
+            THIS: 'this',
+            THAT: 'that',
+            THE_OTHER: 'the other',
+        }
+        render(
+            <div data-testid="container">
+                <DataDetailCheckboxList list={[]} dict={ValuesLookup} />
+            </div>
+        )
+        expect(screen.getByTestId('container')).toBeEmptyDOMElement()
+    })
 })

--- a/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.tsx
@@ -1,11 +1,11 @@
-import { DataDetailMissingField } from '../'
-
 export type DataDetailCheckboxListProps = {
     list: string[] // Checkbox field array
     dict: Record<string, string> // A lang constant dictionary like ManagedCareEntityRecord or FederalAuthorityRecord,
     otherReasons?: (string | null)[] // pass in additional "Other" user generated text to append to end of list,
 }
-// Used to display field values from checkbox components in forms.
+
+// Intended for use as children passed to DataDetail
+// Display field values from checkbox components in forms.
 export const DataDetailCheckboxList = ({
     list,
     dict,
@@ -19,7 +19,7 @@ export const DataDetailCheckboxList = ({
         ? userFriendlyList.concat(otherReasons)
         : userFriendlyList
 
-    if (listToDisplay.length === 0) return <DataDetailMissingField />
+    if (listToDisplay.length === 0) return null
 
     return (
         <ul>

--- a/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailCheckboxList/DataDetailCheckboxList.tsx
@@ -1,7 +1,10 @@
+import { DataDetailMissingField } from '../DataDetailMissingField'
+
 export type DataDetailCheckboxListProps = {
     list: string[] // Checkbox field array
     dict: Record<string, string> // A lang constant dictionary like ManagedCareEntityRecord or FederalAuthorityRecord,
     otherReasons?: (string | null)[] // pass in additional "Other" user generated text to append to end of list,
+    displayEmptyList?: boolean // what happens if list is empty - default to missing data error but surfacing this prop for cases like modified provisions where two lists are related
 }
 
 // Intended for use as children passed to DataDetail
@@ -10,6 +13,7 @@ export const DataDetailCheckboxList = ({
     list,
     dict,
     otherReasons = [],
+    displayEmptyList = false,
 }: DataDetailCheckboxListProps): React.ReactElement | null => {
     const userFriendlyList = list.map((item) => {
         return dict[item] ? dict[item] : null
@@ -19,7 +23,8 @@ export const DataDetailCheckboxList = ({
         ? userFriendlyList.concat(otherReasons)
         : userFriendlyList
 
-    if (listToDisplay.length === 0) return null
+    if (listToDisplay.length === 0)
+        return displayEmptyList ? null : <DataDetailMissingField />
 
     return (
         <ul>

--- a/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.test.tsx
@@ -37,13 +37,4 @@ describe('DataDetailContactField', () => {
         ).toBeInTheDocument()
         expect(screen.getByText(/All Black Incorporated/)).toBeInTheDocument()
     })
-
-    it('renders null contact is missing', () => {
-        render(
-            <div data-testid="container">
-                <DataDetailContactField />
-            </div>
-        )
-        expect(screen.getByTestId('container')).toBeEmptyDOMElement()
-    })
 })

--- a/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.test.tsx
@@ -38,10 +38,12 @@ describe('DataDetailContactField', () => {
         expect(screen.getByText(/All Black Incorporated/)).toBeInTheDocument()
     })
 
-    it('renders missing field if contact is missing', () => {
-        render(<DataDetailContactField />)
-        expect(
-            screen.getByText(/You must provide this information/)
-        ).toBeInTheDocument()
+    it('renders null contact is missing', () => {
+        render(
+            <div data-testid="container">
+                <DataDetailContactField />
+            </div>
+        )
+        expect(screen.getByTestId('container')).toBeEmptyDOMElement()
     })
 })

--- a/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
@@ -4,7 +4,6 @@ import {
     StateContact,
 } from '../../../common-code/healthPlanFormDataType'
 import { getActuaryFirm } from '../../SubmissionSummarySection'
-import { DataDetailMissingField } from '../DataDetailMissingField'
 
 type Contact = ActuaryContact | StateContact
 
@@ -12,14 +11,14 @@ function isCertainActuaryContact(contact: Contact): contact is ActuaryContact {
     return (contact as ActuaryContact).actuarialFirm !== undefined
 }
 
-// Used to contacts inside HTML <address> with link for email
+// Intended for use as children passed to DataDetail
+// displays contacts inside HTML <address> with link for email
 export const DataDetailContactField = ({
     contact,
 }: {
     contact?: Contact
-}): React.ReactElement => {
-    if (!contact || !contact.name || !contact.email)
-        return <DataDetailMissingField />
+}): React.ReactElement | null => {
+    if (!contact || !contact.name || !contact.email) return null
     const { name, titleRole, email } = contact
     return (
         <address>

--- a/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailContactField/DataDetailContactField.tsx
@@ -4,6 +4,7 @@ import {
     StateContact,
 } from '../../../common-code/healthPlanFormDataType'
 import { getActuaryFirm } from '../../SubmissionSummarySection'
+import { DataDetailMissingField } from '../DataDetailMissingField'
 
 type Contact = ActuaryContact | StateContact
 
@@ -17,8 +18,9 @@ export const DataDetailContactField = ({
     contact,
 }: {
     contact?: Contact
-}): React.ReactElement | null => {
-    if (!contact || !contact.name || !contact.email) return null
+}): React.ReactElement => {
+    if (!contact || !contact.name || !contact.email)
+        return <DataDetailMissingField />
     const { name, titleRole, email } = contact
     return (
         <address>

--- a/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.test.tsx
@@ -13,12 +13,15 @@ describe('DataDetailDateRange', () => {
         expect(screen.getByText('06/21/2022 to 06/22/2022')).toBeInTheDocument()
     })
 
-    it('renders missing field if one of the dates is missing', () => {
+    it('renders null if dates is missing', () => {
         render(
-            <DataDetailDateRange startDate={undefined} endDate={undefined} />
+            <div data-testid="container">
+                <DataDetailDateRange
+                    startDate={undefined}
+                    endDate={undefined}
+                />
+            </div>
         )
-        expect(
-            screen.getByText(/You must provide this information/)
-        ).toBeInTheDocument()
+        expect(screen.getByTestId('container')).toBeEmptyDOMElement()
     })
 })

--- a/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.test.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.test.tsx
@@ -13,15 +13,12 @@ describe('DataDetailDateRange', () => {
         expect(screen.getByText('06/21/2022 to 06/22/2022')).toBeInTheDocument()
     })
 
-    it('renders null if dates is missing', () => {
+    it('renders missing field error if dates is missing', () => {
         render(
-            <div data-testid="container">
-                <DataDetailDateRange
-                    startDate={undefined}
-                    endDate={undefined}
-                />
-            </div>
+            <DataDetailDateRange startDate={undefined} endDate={undefined} />
         )
-        expect(screen.getByTestId('container')).toBeEmptyDOMElement()
+        expect(
+            screen.getByText(/You must provide this information/)
+        ).toBeInTheDocument()
     })
 })

--- a/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.tsx
@@ -1,14 +1,14 @@
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
-import { DataDetailMissingField } from '../DataDetailMissingField'
 
+// Intended for use as children passed to DataDetail
 export const DataDetailDateRange = ({
     startDate,
     endDate,
 }: {
     startDate?: Date
     endDate?: Date
-}): React.ReactElement => {
-    if (!startDate || !endDate) return <DataDetailMissingField />
+}): React.ReactElement | null => {
+    if (!startDate || !endDate) return null
     return (
         <>{`${formatCalendarDate(startDate)} to ${formatCalendarDate(
             endDate

--- a/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.tsx
+++ b/services/app-web/src/components/DataDetail/DataDetailDateRange/DataDetailDateRange.tsx
@@ -1,4 +1,5 @@
 import { formatCalendarDate } from '../../../common-code/dateHelpers'
+import { DataDetailMissingField } from '../DataDetailMissingField'
 
 // Intended for use as children passed to DataDetail
 export const DataDetailDateRange = ({
@@ -7,8 +8,8 @@ export const DataDetailDateRange = ({
 }: {
     startDate?: Date
     endDate?: Date
-}): React.ReactElement | null => {
-    if (!startDate || !endDate) return null
+}): React.ReactElement => {
+    if (!startDate || !endDate) return <DataDetailMissingField />
     return (
         <>{`${formatCalendarDate(startDate)} to ${formatCalendarDate(
             endDate

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.test.tsx
@@ -8,7 +8,10 @@ import {
     mockContractAndRatesDraft,
     mockStateSubmission,
 } from '../../../testHelpers/apolloHelpers'
-import { ModifiedProvisions } from '../../../common-code/healthPlanFormDataType'
+import {
+    ModifiedProvisions,
+    UnlockedHealthPlanFormDataType,
+} from '../../../common-code/healthPlanFormDataType'
 
 describe('ContractDetailsSummarySection', () => {
     it('can render draft submission without errors (review and submit behavior)', () => {
@@ -338,13 +341,13 @@ describe('ContractDetailsSummarySection', () => {
     })
 
     it('shows missing field error on amended provisions when expected', () => {
-        const contractWithUnansweredProvisions = {
-            ...mockContractAndRatesDraft(),
-            contractAmendmentInfo: {
-                modifiedProvisions: [],
-                unmodifiedProvisions: [],
-            },
-        }
+        const contractWithUnansweredProvisions: UnlockedHealthPlanFormDataType =
+            {
+                ...mockContractAndRatesDraft(),
+                contractAmendmentInfo: {
+                    modifiedProvisions: undefined,
+                },
+            }
         renderWithProviders(
             <ContractDetailsSummarySection
                 submission={contractWithUnansweredProvisions}
@@ -371,9 +374,33 @@ describe('ContractDetailsSummarySection', () => {
         ).toBeInTheDocument()
     })
     it('does not show missing field error on amended provisions when expected when valid fields present', () => {
+        const contractWithAllUnmodifiedProvisions: UnlockedHealthPlanFormDataType =
+            {
+                ...mockContractAndRatesDraft(),
+                contractAmendmentInfo: {
+                    modifiedProvisions: {
+                        modifiedBenefitsProvided: false,
+                        modifiedGeoAreaServed: false,
+                        modifiedMedicaidBeneficiaries: false,
+                        modifiedRiskSharingStrategy: false,
+                        modifiedIncentiveArrangements: false,
+                        modifiedWitholdAgreements: false,
+                        modifiedStateDirectedPayments: false,
+                        modifiedPassThroughPayments: false,
+                        modifiedPaymentsForMentalDiseaseInstitutions: false,
+                        modifiedMedicalLossRatioStandards: false,
+                        modifiedOtherFinancialPaymentIncentive: false,
+                        modifiedEnrollmentProcess: false,
+                        modifiedGrevienceAndAppeal: false,
+                        modifiedNetworkAdequacyStandards: false,
+                        modifiedLengthOfContract: false,
+                        modifiedNonRiskPaymentArrangements: false,
+                    },
+                },
+            }
         renderWithProviders(
             <ContractDetailsSummarySection
-                submission={mockContractAndRatesDraft()}
+                submission={contractWithAllUnmodifiedProvisions}
                 submissionName="MN-PMAP-0001"
             />
         )

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -111,8 +111,8 @@ export const ContractDetailsSummarySection = ({
         submission.contractAmendmentInfo?.modifiedProvisions
     )
 
-    const amendmentProvisionsUnanswered =
-        modifiedProvisions.length === 0 && unmodifiedProvisions.length === 0
+    const amendmentProvisionsAnswered =
+        modifiedProvisions.length > 0 || unmodifiedProvisions.length > 0
 
     return (
         <section id="contractDetailsSection" className={styles.summarySection}>
@@ -186,29 +186,31 @@ export const ContractDetailsSummarySection = ({
                             id="modifiedProvisions"
                             label="This contract action includes new or modified provisions related to the following"
                             explainMissingData={
-                                amendmentProvisionsUnanswered && !isSubmitted
+                                !amendmentProvisionsAnswered && !isSubmitted
                             }
-                            children={
+                        >
+                            {amendmentProvisionsAnswered && (
                                 <DataDetailCheckboxList
                                     list={modifiedProvisions}
                                     dict={ModifiedProvisionsRecord}
                                 />
-                            }
-                        />
+                            )}
+                        </DataDetail>
 
                         <DataDetail
                             id="unmodifiedProvisions"
                             label="This contract action does NOT include new or modified provisions related to the following"
                             explainMissingData={
-                                amendmentProvisionsUnanswered && !isSubmitted
+                                !amendmentProvisionsAnswered && !isSubmitted
                             }
-                            children={
+                        >
+                            {amendmentProvisionsAnswered && (
                                 <DataDetailCheckboxList
                                     list={unmodifiedProvisions}
                                     dict={ModifiedProvisionsRecord}
                                 />
-                            }
-                        />
+                            )}
+                        </DataDetail>
                     </DoubleColumnGrid>
                 )}
             </dl>

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -111,8 +111,8 @@ export const ContractDetailsSummarySection = ({
         submission.contractAmendmentInfo?.modifiedProvisions
     )
 
-    const amendmentProvisionsAnswered =
-        modifiedProvisions.length > 0 || unmodifiedProvisions.length > 0
+    const amendmentProvisionsUnanswered =
+        modifiedProvisions.length === 0 && unmodifiedProvisions.length === 0
 
     return (
         <section id="contractDetailsSection" className={styles.summarySection}>
@@ -186,13 +186,14 @@ export const ContractDetailsSummarySection = ({
                             id="modifiedProvisions"
                             label="This contract action includes new or modified provisions related to the following"
                             explainMissingData={
-                                !amendmentProvisionsAnswered && !isSubmitted
+                                amendmentProvisionsUnanswered && !isSubmitted
                             }
                         >
-                            {amendmentProvisionsAnswered && (
+                            {amendmentProvisionsUnanswered ? null : (
                                 <DataDetailCheckboxList
                                     list={modifiedProvisions}
                                     dict={ModifiedProvisionsRecord}
+                                    displayEmptyList
                                 />
                             )}
                         </DataDetail>
@@ -201,13 +202,14 @@ export const ContractDetailsSummarySection = ({
                             id="unmodifiedProvisions"
                             label="This contract action does NOT include new or modified provisions related to the following"
                             explainMissingData={
-                                !amendmentProvisionsAnswered && !isSubmitted
+                                amendmentProvisionsUnanswered && !isSubmitted
                             }
                         >
-                            {amendmentProvisionsAnswered && (
+                            {amendmentProvisionsUnanswered ? null : (
                                 <DataDetailCheckboxList
                                     list={unmodifiedProvisions}
                                     dict={ModifiedProvisionsRecord}
+                                    displayEmptyList
                                 />
                             )}
                         </DataDetail>


### PR DESCRIPTION
## Summary
Another pass to fix MR-2962. Follow on from #1451. This time added special prop to checkbox list to allow empty list behavior when two checkbox lists are related like amended provisions

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2962

#### Test cases covered

Adjusted the test cases to get properly failing tests for the bug with checkbox list
- renders missing field error when list is empty by default
- renders null when `displayEmptyList` and list is empty
- 
## QA guidance
- Check review and submit pages for different configurations of amended provisions checkbox list (contract details > amendment needs to be selected). Only if both lists are empty should we show empty state error message. 
