### PR TITLE
MR-2841: Remove rates across subs feature flag

### DIFF
--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -43,13 +43,6 @@ export const featureFlags = {
         defaultValue: 2,
     },
     /**
-     * Enables rates across submissions features
-     */
-    RATES_ACROSS_SUBMISSIONS: {
-        flag: 'rates-across-submissions',
-        defaultValue: false,
-    },
-    /**
      * Enables filter on CMS dashboard
      */
     CMS_DASHBOARD_FILTER: {

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.test.tsx
@@ -4,10 +4,7 @@ import {
     mockStateSubmission,
     mockMNState,
 } from '../../../testHelpers/apolloHelpers'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import * as usePreviousSubmission from '../../../hooks/usePreviousSubmission'
 import { RateDetailsSummarySection } from './RateDetailsSummarySection'
 import { RateInfoType } from '../../../common-code/healthPlanFormDataType'
@@ -530,7 +527,6 @@ describe('RateDetailsSummarySection', () => {
         })
     })
     it('renders all necessary information for documents with shared rate certifications', async () => {
-        ldUseClientSpy({ 'rates-across-submissions': true })
         const testSubmission = {
             ...draftSubmission,
             rateInfos: [
@@ -627,7 +623,6 @@ describe('RateDetailsSummarySection', () => {
             usePreviousSubmission,
             'usePreviousSubmission'
         ).mockReturnValue(true)
-        ldUseClientSpy({ 'rates-across-submissions': true })
         const testSubmission = {
             ...draftSubmission,
             rateInfos: [
@@ -700,7 +695,6 @@ describe('RateDetailsSummarySection', () => {
         })
     })
     it('does not render shared rate cert info if none are present', async () => {
-        ldUseClientSpy({ 'rates-across-submissions': true })
         const testSubmission = {
             ...draftSubmission,
             rateInfos: [

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -15,10 +15,8 @@ import {
     RateInfoType,
 } from '../../../common-code/healthPlanFormDataType'
 import { HealthPlanPackageStatus, Program } from '../../../gen/gqlClient'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { useIndexHealthPlanPackagesQuery } from '../../../gen/gqlClient'
 import { recordJSException } from '../../../otelHelpers'
-import { featureFlags } from '../../../common-code/featureFlags'
 import { getCurrentRevisionFromHealthPlanPackage } from '../../../gqlHelpers'
 import { SharedRateCertDisplay } from '../../../common-code/healthPlanFormDataType/UnlockedHealthPlanFormDataType'
 import { DataDetailMissingField } from '../../DataDetail/DataDetailMissingField'
@@ -54,12 +52,6 @@ export const RateDetailsSummarySection = ({
     const [packageNamesLookup, setPackageNamesLookup] =
         React.useState<PackageNamesLookupType | null>(null)
 
-    // Launch Darkly
-    const ldClient = useLDClient()
-    const showSharedRates = ldClient?.variation(
-        featureFlags.RATES_ACROSS_SUBMISSIONS.flag,
-        featureFlags.RATES_ACROSS_SUBMISSIONS.defaultValue
-    )
     const isSubmitted = submission.status === 'SUBMITTED'
     const isEditing = !isSubmitted && navigateTo !== undefined
     const isPreviousSubmission = usePreviousSubmission()
@@ -325,12 +317,9 @@ export const RateDetailsSummarySection = ({
                                 {!loading ? (
                                     <UploadedDocumentsTable
                                         documents={rateInfo.rateDocuments}
-                                        packagesWithSharedRateCerts={
-                                            showSharedRates &&
-                                            refreshPackagesWithSharedRateCert(
-                                                rateInfo
-                                            )
-                                        }
+                                        packagesWithSharedRateCerts={refreshPackagesWithSharedRateCert(
+                                            rateInfo
+                                        )}
                                         documentDateLookupTable={
                                             documentDateLookupTable
                                         }

--- a/services/app-web/src/pages/App/AppBody.tsx
+++ b/services/app-web/src/pages/App/AppBody.tsx
@@ -30,12 +30,12 @@ export function AppBody({
     useTealium()
     useOTEL()
 
-    const siteUnderMantenanceBannerFlag: string = ldClient?.variation(
+    const siteUnderMaintenanceBannerFlag: string = ldClient?.variation(
         featureFlags.SITE_UNDER_MAINTENANCE_BANNER.flag,
         featureFlags.SITE_UNDER_MAINTENANCE_BANNER.defaultValue
     )
 
-    const siteUnderMaintenance = siteUnderMantenanceBannerFlag !== 'OFF'
+    const siteUnderMaintenance = siteUnderMaintenanceBannerFlag !== 'OFF'
 
     return (
         <div id="App" className={styles.app}>

--- a/services/app-web/src/pages/Landing/Landing.tsx
+++ b/services/app-web/src/pages/Landing/Landing.tsx
@@ -22,13 +22,13 @@ function maintenanceBannerForVariation(flag: string): React.ReactNode {
 export const Landing = (): React.ReactElement => {
     const location = useLocation()
     const ldClient = useLDClient()
-    const siteUnderMantenanceBannerFlag: string = ldClient?.variation(
+    const siteUnderMaintenanceBannerFlag: string = ldClient?.variation(
         featureFlags.SITE_UNDER_MAINTENANCE_BANNER.flag,
         featureFlags.SITE_UNDER_MAINTENANCE_BANNER.defaultValue
     )
 
     const maybeMaintenaceBanner = maintenanceBannerForVariation(
-        siteUnderMantenanceBannerFlag
+        siteUnderMaintenanceBannerFlag
     )
 
     const redirectFromSessionTimeout = new URLSearchParams(location.search).get(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -25,7 +25,6 @@ import {
     TEST_XLS_FILE,
     TEST_PNG_FILE,
     dragAndDrop,
-    ldUseClientSpy,
     updateDateRange,
 } from '../../../testHelpers'
 import { RateDetails } from './RateDetails'
@@ -419,10 +418,6 @@ describe('RateDetails', () => {
         })
 
         it('progressively disclose new rate form fields as expected', async () => {
-            ldUseClientSpy({
-                'rates-across-submissions': true,
-            })
-
             renderWithProviders(
                 <RateDetails
                     draftSubmission={emptyRateDetailsDraft}
@@ -854,16 +849,7 @@ describe('RateDetails', () => {
         })
     })
 
-    describe('rates across submissions', () => {
-        beforeEach(() =>
-            ldUseClientSpy({
-                'rates-across-submissions': true,
-            })
-        )
-        afterEach(() => {
-            jest.clearAllMocks()
-        })
-
+    describe('handles rates across submissions', () => {
         it('correctly checks shared rate certification radios and selects shared packages', async () => {
             //Spy on useStatePrograms hook to get up-to-date state programs
             jest.spyOn(useStatePrograms, 'useStatePrograms').mockReturnValue(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -50,8 +50,6 @@ import { PageActions } from '../PageActions'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { useStatePrograms } from '../../../hooks'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../../common-code/featureFlags'
 import { useFocus } from '../../../hooks'
 import { ActuaryContactFields } from '../Contacts'
 import { useIndexHealthPlanPackagesQuery } from '../../../gen/gqlClient'
@@ -119,13 +117,6 @@ export const RateDetails = ({
     const navigate = useNavigate()
     const statePrograms = useStatePrograms()
 
-    // Launch Darkly
-    const ldClient = useLDClient()
-    const showRatesAcrossSubs = ldClient?.variation(
-        featureFlags.RATES_ACROSS_SUBMISSIONS.flag,
-        featureFlags.RATES_ACROSS_SUBMISSIONS.defaultValue
-    )
-
     // Rate documents state management
     const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
         React.useState(false)
@@ -138,12 +129,9 @@ export const RateDetails = ({
         PackageOptionType[]
     >([])
 
-    const rateDetailsFormSchema = RateDetailsFormSchema({
-        'rates-across-submissions': showRatesAcrossSubs,
-    })
+    const rateDetailsFormSchema = RateDetailsFormSchema()
 
     const { loading, error } = useIndexHealthPlanPackagesQuery({
-        skip: !showRatesAcrossSubs,
         onCompleted: async (data) => {
             const packagesWithUpdatedAt: Array<
                 { updatedAt: Date } & PackageOptionType
@@ -719,19 +707,83 @@ export const RateDetails = ({
                                                                 }
                                                             />
                                                         </FormGroup>
-                                                        {showRatesAcrossSubs && (
-                                                            <FormGroup
-                                                                error={
-                                                                    showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.hasSharedRateCert
-                                                                    ) ||
-                                                                    showFieldErrors(
+                                                        <FormGroup
+                                                            error={
+                                                                showFieldErrors(
+                                                                    rateErrorHandling(
+                                                                        errors
+                                                                            ?.rateInfos?.[
+                                                                            index
+                                                                        ]
+                                                                    )
+                                                                        ?.hasSharedRateCert
+                                                                ) ||
+                                                                showFieldErrors(
+                                                                    rateErrorHandling(
+                                                                        errors
+                                                                            ?.rateInfos?.[
+                                                                            index
+                                                                        ]
+                                                                    )
+                                                                        ?.packagesWithSharedRateCerts
+                                                                )
+                                                            }
+                                                        >
+                                                            <FieldYesNo
+                                                                className={
+                                                                    styles.radioGroup
+                                                                }
+                                                                id={`hasSharedRateCert.${index}.`}
+                                                                name={`rateInfos.${index}.hasSharedRateCert`}
+                                                                label="Was
+                                                                            this
+                                                                            rate
+                                                                            certification
+                                                                            uploaded
+                                                                            to
+                                                                            any
+                                                                            other
+                                                                            submissions?"
+                                                                showError={showFieldErrors(
+                                                                    rateErrorHandling(
+                                                                        errors
+                                                                            ?.rateInfos?.[
+                                                                            index
+                                                                        ]
+                                                                    )
+                                                                        ?.hasSharedRateCert
+                                                                )}
+                                                            />
+
+                                                            {rateInfo.hasSharedRateCert ===
+                                                                'YES' && (
+                                                                <>
+                                                                    <Label
+                                                                        htmlFor={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                    >
+                                                                        Please
+                                                                        select
+                                                                        the
+                                                                        submissions
+                                                                        that
+                                                                        also
+                                                                        contain
+                                                                        this
+                                                                        rate
+                                                                        certification.
+                                                                    </Label>
+                                                                    <Link
+                                                                        aria-label="View all submissions (opens in new window)"
+                                                                        href={
+                                                                            '/dashboard'
+                                                                        }
+                                                                        variant="external"
+                                                                        target="_blank"
+                                                                    >
+                                                                        View all
+                                                                        submissions
+                                                                    </Link>
+                                                                    {showFieldErrors(
                                                                         rateErrorHandling(
                                                                             errors
                                                                                 ?.rateInfos?.[
@@ -739,137 +791,70 @@ export const RateDetails = ({
                                                                             ]
                                                                         )
                                                                             ?.packagesWithSharedRateCerts
-                                                                    )
-                                                                }
-                                                            >
-                                                                <FieldYesNo
-                                                                    className={
-                                                                        styles.radioGroup
-                                                                    }
-                                                                    id={`hasSharedRateCert.${index}.`}
-                                                                    name={`rateInfos.${index}.hasSharedRateCert`}
-                                                                    label="Was
-                                                                                this
-                                                                                rate
-                                                                                certification
-                                                                                uploaded
-                                                                                to
-                                                                                any
-                                                                                other
-                                                                                submissions?"
-                                                                    showError={showFieldErrors(
-                                                                        rateErrorHandling(
-                                                                            errors
-                                                                                ?.rateInfos?.[
-                                                                                index
-                                                                            ]
-                                                                        )
-                                                                            ?.hasSharedRateCert
-                                                                    )}
-                                                                />
-
-                                                                {rateInfo.hasSharedRateCert ===
-                                                                    'YES' && (
-                                                                    <>
-                                                                        <Label
-                                                                            htmlFor={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                        >
-                                                                            Please
-                                                                            select
-                                                                            the
-                                                                            submissions
-                                                                            that
-                                                                            also
-                                                                            contain
-                                                                            this
-                                                                            rate
-                                                                            certification.
-                                                                        </Label>
-                                                                        <Link
-                                                                            aria-label="View all submissions (opens in new window)"
-                                                                            href={
-                                                                                '/dashboard'
-                                                                            }
-                                                                            variant="external"
-                                                                            target="_blank"
-                                                                        >
-                                                                            View
-                                                                            all
-                                                                            submissions
-                                                                        </Link>
-                                                                        {showFieldErrors(
-                                                                            rateErrorHandling(
-                                                                                errors
-                                                                                    ?.rateInfos?.[
-                                                                                    index
-                                                                                ]
-                                                                            )
-                                                                                ?.packagesWithSharedRateCerts
-                                                                        ) && (
-                                                                            <PoliteErrorMessage>
-                                                                                {getIn(
-                                                                                    errors,
-                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`
-                                                                                )}
-                                                                            </PoliteErrorMessage>
-                                                                        )}
-                                                                        <PackageSelect
-                                                                            //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
-                                                                            // causes issues with the default value when reloading the page
-                                                                            key={`${packageOptions}-${rateInfo.key}`}
-                                                                            inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                            name={`rateInfos.${index}.packagesWithSharedRateCerts`}
-                                                                            statePrograms={
-                                                                                statePrograms
-                                                                            }
-                                                                            initialValues={rateInfo.packagesWithSharedRateCerts.map(
-                                                                                (
-                                                                                    item
-                                                                                ) =>
-                                                                                    item.packageId
-                                                                                        ? item.packageId
-                                                                                        : ''
+                                                                    ) && (
+                                                                        <PoliteErrorMessage>
+                                                                            {getIn(
+                                                                                errors,
+                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`
                                                                             )}
-                                                                            packageOptions={
-                                                                                packageOptions
-                                                                            }
-                                                                            draftSubmissionId={
-                                                                                draftSubmission.id
-                                                                            }
-                                                                            isLoading={
-                                                                                loading
-                                                                            }
-                                                                            error={
-                                                                                error instanceof
-                                                                                Error
-                                                                            }
-                                                                            onChange={(
-                                                                                selectedOptions
+                                                                        </PoliteErrorMessage>
+                                                                    )}
+                                                                    <PackageSelect
+                                                                        //This key is required here because the combination of react-select, defaultValue, formik and apollo useQuery
+                                                                        // causes issues with the default value when reloading the page
+                                                                        key={`${packageOptions}-${rateInfo.key}`}
+                                                                        inputId={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                        name={`rateInfos.${index}.packagesWithSharedRateCerts`}
+                                                                        statePrograms={
+                                                                            statePrograms
+                                                                        }
+                                                                        initialValues={rateInfo.packagesWithSharedRateCerts.map(
+                                                                            (
+                                                                                item
                                                                             ) =>
-                                                                                setFieldValue(
-                                                                                    `rateInfos.${index}.packagesWithSharedRateCerts`,
-                                                                                    selectedOptions.map(
-                                                                                        (
-                                                                                            item: PackageOptionType
-                                                                                        ) => {
-                                                                                            return {
-                                                                                                packageName:
-                                                                                                    item.label.replace(
-                                                                                                        /\s\(.*?\)/g,
-                                                                                                        ''
-                                                                                                    ),
-                                                                                                packageId:
-                                                                                                    item.value,
-                                                                                            }
+                                                                                item.packageId
+                                                                                    ? item.packageId
+                                                                                    : ''
+                                                                        )}
+                                                                        packageOptions={
+                                                                            packageOptions
+                                                                        }
+                                                                        draftSubmissionId={
+                                                                            draftSubmission.id
+                                                                        }
+                                                                        isLoading={
+                                                                            loading
+                                                                        }
+                                                                        error={
+                                                                            error instanceof
+                                                                            Error
+                                                                        }
+                                                                        onChange={(
+                                                                            selectedOptions
+                                                                        ) =>
+                                                                            setFieldValue(
+                                                                                `rateInfos.${index}.packagesWithSharedRateCerts`,
+                                                                                selectedOptions.map(
+                                                                                    (
+                                                                                        item: PackageOptionType
+                                                                                    ) => {
+                                                                                        return {
+                                                                                            packageName:
+                                                                                                item.label.replace(
+                                                                                                    /\s\(.*?\)/g,
+                                                                                                    ''
+                                                                                                ),
+                                                                                            packageId:
+                                                                                                item.value,
                                                                                         }
-                                                                                    )
+                                                                                    }
                                                                                 )
-                                                                            }
-                                                                        />
-                                                                    </>
-                                                                )}
-                                                            </FormGroup>
-                                                        )}
+                                                                            )
+                                                                        }
+                                                                    />
+                                                                </>
+                                                            )}
+                                                        </FormGroup>
                                                         <FormGroup
                                                             error={showFieldErrors(
                                                                 rateErrorHandling(

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -304,7 +304,7 @@ Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', (id = 0) => {
         'radiogroup',
         { name: /Was this rate certification uploaded to any other submissions?/}
     ).should('exist').within(() => {
-        cy.findByRole('radio', { name: /No/}).click()
+        cy.findByText('No').click()
     })
 
     cy.findByText('Amendment to prior rate certification').click()

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -259,12 +259,11 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
 Cypress.Commands.add('fillOutNewRateCertification', () => {
     // Must be on '/submissions/:id/edit/rate-details'
     // Must be a contract and rates submission
-
     cy.findByRole(
         'radiogroup',
         { name: /Was this rate certification uploaded to any other submissions?/}
     ).should('exist').within(() => {
-        cy.findByRole('radio', { name: /No/}).click()
+        cy.findByText('No').click()
     })
 
     cy.findByText('New rate certification').click()
@@ -299,7 +298,6 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
 Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', (id = 0) => {
     // Must be on '/submissions/:id/edit/rate-details'
     // Must be a contract and rates submission
-
     cy.findByRole(
         'radiogroup',
         { name: /Was this rate certification uploaded to any other submissions?/}

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -259,7 +259,14 @@ Cypress.Commands.add('fillOutAmendmentToBaseContractDetails', () => {
 Cypress.Commands.add('fillOutNewRateCertification', () => {
     // Must be on '/submissions/:id/edit/rate-details'
     // Must be a contract and rates submission
-    cy.wait(2000)
+
+    cy.findByRole(
+        'radiogroup',
+        { name: /Was this rate certification uploaded to any other submissions?/}
+    ).should('exist').within(() => {
+        cy.findByRole('radio', { name: /No/}).click()
+    })
+
     cy.findByText('New rate certification').click()
     cy.findByText(
         'Certification of capitation rates specific to each rate cell'
@@ -292,7 +299,14 @@ Cypress.Commands.add('fillOutNewRateCertification', () => {
 Cypress.Commands.add('fillOutAmendmentToPriorRateCertification', (id = 0) => {
     // Must be on '/submissions/:id/edit/rate-details'
     // Must be a contract and rates submission
-    cy.wait(2000)
+
+    cy.findByRole(
+        'radiogroup',
+        { name: /Was this rate certification uploaded to any other submissions?/}
+    ).should('exist').within(() => {
+        cy.findByRole('radio', { name: /No/}).click()
+    })
+
     cy.findByText('Amendment to prior rate certification').click()
     cy.findByText(
         'Certification of capitation rates specific to each rate cell'


### PR DESCRIPTION
## Summary
[MR-2841](https://qmacbis.atlassian.net/jira/software/projects/MR/boards/234)

- Removed the `rates-across-submissions` flag from `flags.ts` and updated code everywhere that was using the flag.
- Fixed typos.
- Removed the `rates-across-submissions` flag from unit tests.
- Added code to cypress commands to handle rates-across-submissions questions 
   - `stateSubmissionFormCommands.ts`
      - `fillOutNewRateCertification`
      - `fillOutAmendmentToPriorRateCertification`

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
