### PR TITLE
Set our reviewapp deployments to be transient

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,12 +76,13 @@ jobs:
         run: |
           echo "${{steps.changed-services-action.outputs.changed-services}}"
 
-      - uses: chrnorm/deployment-action@releases/v2
+      - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment
         id: ghdeployment
         with:
           token: '${{ github.token }}'
           environment: review-apps
+          transient-environment: true
           description: stack ${{ steps.branch-name.outputs.stage-name-for-branch}}
           initial-status: in_progress
 
@@ -323,7 +324,7 @@ jobs:
 
       - name: Update deployment status (failure)
         if: failure() && needs.begin-deployment.result == 'success'
-        uses: chrnorm/deployment-status@releases/v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: '${{ github.token }}'
           state: 'failure'
@@ -331,7 +332,7 @@ jobs:
 
       - name: Update deployment status (success)
         if: needs.deploy-app.result == 'success'
-        uses: chrnorm/deployment-status@releases/v2
+        uses: chrnorm/deployment-status@v2
         with:
           token: '${{ github.token }}'
           environment-url: ${{ needs.finishing-prep.outputs.application-endpoint }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,11 @@ jobs:
       ]
     if: |
       always() &&
-      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped')
+      (needs.deploy-infra.result == 'success' || needs.deploy-infra.result == 'skipped') &&
+      needs.web-unit-tests.result == 'success' &&
+      needs.api-unit-tests.result == 'success' &&
+      needs.build-prisma-client-lambda-layer.result == 'success' &&
+      needs.begin-deployment.result == 'success'
     uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
       environment: dev


### PR DESCRIPTION
## Summary

Something changed in GH and our “deployment” lines in PRs have stopped having links in them that work pointing to the review app. 

All of our deployments are set to the environment: reviewapps, and it looks like now when a new review app deploys, it sets all previous deployments for “reviewapps” to be inactive. 

First try is to set each deployment to be “transient” which prevents that auto-inactive problem. But then we might want to delete them in destroy or something. We’ll see.

Also, setting environment: dev as part of our OIDC work seems to [unavoidably](https://github.com/actions/runner/issues/2120) create a deployment each time, which is why there are 3 extra “deployment” notifications per deployment in the PR history. 