### PR TITLE
MR-2994 Fix focus on rerender

### DIFF
--- a/services/app-web/src/components/FilterAccordion/FilterAccordion.tsx
+++ b/services/app-web/src/components/FilterAccordion/FilterAccordion.tsx
@@ -31,6 +31,7 @@ export const FilterAccordion = ({
                 <>
                     <div className={styles.filters}>{childFilters}</div>
                     <Button
+                        id="clearFiltersButton"
                         type="button"
                         className={styles.clearFilterButton}
                         unstyled

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -437,7 +437,7 @@ describe('HealthPlanPackageTable for CMS User (with filters)', () => {
         expect(submissionTypeCombobox).toBeInTheDocument()
 
         //Open state combobox and select Minnesota option
-        selectEvent.openMenu(stateCombobox)
+        await selectEvent.openMenu(stateCombobox)
         const stateOptions = screen.getByTestId('state-filter-options')
         expect(stateOptions).toBeInTheDocument()
         await waitFor(async () => {
@@ -448,7 +448,7 @@ describe('HealthPlanPackageTable for CMS User (with filters)', () => {
             await selectEvent.select(stateOptions, 'Minnesota')
         })
 
-        //Open submission type combobox and select Minnesota option
+        //Open submission type combobox and select 'Contract action and rate certification' option
         selectEvent.openMenu(submissionTypeCombobox)
         const submissionTypeOptions = screen.getByTestId(
             'submissionType-filter-options'
@@ -475,10 +475,13 @@ describe('HealthPlanPackageTable for CMS User (with filters)', () => {
         expect(rows[1]).toHaveTextContent('Minnesota') // row[0] is the header
         expect(rows[1]).toHaveTextContent(
             'Contract action and rate certification'
-        ) // row[0] is the header
+        )
         expect(
             screen.getByText('Displaying 1 of 3 submissions')
         ).toBeInTheDocument()
+        expect(global.window.location.href).toContain(
+            '#filters=stateName%3DMinnesota%26submissionType%3DContract+action+and+rate+certification'
+        )
     })
 
     it('should clear all filters when clear filter button is clicked', async () => {
@@ -570,6 +573,9 @@ describe('HealthPlanPackageTable for CMS User (with filters)', () => {
         expect(
             screen.getByText('Displaying 3 of 3 submissions')
         ).toBeInTheDocument()
+        expect(clearFiltersButton).toHaveFocus()
+        expect(global.window.location.href).not.toContain('stateName')
+        expect(global.window.location.href).not.toContain('submissionType')
     })
 
     it('displays no results found when filters return no results', async () => {

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.test.tsx
@@ -437,7 +437,7 @@ describe('HealthPlanPackageTable for CMS User (with filters)', () => {
         expect(submissionTypeCombobox).toBeInTheDocument()
 
         //Open state combobox and select Minnesota option
-        await selectEvent.openMenu(stateCombobox)
+        selectEvent.openMenu(stateCombobox)
         const stateOptions = screen.getByTestId('state-filter-options')
         expect(stateOptions).toBeInTheDocument()
         await waitFor(async () => {

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import {
     createColumnHelper,
     flexRender,
@@ -143,8 +143,39 @@ export const HealthPlanPackageTable = ({
     user,
     showFilters = false,
 }: PackageTableProps): React.ReactElement => {
+    const lastClickedElement = useRef<string | null>(null)
     const [columnFilters, setColumnFilters] =
         useAtom<ColumnFilter[]>(columnHash)
+
+    /* we store the last clicked element in a ref so that when the url is updated and the page rerenders
+        we can focus that element for the user.  this useEffect (with no dependency array) will run once on each render. 
+        Note that the React-y way to do this is to use forwardRef, but the clearFilters button is deeply nested 
+        and we'd wind passing down the ref through several layers to achieve what we can do here in a few lines 
+        with DOM methods */
+    useEffect(() => {
+        const currentValue = lastClickedElement.current
+        if (!currentValue) {
+            return
+        }
+        /* if the last clicked element had a label, it was a react-select component and the label will match our
+        naming convention */
+        const labels = document.getElementsByTagName('label')
+        const labelNames = Array.from(labels).map((item) => item.htmlFor)
+        const indexOfLabel = labelNames.indexOf(
+            `${currentValue}-filter-select-input`
+        )
+        if (indexOfLabel > -1) {
+            labels[indexOfLabel].focus()
+            /* if the last clicked element was NOT a label, then it was the clear filters button, which we can look
+            up by id */
+        } else {
+            const element = document.getElementById(currentValue)
+            if (element) {
+                element.focus()
+            }
+        }
+        lastClickedElement.current = null
+    })
 
     /* transform react-table's ColumnFilterState (stringified, formatted, and stored in the URL) to react-select's FilterOptionType
         and return only the items matching the FilterSelect component that's calling the function*/
@@ -313,6 +344,8 @@ export const HealthPlanPackageTable = ({
                                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                                 //@ts-ignore
                                 setColumnFilters([])
+                                lastClickedElement.current =
+                                    'clearFiltersButton'
                             }}
                             filterTitle="Filters"
                         >
@@ -321,13 +354,14 @@ export const HealthPlanPackageTable = ({
                                 name="state"
                                 label="State"
                                 filterOptions={stateFilterOptions}
-                                onChange={(selectedOptions) =>
+                                onChange={(selectedOptions) => {
+                                    lastClickedElement.current = 'state'
                                     stateColumn.setFilterValue(
                                         selectedOptions.map(
                                             (selection) => selection.value
                                         )
                                     )
-                                }
+                                }}
                             />
                             <FilterSelect
                                 value={getSelectedFiltersFromUrl(
@@ -336,13 +370,15 @@ export const HealthPlanPackageTable = ({
                                 name="submissionType"
                                 label="Submission type"
                                 filterOptions={submissionTypeOptions}
-                                onChange={(selectedOptions) =>
+                                onChange={(selectedOptions) => {
+                                    lastClickedElement.current =
+                                        'submissionType'
                                     submissionTypeColumn.setFilterValue(
                                         selectedOptions.map(
                                             (selection) => selection.value
                                         )
                                     )
-                                }
+                                }}
                             />
                         </FilterAccordion>
                     )}

--- a/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
+++ b/services/app-web/src/components/HealthPlanPackageTable/HealthPlanPackageTable.tsx
@@ -141,7 +141,7 @@ export const HealthPlanPackageTable = ({
     const [columnFilters, setColumnFilters] = useAtom(columnHash)
 
     /* we store the last clicked element in a ref so that when the url is updated and the page rerenders
-        we can focus that element for the user.  this useEffect (with no dependency array) will run once on each render. 
+        we can focus that element.  this useEffect (with no dependency array) will run once on each render. 
         Note that the React-y way to do this is to use forwardRef, but the clearFilters button is deeply nested 
         and we'd wind up passing down the ref through several layers to achieve what we can do here in a few lines 
         with DOM methods */


### PR DESCRIPTION
## Summary

There were a few outstanding issues from putting the filter state into the URL.

1) Focus was lost on the clicked element on rerender.  This fixes that.
2) A Typescript warning was being silenced. Using react-table's provided types and letting Jotai infer from those fixed that issue.
3) The URL is still URI encoded and hard to read.  This was partially addressed.  We can turn off encoding _within_ the values, but not between the values.  For example, what was 
 ```Contract%2520action%2520and%2520rate%2520certification``` 
is now  
```Contract+action+and+rate+certification```

But we still have substrings like  ```stateName%3DVirginia%252CMinnesota```

and that's because Jotai [runs `toString` on the URLParams](https://github.com/jotai-labs/jotai-location/blob/adabca165c3486cade23efa238f1f27d16255ff1/src/atomWithHash.ts#L91).  This is actually a reasonable thing for them to do.

#### Test cases covered

Added some tests to make sure the URL was what we expect, and one test to check focus on the "clear filters" button.  I could **not** get focus to work properly for react-select inside jest.  I gave up after the better part of a day.
