### PR TITLE
Fix for AVScan failure

### DIFF
--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -203,20 +203,26 @@ function scanLocalFile(pathToFile) {
             `-d ${pathToFile}`,
         ]);
 
+        // Error status 1 means that the file is infected.
+        if (avResult.status === 1) {
+            utils.generateSystemMessage('SUCCESSFUL SCAN, FILE INFECTED');
+            return constants.STATUS_INFECTED_FILE;
+        } else if (avResult.status !== 0) {
+            utils.generateSystemMessage('-- SCAN FAILED WITH ERROR --');
+            console.error('stderror', avResult.stderr.toString());
+            console.error('stdout', avResult.stdout.toString());
+            console.error('err', avResult.error);
+            return constants.STATUS_ERROR_PROCESSING_FILE;
+        }
+
         utils.generateSystemMessage('SUCCESSFUL SCAN, FILE CLEAN');
-        console.log(avResult.toString());
+        console.info(avResult.stdout.toString());
 
         return constants.STATUS_CLEAN_FILE;
     } catch (err) {
-        // Error status 1 means that the file is infected.
-        if (err.status === 1) {
-            utils.generateSystemMessage('SUCCESSFUL SCAN, FILE INFECTED');
-            return constants.STATUS_INFECTED_FILE;
-        } else {
-            utils.generateSystemMessage('-- SCAN FAILED --');
-            console.log(err);
-            return constants.STATUS_ERROR_PROCESSING_FILE;
-        }
+        utils.generateSystemMessage('-- SCAN FAILED ERR--');
+        console.errror(err);
+        return constants.STATUS_ERROR_PROCESSING_FILE;
     }
 }
 

--- a/services/uploads/src/clamav.js
+++ b/services/uploads/src/clamav.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk');
 const fs = require('fs');
-const spawnSync = require('child_process').spawnSync;
+const child_process = require('child_process');
 const path = require('path');
 const constants = require('./constants');
 const utils = require('./utils');
@@ -34,7 +34,7 @@ async function listBucketFiles(bucketName) {
  */
 function updateAVDefinitonsWithFreshclam() {
     try {
-        let executionResult = execSync(
+        let executionResult = child_process.execSync(
             `${constants.PATH_TO_FRESHCLAM} --config-file=${constants.FRESHCLAM_CONFIG} --datadir=${constants.FRESHCLAM_WORK_DIR}`
         );
 
@@ -196,11 +196,13 @@ async function uploadAVDefinitions() {
  */
 function scanLocalFile(pathToFile) {
     try {
-        let avResult = spawnSync(constants.PATH_TO_CLAMAV, [
+        let avResult = child_process.spawnSync(constants.PATH_TO_CLAMAV, [
             '--stdout',
             '-v',
             '-a',
-            `-d ${pathToFile}`,
+            '-d',
+            '/tmp/',
+            pathToFile
         ]);
 
         // Error status 1 means that the file is infected.
@@ -208,7 +210,7 @@ function scanLocalFile(pathToFile) {
             utils.generateSystemMessage('SUCCESSFUL SCAN, FILE INFECTED');
             return constants.STATUS_INFECTED_FILE;
         } else if (avResult.status !== 0) {
-            utils.generateSystemMessage('-- SCAN FAILED WITH ERROR --');
+            utils.generateSystemMessage('SCAN FAILED WITH ERROR');
             console.error('stderror', avResult.stderr.toString());
             console.error('stdout', avResult.stdout.toString());
             console.error('err', avResult.error);


### PR DESCRIPTION
## Summary

This is a fix for the issue where the AV Scan service has not been scanning anything for months. 

Details of ongoing investigation here: https://docs.google.com/document/d/1V3OUC9ryF24YY-kQccUhMfKH4JRWXVAp7vhPH2ckW5M/

Causes:
* avDownloadDefinitions has been failing because execSync() was not defined
* avScan has been failing because the invocation of the binary was munged
* avScan has been ignoring the binary failing because spawnSync() doesn’t throw when it errors

#### Related issues

https://qmacbis.atlassian.net/browse/MR-3027

#### Test cases covered

I attempted to upload a bad file to this review app and it was correctly flagged as dirty.
