### PR TITLE
Upgrade Aurora Serverless v1 to Postgres 11

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -116,6 +116,7 @@ resources:
       Properties:
         Engine: aurora-postgresql
         EngineMode: serverless
+        EngineVersion: '11.18'
         DatabaseName: '${self:custom.databaseName}'
         MasterUsername: !Sub '{{resolve:secretsmanager:${PostgresSecret}::username}}'
         MasterUserPassword: !Sub '{{resolve:secretsmanager:${PostgresSecret}::password}}'

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -116,7 +116,7 @@ resources:
       Properties:
         Engine: aurora-postgresql
         EngineMode: serverless
-        EngineVersion: '11.18'
+        EngineVersion: '11.13'
         DatabaseName: '${self:custom.databaseName}'
         MasterUsername: !Sub '{{resolve:secretsmanager:${PostgresSecret}::username}}'
         MasterUserPassword: !Sub '{{resolve:secretsmanager:${PostgresSecret}::password}}'


### PR DESCRIPTION
## Summary

Postgres 10 is EOL in AWS Aurora, so we need to run the manual in-place upgrade to Postgres 11 on dev/val/prod. This change sets the pg version to 11.13, which is the version that AWS does an in place upgrade to, so that all PR branches get the same version as is deployed in our higher environments. 

Once the dev/val/prod DBs have been upgraded in the AWS console we can merge this. This needs to land before January 31.

We have a separate ticket to do the more involved upgrade to Aurora Serverless v2 with a newer Postgres release.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2577

