### PR TITLE
Fix typo in QA Bucket IAM

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -42,7 +42,7 @@ provider:
           Resource:
             - !Sub arn:aws:s3:::${self:service}-${sls:stage}-uploads-${AWS::AccountId}
             - !Sub arn:aws:s3:::${self:service}-${sls:stage}-avscan-${AWS::AccountId}
-            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-qa-${AWS::AccountId}/*
+            - !Sub arn:aws:s3:::${self:service}-${sls:stage}-qa-${AWS::AccountId}
 
 custom:
   region: ${aws:region}


### PR DESCRIPTION
## Summary

I just discovered a small copy/paste error with the IAM permission on the QA bucket for s3 list permissions. This removes the trailing wildcard to match the other buckets.
