### PR TITLE
update maintenance banner

### DIFF
--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -15,6 +15,13 @@ export const featureFlags = {
         defaultValue: false,
     },
     /**
+     Toggles the site maintenance alert on the landing page
+    */
+    SITE_UNDER_MAINTENANCE_BANNER: {
+        flag: 'site-under-maintenance-banner',
+        defaultValue: 'OFF',
+    },
+    /**
      Enables the modal that alerts the user to an expiring session
     */
     SESSION_EXPIRING_MODAL: {

--- a/services/app-web/src/components/ErrorAlert/ErrorAlert.module.scss
+++ b/services/app-web/src/components/ErrorAlert/ErrorAlert.module.scss
@@ -6,3 +6,7 @@
     margin: 0
   }
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/services/app-web/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/services/app-web/src/components/ErrorAlert/ErrorAlert.tsx
@@ -37,7 +37,10 @@ export const ErrorAlert = ({
 
             {showLink && (
                 <span>
-                    &nbsp;<Link href={MAIL_TO_SUPPORT}>let us know.</Link>
+                    &nbsp;email{' '}
+                    <Link className={styles.nowrap} href={MAIL_TO_SUPPORT}>
+                        {MAIL_TO_SUPPORT}
+                    </Link>
                 </span>
             )}
         </Alert>

--- a/services/app-web/src/components/ErrorAlert/ErrorAlertScheduledMaintenance.tsx
+++ b/services/app-web/src/components/ErrorAlert/ErrorAlertScheduledMaintenance.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { ErrorAlert } from './ErrorAlert'
+
+export const ErrorAlertScheduledMaintenance = (): React.ReactElement => (
+    <ErrorAlert
+        heading="Site unavailable"
+        message="MC-Review is temporarily unavailable due to scheduled 
+                        maintenance. Please check back later. If you have questions or 
+                        need immediate assistance with your submission, please"
+        appendLetUsKnow
+    />
+)

--- a/services/app-web/src/components/ErrorAlert/index.ts
+++ b/services/app-web/src/components/ErrorAlert/index.ts
@@ -3,5 +3,6 @@ export { ErrorAlertSignIn } from './ErrorAlertSignIn'
 export { ErrorAlertSessionExpired } from './ErrorAlertSessionExpired'
 export { ErrorAlertSiteUnavailable } from './ErrorAlertSiteUnavailable'
 export { ErrorAlertFailedRequest } from './ErrorAlertFailedRequest'
+export { ErrorAlertScheduledMaintenance } from './ErrorAlertScheduledMaintenance'
 
 export type { ErrorAlertProps } from './ErrorAlert'

--- a/services/app-web/src/components/Header/Header.tsx
+++ b/services/app-web/src/components/Header/Header.tsx
@@ -16,6 +16,7 @@ import { ErrorAlertSignIn } from '../ErrorAlert'
 export type HeaderProps = {
     authMode: AuthModeType
     setAlert?: React.Dispatch<React.ReactElement>
+    disableLogin?: boolean
 }
 
 /**
@@ -24,6 +25,7 @@ export type HeaderProps = {
 export const Header = ({
     authMode,
     setAlert,
+    disableLogin = false,
 }: HeaderProps): React.ReactElement => {
     const { logout, loggedInUser, loginStatus } = useAuth()
     const { heading } = usePage()
@@ -61,6 +63,7 @@ export const Header = ({
                             loginStatus={loginStatus}
                             authMode={authMode}
                             logout={handleLogout}
+                            disableLogin={disableLogin}
                         />
                     </Grid>
                 </GridContainer>

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.test.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.test.tsx
@@ -28,6 +28,7 @@ describe('UserLoginInfo', () => {
                 loginStatus={'LOGGED_OUT'}
                 authMode={'LOCAL'}
                 logout={jestFn}
+                disableLogin={false}
             />
         )
         expect(screen.getByRole('link')).toBeInTheDocument()
@@ -42,6 +43,7 @@ describe('UserLoginInfo', () => {
                 loginStatus={'LOGGED_IN'}
                 authMode={'LOCAL'}
                 logout={jestFn}
+                disableLogin={false}
             />
         )
         expect(screen.getByRole('button')).toBeInTheDocument()
@@ -57,6 +59,7 @@ describe('UserLoginInfo', () => {
                 loginStatus={'LOGGED_IN'}
                 authMode={'LOCAL'}
                 logout={jestFn}
+                disableLogin={false}
             />
         )
         const feedbackLink = screen.getByRole('link', {
@@ -77,6 +80,23 @@ describe('UserLoginInfo', () => {
                 loginStatus={'LOADING'}
                 authMode={'LOCAL'}
                 logout={jestFn}
+                disableLogin={false}
+            />
+        )
+        expect(screen.queryByRole('button')).toBeNull()
+        expect(screen.queryByRole('link')).toBeNull()
+    })
+
+    it('displays nothing when disabled', () => {
+        const jestFn = jest.fn()
+
+        renderWithProviders(
+            <UserLoginInfo
+                user={undefined}
+                loginStatus={'LOGGED_OUT'}
+                authMode={'LOCAL'}
+                logout={jestFn}
+                disableLogin={true}
             />
         )
         expect(screen.queryByRole('button')).toBeNull()

--- a/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
+++ b/services/app-web/src/components/Header/UserLoginInfo/UserLoginInfo.tsx
@@ -64,15 +64,17 @@ export const UserLoginInfo = ({
     loginStatus,
     authMode,
     logout,
+    disableLogin,
 }: {
     user: User | undefined
     loginStatus: LoginStatusType
     authMode: AuthModeType
     logout: LogoutHandlerT
+    disableLogin: boolean
 }): React.ReactElement | null => {
     return user
         ? LoggedInUserInfo(user, logout)
-        : loginStatus === 'LOADING'
+        : loginStatus === 'LOADING' || disableLogin
         ? null
         : LoggedOutUserInfo(authMode)
 }

--- a/services/app-web/src/components/index.ts
+++ b/services/app-web/src/components/index.ts
@@ -73,6 +73,7 @@ export {
     ErrorAlertSiteUnavailable,
     ErrorAlertFailedRequest,
     ErrorAlertSessionExpired,
+    ErrorAlertScheduledMaintenance,
 } from './ErrorAlert'
 
 export { FilterAccordion } from './FilterAccordion'

--- a/services/app-web/src/constants/errors.ts
+++ b/services/app-web/src/constants/errors.ts
@@ -16,7 +16,6 @@ const ERROR_MESSAGES = {
     resubmit_error_heading: 'Resubmission error',
 }
 
-const MAIL_TO_SUPPORT =
-    'mailto: mc-review@cms.hhs.gov, mc-review-team@truss.works'
+const MAIL_TO_SUPPORT = 'mc-review@cms.hhs.gov'
 
 export { MAIL_TO_SUPPORT, ERROR_MESSAGES }

--- a/services/app-web/src/pages/App/AppBody.test.tsx
+++ b/services/app-web/src/pages/App/AppBody.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react'
 
 import {
+    ldUseClientSpy,
     renderWithProviders,
     userClickSignIn,
 } from '../../testHelpers/jestHelpers'
@@ -72,6 +73,46 @@ describe('App Body and routes', () => {
         })
     })
 
+    it('displays maintenance banner when flag is on', async () => {
+        ldUseClientSpy({ 'site-under-maintenance-banner': 'UNSCHEDULED' })
+        renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+            apolloProvider: {
+                mocks: [
+                    fetchCurrentUserMock({ statusCode: 200 }),
+                    indexHealthPlanPackagesMockSuccess(),
+                ],
+            },
+        })
+        expect(
+            await screen.findByRole('heading', { name: 'Site unavailable' })
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByText(
+                /MC-Review is currently unavailable due to technical issues/
+            )
+        ).toBeInTheDocument()
+    })
+
+    it('does not display maintenance banner when flag is off', async () => {
+        ldUseClientSpy({})
+        renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
+            apolloProvider: {
+                mocks: [
+                    fetchCurrentUserMock({ statusCode: 200 }),
+                    indexHealthPlanPackagesMockSuccess(),
+                ],
+            },
+        })
+        expect(
+            screen.queryByRole('heading', { name: 'Site Unavailable' })
+        ).toBeNull()
+        expect(
+            screen.queryByText(
+                /MC-Review is currently unavailable due to technical issues/
+            )
+        ).toBeNull()
+    })
+
     describe('/', () => {
         it('display dashboard when logged in', async () => {
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
@@ -138,6 +179,7 @@ describe('App Body and routes', () => {
         })
 
         it('when user clicks Sign In link, redirects to /auth', async () => {
+            ldUseClientSpy({})
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
             await userClickSignIn(screen)
 
@@ -147,6 +189,7 @@ describe('App Body and routes', () => {
         })
 
         it('display local login page when expected', async () => {
+            ldUseClientSpy({})
             renderWithProviders(<AppBody authMode={'LOCAL'} />)
 
             await userClickSignIn(screen)
@@ -160,6 +203,7 @@ describe('App Body and routes', () => {
         })
 
         it('display cognito signup page when expected', async () => {
+            ldUseClientSpy({})
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
             await userClickSignIn(screen)
 
@@ -177,6 +221,7 @@ describe('App Body and routes', () => {
 
     describe('page scrolling', () => {
         it('scroll top on page load', async () => {
+            ldUseClientSpy({})
             renderWithProviders(<AppBody authMode={'LOCAL'} />)
             await userClickSignIn(screen)
             expect(window.scrollTo).toHaveBeenCalledWith(0, 0)

--- a/services/app-web/src/pages/App/AppBody.test.tsx
+++ b/services/app-web/src/pages/App/AppBody.test.tsx
@@ -25,6 +25,7 @@ describe('App Body and routes', () => {
     })
 
     it('App renders without errors', () => {
+        ldUseClientSpy({ 'session-expiring-modal': false })
         renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
         const mainElement = screen.getByRole('main')
         expect(mainElement).toBeInTheDocument()
@@ -44,6 +45,7 @@ describe('App Body and routes', () => {
 
         it('shows test environment banner in val', () => {
             process.env.REACT_APP_STAGE_NAME = 'val'
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -60,6 +62,7 @@ describe('App Body and routes', () => {
 
         it('does not show test environment banner in prod', () => {
             process.env.REACT_APP_STAGE_NAME = 'prod'
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -74,7 +77,10 @@ describe('App Body and routes', () => {
     })
 
     it('displays maintenance banner when flag is on', async () => {
-        ldUseClientSpy({ 'site-under-maintenance-banner': 'UNSCHEDULED' })
+        ldUseClientSpy({
+            'site-under-maintenance-banner': 'UNSCHEDULED',
+            'session-expiring-modal': false,
+        })
         renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
             apolloProvider: {
                 mocks: [
@@ -94,7 +100,7 @@ describe('App Body and routes', () => {
     })
 
     it('does not display maintenance banner when flag is off', async () => {
-        ldUseClientSpy({})
+        ldUseClientSpy({ 'session-expiring-modal': false })
         renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
             apolloProvider: {
                 mocks: [
@@ -115,6 +121,7 @@ describe('App Body and routes', () => {
 
     describe('/', () => {
         it('display dashboard when logged in', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [
@@ -138,6 +145,7 @@ describe('App Body and routes', () => {
         })
 
         it('display landing page when logged out', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
             await waitFor(() => {
                 expect(
@@ -158,6 +166,7 @@ describe('App Body and routes', () => {
 
     describe('/auth', () => {
         it('when app loads at /auth route, Auth header is displayed', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/auth' },
             })
@@ -179,7 +188,7 @@ describe('App Body and routes', () => {
         })
 
         it('when user clicks Sign In link, redirects to /auth', async () => {
-            ldUseClientSpy({})
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
             await userClickSignIn(screen)
 
@@ -203,7 +212,7 @@ describe('App Body and routes', () => {
         })
 
         it('display cognito signup page when expected', async () => {
-            ldUseClientSpy({})
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />)
             await userClickSignIn(screen)
 
@@ -230,6 +239,7 @@ describe('App Body and routes', () => {
 
     describe('invalid routes', () => {
         it('redirect to landing page when logged out', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 routerProvider: { route: '/not-a-real-place' },
             })
@@ -244,6 +254,7 @@ describe('App Body and routes', () => {
         })
 
         it('redirects to 404 error page when logged in', async () => {
+            ldUseClientSpy({ 'session-expiring-modal': false })
             renderWithProviders(<AppBody authMode={'AWS_COGNITO'} />, {
                 apolloProvider: {
                     mocks: [fetchCurrentUserMock({ statusCode: 200 })],

--- a/services/app-web/src/pages/App/AppBody.tsx
+++ b/services/app-web/src/pages/App/AppBody.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { GovBanner, GridContainer } from '@trussworks/react-uswds'
+import { GovBanner } from '@trussworks/react-uswds'
 import styles from './AppBody.module.scss'
-
 import { AppRoutes } from './AppRoutes'
 import { Footer } from '../../components/Footer'
 import { Header } from '../../components/Header'
@@ -12,27 +11,7 @@ import { AuthModeType } from '../../common-code/config'
 import { useAuth } from '../../contexts/AuthContext'
 import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { featureFlags } from '../../common-code/featureFlags'
-import {
-    ErrorAlertScheduledMaintenance,
-    ErrorAlertSiteUnavailable,
-} from '../../components'
-
-function maintenanceBannerForVariation(flag: string): React.ReactNode {
-    if (flag === 'UNSCHEDULED') {
-        return (
-            <GridContainer>
-                <ErrorAlertSiteUnavailable />
-            </GridContainer>
-        )
-    } else if (flag === 'SCHEDULED') {
-        return (
-            <GridContainer>
-                <ErrorAlertScheduledMaintenance />
-            </GridContainer>
-        )
-    }
-    return undefined
-}
+import { Landing } from '../Landing/Landing'
 
 export function AppBody({
     authMode,
@@ -57,9 +36,6 @@ export function AppBody({
     )
 
     const siteUnderMaintenance = siteUnderMantenanceBannerFlag !== 'OFF'
-    const maintenanceBanner = maintenanceBannerForVariation(
-        siteUnderMantenanceBannerFlag
-    )
 
     return (
         <div id="App" className={styles.app}>
@@ -80,8 +56,8 @@ export function AppBody({
             />
             <main id="main-content" className={styles.mainContent} role="main">
                 {globalAlert && globalAlert}
-                {maintenanceBanner ? (
-                    maintenanceBanner
+                {siteUnderMaintenance ? (
+                    <Landing />
                 ) : loginStatus === 'LOADING' ? (
                     <Loading />
                 ) : (

--- a/services/app-web/src/pages/Landing/Landing.test.tsx
+++ b/services/app-web/src/pages/Landing/Landing.test.tsx
@@ -8,44 +8,16 @@ import { Landing } from './Landing'
 describe('Landing', () => {
     afterAll(() => jest.clearAllMocks())
 
-    it('displays maintenance banner when flag is on', async () => {
-        ldUseClientSpy({ 'site-maintenance-banner': true })
-        renderWithProviders(<Landing />)
-        expect(
-            await screen.findByRole('heading', { name: 'Site unavailable' })
-        ).toBeInTheDocument()
-        expect(
-            await screen.findByText(
-                /MC-Review is currently unavailable due to technical issues/
-            )
-        ).toBeInTheDocument()
-    })
-
-    it('does not display maintenance banner when flag is off', async () => {
-        ldUseClientSpy({ 'site-maintenance-banner': false })
-        renderWithProviders(<Landing />)
-        expect(
-            await screen.queryByRole('heading', { name: 'Site Unavailable' })
-        ).toBeNull()
-        expect(
-            await screen.queryByText(
-                /MC-Review is currently unavailable due to technical issues/
-            )
-        ).toBeNull()
-    })
-
     it('displays session expired when query parameter included', async () => {
         ldUseClientSpy({ 'site-maintenance-banner': false })
         renderWithProviders(<Landing />, {
             routerProvider: { route: '/?session-timeout' },
         })
         expect(
-            await screen.queryByRole('heading', { name: 'Session expired' })
+            screen.queryByRole('heading', { name: 'Session expired' })
         ).toBeNull()
         expect(
-            await screen.queryByText(
-                /You have been logged out due to inactivity/
-            )
+            screen.queryByText(/You have been logged out due to inactivity/)
         ).toBeNull()
     })
     it('does not display session expired by default', async () => {
@@ -54,14 +26,12 @@ describe('Landing', () => {
             routerProvider: { route: '/' },
         })
         expect(
-            await screen.queryByRole('heading', {
+            screen.queryByRole('heading', {
                 name: 'Session expired',
             })
         ).toBeNull()
         expect(
-            await screen.queryByText(
-                /You have been logged out due to inactivity/
-            )
+            screen.queryByText(/You have been logged out due to inactivity/)
         ).toBeNull()
     })
 })

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -1,38 +1,11 @@
 import React from 'react'
 import { GridContainer, Grid } from '@trussworks/react-uswds'
 import styles from './Landing.module.scss'
-import { featureFlags } from '../../common-code/featureFlags'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { useLocation } from 'react-router-dom'
-import {
-    ErrorAlertSiteUnavailable,
-    ErrorAlertScheduledMaintenance,
-    ErrorAlertSessionExpired,
-} from '../../components'
-
-function maintenanceBannerForVariation(flag: string): React.ReactNode {
-    if (flag === 'UNSCHEDULED') {
-        return <ErrorAlertSiteUnavailable />
-    } else if (flag === 'SCHEDULED') {
-        return <ErrorAlertScheduledMaintenance />
-    } else if (flag !== 'OFF') {
-        console.error('Unexpected under-maintenance-banner flag: ', flag)
-    }
-    return null
-}
+import { ErrorAlertSessionExpired } from '../../components'
 
 export const Landing = (): React.ReactElement => {
     const location = useLocation()
-    const ldClient = useLDClient()
-
-    const siteUnderMantenanceBannerFlag: string = ldClient?.variation(
-        featureFlags.SITE_UNDER_MAINTENANCE_BANNER.flag,
-        featureFlags.SITE_UNDER_MAINTENANCE_BANNER.defaultValue
-    )
-
-    const maybeMaintenaceBanner = maintenanceBannerForVariation(
-        siteUnderMantenanceBannerFlag
-    )
 
     const redirectFromSessionTimeout = new URLSearchParams(location.search).get(
         'session-timeout'
@@ -42,10 +15,7 @@ export const Landing = (): React.ReactElement => {
         <>
             <section className={styles.detailsSection}>
                 <GridContainer className={styles.detailsSectionContent}>
-                    {maybeMaintenaceBanner}
-                    {redirectFromSessionTimeout && !maybeMaintenaceBanner && (
-                        <ErrorAlertSessionExpired />
-                    )}
+                    {redirectFromSessionTimeout && <ErrorAlertSessionExpired />}
                     <Grid row gap className="margin-top-2">
                         <Grid tablet={{ col: 6 }}>
                             <div className={styles.detailsSteps}>


### PR DESCRIPTION
## Summary

I made a new launch darkly flag to replace the current LD flag that has variations instead of just being a bool. Setup that flag to control the new scheduled maintenance alert vs. the unschedule maintenance alert. 

Moved that alert up from the landing page to AppBody. 
* This means that it shows no matter where someone is in the app
* I haven’t investigated if that would mean there would be data loss if someone left a tab open in our app when maintenance started, I think that risk is worth investigating but not before our first maintenance tomorrow that we have notified people about. 
* It means that whatever page someone is on disappears, replaced by the banner. This too is something we can revisit after tomorrow but would require a lot more changes (each page would need to display the banner on its own) which I’d rather not do before tomorrow.

Also pass a bool down to Header to remove the login link whenever we are under maintenance. 

#### Related issues

#### Screenshots

#### Test cases covered
@JasonLin0991 I had to call the useClientSpy with `{}` even when I didn’t want to override the default value, let’s talk about that I think it would be best if you didn’t have to swizzle the method if you just want the defaults. 

I moved the tests up to AppBody as well

## QA guidance

You should be able to modify this variable in Dev and see it reflected in the review app.