### PR TITLE
MR-2886 CMS can upload a Q&A document

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -28,6 +28,7 @@ custom:
   parameterStoreMode: ${env:PARAMETER_STORE_MODE, ssm:/configuration/parameterStoreMode}
   auroraArn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:postgres-${sls:stage}.PostgresAuroraArn }
   document_uploads_bucket_arn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.DocumentUploadsBucketArn}
+  qa_uploads_bucket_arn: ${env:CF_CONFIG_IGNORED_LOCALLY, cf:uploads-${sls:stage}.QAUploadsBucketArn}
   secretsManagerSecret: aurora_postgres_${sls:stage} #pragma: allowlist secret
   reactAppAuthMode: ${env:REACT_APP_AUTH_MODE}
   reactAppOtelCollectorUrl: ${env:REACT_APP_OTEL_COLLECTOR_URL, ssm:/configuration/react_app_otel_collector_url}
@@ -111,6 +112,8 @@ provider:
           Resource:
             # this is the "public" folder for all regular uploads from Amplify
             - ${self:custom.document_uploads_bucket_arn}/allusers/*
+            - ${self:custom.qa_uploads_bucket_arn}/allusers/*
+
         - Effect: 'Allow'
           Action:
             - ssm:GetParameter

--- a/services/app-api/src/resolvers/questionAnswers/createQuestion.ts
+++ b/services/app-api/src/resolvers/questionAnswers/createQuestion.ts
@@ -22,6 +22,13 @@ export function createQuestionResolver(
             throw new ForbiddenError(msg)
         }
 
+        if (input.documents.length === 0 ) {
+            const msg = 'question documents are required'
+            logError('createQuestion', msg)
+            setErrorAttributesOnActiveSpan(msg, span)
+            throw new UserInputError(msg)
+        }
+
         // Return error if package is not found or errors
         const result = await store.findHealthPlanPackage(input.pkgID)
 

--- a/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/ContractDetailsSummarySection/ContractDetailsSummarySection.tsx
@@ -88,7 +88,8 @@ export const ContractDetailsSummarySection = ({
             // call the lambda to zip the files and get the url
             const zippedURL = await getBulkDlURL(
                 keysFromDocs,
-                submissionName + '-contract-details.zip'
+                submissionName + '-contract-details.zip',
+                'HEALTH_PLAN_DOCS'
             )
             if (zippedURL instanceof Error) {
                 console.info('ERROR: TODO: DISPLAY AN ERROR MESSAGE')

--- a/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/RateDetailsSummarySection/RateDetailsSummarySection.tsx
@@ -181,7 +181,8 @@ export const RateDetailsSummarySection = ({
             // call the lambda to zip the files and get the url
             const zippedURL = await getBulkDlURL(
                 keysFromDocs,
-                submissionName + '-rate-details.zip'
+                submissionName + '-rate-details.zip',
+                'HEALTH_PLAN_DOCS'
             )
             if (zippedURL instanceof Error) {
                 console.info('ERROR: TODO: DISPLAY AN ERROR MESSAGE')

--- a/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SupportingDocumentsSummarySection/SupportingDocumentsSummarySection.tsx
@@ -48,7 +48,7 @@ export const SupportingDocumentsSummarySection = ({
                             url: null,
                         }
 
-                    const documentLink = await getURL(key)
+                    const documentLink = await getURL(key, 'HEALTH_PLAN_DOCS')
                     return {
                         ...doc,
                         url: documentLink,
@@ -83,7 +83,8 @@ export const SupportingDocumentsSummarySection = ({
             // call the lambda to zip the files and get the url
             const zippedURL = await getBulkDlURL(
                 keysFromDocs,
-                submissionName + '-supporting-documents.zip'
+                submissionName + '-supporting-documents.zip',
+                'HEALTH_PLAN_DOCS'
             )
             if (zippedURL instanceof Error) {
                 console.info('ERROR: TODO: DISPLAY AN ERROR MESSAGE')

--- a/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/UploadedDocumentsTable/UploadedDocumentsTable.tsx
@@ -126,7 +126,7 @@ export const UploadedDocumentsTable = ({
                             url: null,
                         }
 
-                    const documentLink = await getURL(key)
+                    const documentLink = await getURL(key, 'HEALTH_PLAN_DOCS')
                     return {
                         ...doc,
                         url: documentLink,

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -16,7 +16,7 @@ type S3ContextT = {
     handleDeleteFile: (key: string, bucket: BucketShortName) => Promise<void>
 } & S3ClientT
 
-const S3Context = React.createContext<S3ClientT| undefined>(undefined)
+const S3Context = React.createContext<S3ClientT | undefined>(undefined)
 
 export type S3ProviderProps = {
     client: S3ClientT
@@ -33,9 +33,7 @@ const useS3 = (): S3ContextT => {
         throw new Error('useS3 can only be used within an S3Provider')
     }
 
-
     const { deleteFile, uploadFile, scanFile, getS3URL } = context
-
 
     const handleUploadFile = async (
         file: File,
@@ -65,11 +63,17 @@ const useS3 = (): S3ContextT => {
         }
     }
     // We often don't want to actually delete a resource from s3 and that's what permanentFileKeys is for
-    // e.g. document files that also exist on already submitted packages are part of permanent record, even if deleted on a later revision 
-    const handleDeleteFile = async (key: string, bucket: BucketShortName, permanentFileKeys?: string[]) => {
+    // e.g. document files that also exist on already submitted packages are part of permanent record, even if deleted on a later revision
+    const handleDeleteFile = async (
+        key: string,
+        bucket: BucketShortName,
+        permanentFileKeys?: string[]
+    ) => {
         const shouldPreserveFile =
             permanentFileKeys &&
-            Boolean(permanentFileKeys.some((testFileKey) => testFileKey === key))
+            Boolean(
+                permanentFileKeys.some((testFileKey) => testFileKey === key)
+            )
 
         if (!shouldPreserveFile) {
             const result = await deleteFile(key, bucket)
@@ -77,10 +81,9 @@ const useS3 = (): S3ContextT => {
                 throw new Error(`Error in S3 key: ${key}`)
             }
         }
-    return
     }
 
-    return {...context, handleUploadFile, handleScanFile, handleDeleteFile}
+    return { ...context, handleUploadFile, handleScanFile, handleDeleteFile }
 }
 
 export { S3Provider, useS3 }

--- a/services/app-web/src/contexts/S3Context.tsx
+++ b/services/app-web/src/contexts/S3Context.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react'
-
+import { isS3Error } from '../s3'
+import { S3FileData } from '../components'
 import type { S3ClientT } from '../s3'
 
-// For now, the Context is the same as the Client.
-// We make a typealias here so that if in the future they need to diverge we
-// have a separate ContextT
-type S3ContextT = S3ClientT
+type S3ContextT = {
+    handleUploadFile: (file: File) => Promise<S3FileData>
+    handleScanFile: (key: string) => Promise<void | Error>
+    handleDeleteFile: (key: string) => Promise<void>
+} & S3ClientT
 
-const S3Context = React.createContext<S3ContextT | undefined>(undefined)
+const S3Context = React.createContext<S3ClientT| undefined>(undefined)
 
 export type S3ProviderProps = {
     client: S3ClientT
@@ -21,11 +23,51 @@ function S3Provider({ client, children }: S3ProviderProps): React.ReactElement {
 const useS3 = (): S3ContextT => {
     const context = React.useContext(S3Context)
     if (context === undefined) {
-        // stole this trick from Kent C Dodds
-        // https://kentcdodds.com/blog/how-to-use-react-context-effectively
         throw new Error('useS3 can only be used within an S3Provider')
     }
-    return context
+
+
+    const { deleteFile, uploadFile, scanFile, getS3URL } = context
+
+
+    const handleUploadFile = async (file: File): Promise<S3FileData> => {
+        const s3Key = await uploadFile(file)
+
+        if (isS3Error(s3Key)) {
+            throw new Error(`Error in S3: ${file.name}`)
+        }
+
+        const s3URL = await getS3URL(s3Key, file.name)
+        return { key: s3Key, s3URL: s3URL }
+    }
+
+    const handleScanFile = async (key: string): Promise<void | Error> => {
+        try {
+            await scanFile(key)
+        } catch (e) {
+            if (isS3Error(e)) {
+                throw new Error(`Error in S3: ${key}`)
+            }
+            throw new Error('Scanning error: Scanning retry timed out')
+        }
+    }
+    // We often don't want to actually delete a resource from s3 and that's what permanentFileKeys is for
+    // e.g. document files that also exist on already submitted packages are part of permanent record, even if deleted on a later revision 
+    const handleDeleteFile = async (key: string, permanentFileKeys?: string[]) => {
+        const shouldPreserveFile =
+            permanentFileKeys &&
+            Boolean(permanentFileKeys.some((testFileKey) => testFileKey === key))
+
+        if (!shouldPreserveFile) {
+            const result = await deleteFile(key)
+            if (isS3Error(result)) {
+                throw new Error(`Error in S3 key: ${key}`)
+            }
+        }
+    return
+    }
+
+    return {...context, handleUploadFile, handleScanFile, handleDeleteFile}
 }
 
 export { S3Provider, useS3 }

--- a/services/app-web/src/hooks/useErrorSummary.ts
+++ b/services/app-web/src/hooks/useErrorSummary.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react'
+
+// Intended for use with ErrorSummary component
+const useErrorSummary = () => {
+    const errorSummaryHeadingRef = useRef<HTMLHeadingElement>(null)
+    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] = useState(false)
+    
+    useEffect(() => {
+        // Focus the error summary heading only if we are displaying
+        // validation errors and the heading element exist
+        if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
+            errorSummaryHeadingRef.current.focus()
+        }
+        setFocusErrorSummaryHeading(false)
+
+    }, [focusErrorSummaryHeading])
+
+    
+    return {
+        setFocusErrorSummaryHeading,
+        errorSummaryHeadingRef
+    }
+}
+
+export { useErrorSummary }

--- a/services/app-web/src/hooks/useFileUpload.ts
+++ b/services/app-web/src/hooks/useFileUpload.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react"
+import { FileItemT } from "../components"
+
+// Intended for use with FileUpload component 
+const useFileUpload = () => {
+    const [fileItems, setFileItems] = useState<FileItemT[]>([])
+    const [hasValidFiles, setHasValidFiles] = useState(false)
+    const [hasLoadingFiles, setHasLoadingFiles] = useState(false)
+
+    const onFileItemsUpdate = async ({
+        fileItems,
+    }: {
+        fileItems: FileItemT[]
+    }) => {
+        setFileItems(fileItems)
+    }
+    useEffect( () => {
+        console.log('in file update effect')
+           setHasValidFiles((prevValue) => { 
+                const updatedHasValidFiles = fileItems.every(
+                    (item) => item.status === 'UPLOAD_COMPLETE'
+                )
+                    return prevValue === updatedHasValidFiles ? prevValue : updatedHasValidFiles
+            })
+
+           setHasLoadingFiles((prevValue) => {
+               const updatedLoading =
+                   fileItems.some((item) => item.status === 'PENDING') ||
+                   fileItems.some((item) => item.status === 'SCANNING')
+
+               return prevValue === updatedLoading ? prevValue : updatedLoading
+           })
+
+    }, [fileItems])
+
+
+    return { hasValidFiles, hasLoadingFiles, setFileItems, fileItems, onFileItemsUpdate}
+
+}
+
+
+export {useFileUpload}

--- a/services/app-web/src/hooks/useFileUpload.ts
+++ b/services/app-web/src/hooks/useFileUpload.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { FileItemT } from "../components"
 
 // Intended for use with FileUpload component 
-const useFileUpload = () => {
+const useFileUpload = (shouldValidate = false) => {
     const [fileItems, setFileItems] = useState<FileItemT[]>([])
     const [hasValidFiles, setHasValidFiles] = useState(false)
     const [hasLoadingFiles, setHasLoadingFiles] = useState(false)
@@ -12,30 +12,77 @@ const useFileUpload = () => {
     }: {
         fileItems: FileItemT[]
     }) => {
-        setFileItems(fileItems)
+        setFileItems((prevValue) =>
+            fileItems.length !== prevValue.length ||
+            !prevValue.every((el) => fileItems.includes(el))
+                ? fileItems
+                : prevValue
+        )
     }
-    useEffect( () => {
-        console.log('in file update effect')
-           setHasValidFiles((prevValue) => { 
-                const updatedHasValidFiles = fileItems.every(
-                    (item) => item.status === 'UPLOAD_COMPLETE'
-                )
-                    return prevValue === updatedHasValidFiles ? prevValue : updatedHasValidFiles
-            })
+    useEffect(() => {
+        const allFilesComplete = fileItems.every(
+            (item) => item.status === 'UPLOAD_COMPLETE'
+        )
+        setHasValidFiles(allFilesComplete)
 
-           setHasLoadingFiles((prevValue) => {
-               const updatedLoading =
-                   fileItems.some((item) => item.status === 'PENDING') ||
-                   fileItems.some((item) => item.status === 'SCANNING')
-
-               return prevValue === updatedLoading ? prevValue : updatedLoading
-           })
-
+        if (!allFilesComplete) {
+            const updatedLoading = fileItems.some(
+                (item) =>
+                    item.status === 'PENDING' || item.status === 'SCANNING'
+            )
+            setHasLoadingFiles(updatedLoading)
+        }
     }, [fileItems])
 
+    const hasNoFiles = fileItems.length === 0;
 
-    return { hasValidFiles, hasLoadingFiles, setFileItems, fileItems, onFileItemsUpdate}
+    const fileUploadErrorMessage = shouldValidate? hasLoadingFiles
+            ? 'You must wait for all documents to finish uploading before continuing'
+            : fileItems.length === 0
+            ? 'You must upload at least one document'
+            : !hasValidFiles
+            ? 'You must remove all documents with error messages before continuing'
+            : undefined
+            : undefined
 
+    // This is a safeguard. In case something goes wrong with managing the state of file items (see FileUpload component for that logic) we surface a function to double check everything, filter out bad states, and log errors
+    // Can be used right before we transform React-based file items to database friendly formats 
+    const cleanFileItemsBeforeSave = () =>{     
+        return fileItems.reduce((cleanedFileItems, fileItem) => {
+            if (fileItem.status === 'UPLOAD_ERROR') {
+                console.info(
+                    'Attempting to save files that failed upload, discarding invalid files'
+                )
+            } else if (fileItem.status === 'SCANNING_ERROR') {
+                console.info(
+                    'Attempting to save files that failed scanning, discarding invalid files'
+                )
+            } else if (fileItem.status === 'DUPLICATE_NAME_ERROR') {
+                console.info(
+                    'Attempting to save files that are duplicate names, discarding duplicate'
+                )
+            } else if (!fileItem.s3URL)
+                console.info(
+                    'Attempting to save a seemingly valid file item is not yet uploaded to S3, this should not happen on form submit. Discarding file.'
+                )
+            else {
+                cleanedFileItems.push(fileItem)
+            }
+            return cleanedFileItems
+        }, [] as FileItemT[])
+
+    }
+
+    return {
+        hasNoFiles,
+        hasValidFiles,
+        hasLoadingFiles,
+        setFileItems,
+        fileItems,
+        onFileItemsUpdate,
+        fileUploadErrorMessage,
+        cleanFileItemsBeforeSave,
+    }
 }
 
 

--- a/services/app-web/src/hooks/useFileUpload.ts
+++ b/services/app-web/src/hooks/useFileUpload.ts
@@ -1,12 +1,14 @@
-import { useEffect, useState } from "react"
-import { FileItemT } from "../components"
+import { useEffect, useState } from 'react'
+import { FileItemT } from '../components'
 
-// Intended for use with FileUpload component 
+// Intended for use with FileUpload component
 const useFileUpload = (shouldValidate = false) => {
     const [fileItems, setFileItems] = useState<FileItemT[]>([])
     const [hasValidFiles, setHasValidFiles] = useState(false)
     const [hasLoadingFiles, setHasLoadingFiles] = useState(false)
+    const hasNoFiles = fileItems.length === 0
 
+    // This is surfaced to consumers instead of setFileItems to ensures we avoid unnecessary updates. This is a "functional update" in React language
     const onFileItemsUpdate = async ({
         fileItems,
     }: {
@@ -34,20 +36,23 @@ const useFileUpload = (shouldValidate = false) => {
         }
     }, [fileItems])
 
-    const hasNoFiles = fileItems.length === 0;
+    let fileUploadErrorMessage = undefined
 
-    const fileUploadErrorMessage = shouldValidate? hasLoadingFiles
-            ? 'You must wait for all documents to finish uploading before continuing'
-            : fileItems.length === 0
-            ? 'You must upload at least one document'
-            : !hasValidFiles
-            ? 'You must remove all documents with error messages before continuing'
-            : undefined
-            : undefined
+    if (shouldValidate) {
+        if (hasLoadingFiles) {
+            fileUploadErrorMessage =
+                'You must wait for all documents to finish uploading before continuing'
+        } else if (fileItems.length === 0) {
+            fileUploadErrorMessage = 'You must upload at least one document'
+        } else if (!hasValidFiles) {
+            fileUploadErrorMessage =
+                'You must remove all documents with error messages before continuing'
+        }
+    }
 
     // This is a safeguard. In case something goes wrong with managing the state of file items (see FileUpload component for that logic) we surface a function to double check everything, filter out bad states, and log errors
-    // Can be used right before we transform React-based file items to database friendly formats 
-    const cleanFileItemsBeforeSave = () =>{     
+    // Can be used right before we transform React-based "file items" to database friendly documents
+    const cleanFileItemsBeforeSave = () => {
         return fileItems.reduce((cleanedFileItems, fileItem) => {
             if (fileItem.status === 'UPLOAD_ERROR') {
                 console.info(
@@ -70,14 +75,12 @@ const useFileUpload = (shouldValidate = false) => {
             }
             return cleanedFileItems
         }, [] as FileItemT[])
-
     }
 
     return {
         hasNoFiles,
         hasValidFiles,
         hasLoadingFiles,
-        setFileItems,
         fileItems,
         onFileItemsUpdate,
         fileUploadErrorMessage,
@@ -85,5 +88,4 @@ const useFileUpload = (shouldValidate = false) => {
     }
 }
 
-
-export {useFileUpload}
+export { useFileUpload }

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -12,6 +12,7 @@ import { localGQLFetch, fakeAmplifyFetch } from './api'
 import { assertIsAuthMode } from './common-code/config'
 import { S3ClientT, newAmplifyS3Client, newLocalS3Client } from './s3'
 import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk'
+import  type { S3BucketConfigType } from './s3/s3Amplify'
 
 const gqlSchema = loader('../../app-web/src/gen/schema.graphql')
 
@@ -70,24 +71,29 @@ const apolloClient = new ApolloClient({
 const s3Region = process.env.REACT_APP_S3_REGION
 const s3LocalURL = process.env.REACT_APP_S3_LOCAL_URL
 const s3DocumentsBucket = process.env.REACT_APP_S3_DOCUMENTS_BUCKET
+const s3QABucket = process.env.REACT_APP_S3_QA_BUCKET 
 
-if (s3DocumentsBucket === undefined) {
+if (s3DocumentsBucket === undefined || s3QABucket === undefined) {
     throw new Error(
-        'To configure s3, you  must set REACT_APP_S3_DOCUMENTS_BUCKET'
+        'To configure s3, you  must set REACT_APP_S3_DOCUMENTS_BUCKET and REACT_APP_S3_QA_BUCKET'
     )
 }
 
 if (s3Region !== undefined && s3LocalURL !== undefined) {
     throw new Error(
-        'You cant set both REACT_APP_S3_REGION and REACT_APP_S3_LOCAL_URL. Pick one dependning on what environment you are in'
+        'You cant set both REACT_APP_S3_REGION and REACT_APP_S3_LOCAL_URL. Pick one depending on what environment you are in'
     )
 }
 
 let s3Client: S3ClientT
+const S3_BUCKETS_CONFIG: S3BucketConfigType = {
+          HEALTH_PLAN: s3DocumentsBucket,
+          QUESTION_AND_ANSWER: s3QABucket,
+      }
 if (s3Region) {
-    s3Client = newAmplifyS3Client(s3DocumentsBucket)
+    s3Client = newAmplifyS3Client(S3_BUCKETS_CONFIG)
 } else if (s3LocalURL) {
-    s3Client = newLocalS3Client(s3LocalURL, s3DocumentsBucket)
+    s3Client = newLocalS3Client(s3LocalURL, S3_BUCKETS_CONFIG)
 } else {
     throw new Error(
         'You must set either REACT_APP_S3_REGION or REACT_APP_S3_LOCAL_URL depending on what environment you are in'

--- a/services/app-web/src/index.tsx
+++ b/services/app-web/src/index.tsx
@@ -87,8 +87,8 @@ if (s3Region !== undefined && s3LocalURL !== undefined) {
 
 let s3Client: S3ClientT
 const S3_BUCKETS_CONFIG: S3BucketConfigType = {
-          HEALTH_PLAN: s3DocumentsBucket,
-          QUESTION_AND_ANSWER: s3QABucket,
+          HEALTH_PLAN_DOCS: s3DocumentsBucket,
+          QUESTION_ANSWER_DOCS: s3QABucket,
       }
 if (s3Region) {
     s3Client = newAmplifyS3Client(S3_BUCKETS_CONFIG)

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.module.scss
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.module.scss
@@ -1,0 +1,34 @@
+@import '../../../styles/uswdsImports.scss';
+@import '../../../styles/custom.scss';
+
+.formContainer {
+        padding-top: 5rem;
+    > [class^='usa-fieldset'] {
+        padding: units(4);
+        margin-bottom: units(2);
+        margin-top: units(2);
+        background: $cms-color-white;
+        border: 1px solid $theme-color-base-lighter;
+        @include u-radius('md');
+    }
+
+    h2 {
+        margin-top: 0;
+    }
+
+    > div[class^='usa-form-group']:not(:first-of-type) {
+        margin-top: 2.5rem;
+    }
+
+    &[class^='usa-form'] {
+
+        min-width: 100%;
+        max-width: 100%;
+
+        @include at-media(tablet){
+            min-width: 40rem;
+            max-width: 20rem;
+            margin: 0 auto;
+        }
+    }
+}

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.test.tsx
@@ -1,12 +1,19 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Route, Routes } from 'react-router-dom'
 import { UploadQuestions } from '../../QuestionsAnswers'
-import { renderWithProviders, TEST_DOC_FILE, TEST_PDF_FILE, TEST_XLS_FILE } from '../../../testHelpers'
+import {
+    dragAndDrop,
+    renderWithProviders,
+    TEST_DOC_FILE,
+    TEST_PDF_FILE,
+    TEST_PNG_FILE,
+    TEST_XLS_FILE,
+} from '../../../testHelpers'
 import { RoutesRecord } from '../../../constants/routes'
-import React from 'react'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
 import { fetchCurrentUserMock } from '../../../testHelpers/apolloMocks'
+import { createQuestionNetworkFailure } from '../../../testHelpers/apolloMocks/questionAnswerGQLMock'
 
 describe('UploadQuestions', () => {
     it('displays file upload for correct cms division', async () => {
@@ -38,21 +45,28 @@ describe('UploadQuestions', () => {
             ).toBeInTheDocument()
         })
         // Expect file upload input on page
-         expect(screen.getByTestId('file-input')).toBeInTheDocument()
+        expect(await screen.findByTestId('file-input')).toBeInTheDocument()
         expect(screen.getByLabelText('Upload questions')).toBeInTheDocument()
     })
 
     it('file upload accepts multiple pdf, word, excel documents', async () => {
         renderWithProviders(
-            <UploadQuestions />
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                    element={<UploadQuestions />}
+                />
+            </Routes>,
+            {
+                routerProvider: {
+                    route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+            }
         )
 
         const input = screen.getByLabelText('Upload questions')
         expect(input).toBeInTheDocument()
-        expect(input).toHaveAttribute(
-            'accept',
-            ACCEPTED_SUBMISSION_FILE_TYPES
-        )
+        expect(input).toHaveAttribute('accept', ACCEPTED_SUBMISSION_FILE_TYPES)
         await userEvent.upload(input, [
             TEST_DOC_FILE,
             TEST_PDF_FILE,
@@ -65,135 +79,153 @@ describe('UploadQuestions', () => {
         })
     })
 
+    it('displays form validation error if attempting to add question with zero files', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                    element={<UploadQuestions />}
+                />
+            </Routes>,
+            {
+                routerProvider: {
+                    route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+
+        const continueButton = screen.getByRole('button', {
+            name: 'Add questions',
+        })
+        expect(continueButton).not.toHaveAttribute('aria-disabled')
+
+        continueButton.click()
+
+        await waitFor(() => {
+            expect(
+                screen.getAllByText('You must upload at least one document')
+            ).toHaveLength(2)
+        })
+    })
+
+    it('displays file upload alert if attempting to add question with all invalid files', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                    element={<UploadQuestions />}
+                />
+            </Routes>,
+            {
+                routerProvider: {
+                    route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        const continueButton = screen.getByRole('button', {
+            name: 'Add questions',
+        })
+
+        const targetEl = screen.getByTestId('file-input-droptarget')
+        dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+        expect(
+            await screen.findByText('This is not a valid file type.')
+        ).toBeInTheDocument()
+
+        expect(continueButton).not.toHaveAttribute('aria-disabled')
+        continueButton.click()
+
+        expect(
+            await screen.findAllByText('You must upload at least one document')
+        ).toHaveLength(2)
+    })
+
+    it('displays file upload error alert if attempting to add question while a file is still uploading', async () => {
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                    element={<UploadQuestions />}
+                />
+            </Routes>,
+            {
+                routerProvider: {
+                    route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+                apolloProvider: {
+                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                },
+            }
+        )
+        const continueButton = screen.getByRole('button', {
+            name: 'Add questions',
+        })
+        const targetEl = screen.getByTestId('file-input-droptarget')
+
+        // upload one file
+        dragAndDrop(targetEl, [TEST_PDF_FILE])
+        const imageElFile1 = screen.getByTestId('file-input-preview-image')
+        expect(imageElFile1).toHaveClass('is-loading')
+        await waitFor(() => expect(imageElFile1).not.toHaveClass('is-loading'))
+
+        // upload second file
+        dragAndDrop(targetEl, [TEST_DOC_FILE])
+
+        const imageElFile2 = screen.getAllByTestId(
+            'file-input-preview-image'
+        )[1]
+        expect(imageElFile2).toHaveClass('is-loading')
+        fireEvent.click(continueButton)
+        await waitFor(() => {
+            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
+        })
+
+        expect(
+            await screen.findAllByText(
+                'You must wait for all documents to finish uploading before continuing'
+            )
+        ).toHaveLength(2)
+    })
+
     it('displays api error if createQuestion fails', async () => {
-        renderWithProviders(<UploadQuestions />, {
-            apolloProvider: {
-                mocks: [
-                    fetchCurrentUserMock({ statusCode: 200 }),
-                    addQuestionMock({ statusCode: 200 }),
-                ],
-            },
+        renderWithProviders(
+            <Routes>
+                <Route
+                    path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                    element={<UploadQuestions />}
+                />
+            </Routes>,
+            {
+                routerProvider: {
+                    route: `/submissions/15/question-and-answers/dmco/upload-questions`,
+                },
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({ statusCode: 200 }),
+                        createQuestionNetworkFailure(),
+                    ],
+                },
+            }
+        )
+
+        const createQuestionButton = screen.getByRole('button', {
+            name: 'Add questions',
         })
+        const input = screen.getByLabelText('Upload questions')
 
-           const createQuestionButton = screen.getByRole('button', {
-               name: 'Add questions',
-           })
-           const input = screen.getByLabelText('Upload questions')
+        await userEvent.upload(input, [TEST_DOC_FILE])
+        createQuestionButton.click()
 
-           await userEvent.upload(input, [TEST_DOC_FILE])
-
-           await waitFor(() => {
-               expect(createQuestionButton).not.toHaveAttribute('aria-disabled')
-           })
-
+        expect(await screen.findByText(TEST_DOC_FILE.name)).toBeInTheDocument()
+        expect(
+            await screen.findByText("We're having trouble loading this page.")
+        ).toBeDefined()
     })
-
-        it('Add questions button disabled with alert after first attempt to continue with zero files', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
-
-            continueButton.click()
-
-            await waitFor(() => {
-                expect(
-                    screen.getAllByText('You must upload at least one document')
-                ).toHaveLength(2)
-
-                expect(continueButton).toHaveAttribute('aria-disabled', 'true')
-            })
-        })
-
-        it('Display error alert if add questions clicked with all invalid files', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-
-            const targetEl = screen.getByTestId('file-input-droptarget')
-            dragAndDrop(targetEl, [TEST_PNG_FILE])
-
-            expect(
-                await screen.findByText('This is not a valid file type.')
-            ).toBeInTheDocument()
-
-            expect(continueButton).not.toHaveAttribute('aria-disabled')
-            continueButton.click()
-
-            expect(
-                await screen.findAllByText(
-                    'You must upload at least one document'
-                )
-            ).toHaveLength(2)
-
-            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
-        })
-
-        it('Display error alert if add questions clicked while a file is still uploading', async () => {
-            renderWithProviders(
-                <ContractDetails
-                    draftSubmission={emptyContractDetailsDraft}
-                    updateDraft={jest.fn()}
-                    previousDocuments={[]}
-                />,
-                {
-                    apolloProvider: {
-                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                    },
-                }
-            )
-            const continueButton = screen.getByRole('button', {
-                name: 'Continue',
-            })
-            const targetEl = screen.getByTestId('file-input-droptarget')
-
-            // upload one file
-            dragAndDrop(targetEl, [TEST_PDF_FILE])
-            const imageElFile1 = screen.getByTestId('file-input-preview-image')
-            expect(imageElFile1).toHaveClass('is-loading')
-            await waitFor(() =>
-                expect(imageElFile1).not.toHaveClass('is-loading')
-            )
-
-            // upload second file
-            dragAndDrop(targetEl, [TEST_DOC_FILE])
-
-            const imageElFile2 = screen.getAllByTestId(
-                'file-input-preview-image'
-            )[1]
-            expect(imageElFile2).toHaveClass('is-loading')
-            fireEvent.click(continueButton)
-            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
-
-            expect(
-                screen.getAllByText(
-                    'You must wait for all documents to finish uploading before continuing'
-                )
-            ).toHaveLength(2)
-        })
-    })
+})

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.test.tsx
@@ -1,12 +1,15 @@
 import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Route, Routes } from 'react-router-dom'
 import { UploadQuestions } from '../../QuestionsAnswers'
-import { renderWithProviders } from '../../../testHelpers'
+import { renderWithProviders, TEST_DOC_FILE, TEST_PDF_FILE, TEST_XLS_FILE } from '../../../testHelpers'
 import { RoutesRecord } from '../../../constants/routes'
 import React from 'react'
+import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
+import { fetchCurrentUserMock } from '../../../testHelpers/apolloMocks'
 
 describe('UploadQuestions', () => {
-    it('displays correct cms division', async () => {
+    it('displays file upload for correct cms division', async () => {
         const division = 'testDivision'
         renderWithProviders(
             <Routes>
@@ -34,5 +37,163 @@ describe('UploadQuestions', () => {
                 screen.queryByText(`Questions from ${division.toUpperCase()}`)
             ).toBeInTheDocument()
         })
+        // Expect file upload input on page
+         expect(screen.getByTestId('file-input')).toBeInTheDocument()
+        expect(screen.getByLabelText('Upload questions')).toBeInTheDocument()
     })
-})
+
+    it('file upload accepts multiple pdf, word, excel documents', async () => {
+        renderWithProviders(
+            <UploadQuestions />
+        )
+
+        const input = screen.getByLabelText('Upload questions')
+        expect(input).toBeInTheDocument()
+        expect(input).toHaveAttribute(
+            'accept',
+            ACCEPTED_SUBMISSION_FILE_TYPES
+        )
+        await userEvent.upload(input, [
+            TEST_DOC_FILE,
+            TEST_PDF_FILE,
+            TEST_XLS_FILE,
+        ])
+        await waitFor(() => {
+            expect(screen.getByText(TEST_DOC_FILE.name)).toBeInTheDocument()
+            expect(screen.getByText(TEST_PDF_FILE.name)).toBeInTheDocument()
+            expect(screen.getByText(TEST_XLS_FILE.name)).toBeInTheDocument()
+        })
+    })
+
+    it('displays api error if createQuestion fails', async () => {
+        renderWithProviders(<UploadQuestions />, {
+            apolloProvider: {
+                mocks: [
+                    fetchCurrentUserMock({ statusCode: 200 }),
+                    addQuestionMock({ statusCode: 200 }),
+                ],
+            },
+        })
+
+           const createQuestionButton = screen.getByRole('button', {
+               name: 'Add questions',
+           })
+           const input = screen.getByLabelText('Upload questions')
+
+           await userEvent.upload(input, [TEST_DOC_FILE])
+
+           await waitFor(() => {
+               expect(createQuestionButton).not.toHaveAttribute('aria-disabled')
+           })
+
+    })
+
+        it('Add questions button disabled with alert after first attempt to continue with zero files', async () => {
+            renderWithProviders(
+                <ContractDetails
+                    draftSubmission={emptyContractDetailsDraft}
+                    updateDraft={jest.fn()}
+                    previousDocuments={[]}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    },
+                }
+            )
+
+            const continueButton = screen.getByRole('button', {
+                name: 'Continue',
+            })
+            expect(continueButton).not.toHaveAttribute('aria-disabled')
+
+            continueButton.click()
+
+            await waitFor(() => {
+                expect(
+                    screen.getAllByText('You must upload at least one document')
+                ).toHaveLength(2)
+
+                expect(continueButton).toHaveAttribute('aria-disabled', 'true')
+            })
+        })
+
+        it('Display error alert if add questions clicked with all invalid files', async () => {
+            renderWithProviders(
+                <ContractDetails
+                    draftSubmission={emptyContractDetailsDraft}
+                    updateDraft={jest.fn()}
+                    previousDocuments={[]}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    },
+                }
+            )
+            const continueButton = screen.getByRole('button', {
+                name: 'Continue',
+            })
+
+            const targetEl = screen.getByTestId('file-input-droptarget')
+            dragAndDrop(targetEl, [TEST_PNG_FILE])
+
+            expect(
+                await screen.findByText('This is not a valid file type.')
+            ).toBeInTheDocument()
+
+            expect(continueButton).not.toHaveAttribute('aria-disabled')
+            continueButton.click()
+
+            expect(
+                await screen.findAllByText(
+                    'You must upload at least one document'
+                )
+            ).toHaveLength(2)
+
+            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
+        })
+
+        it('Display error alert if add questions clicked while a file is still uploading', async () => {
+            renderWithProviders(
+                <ContractDetails
+                    draftSubmission={emptyContractDetailsDraft}
+                    updateDraft={jest.fn()}
+                    previousDocuments={[]}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    },
+                }
+            )
+            const continueButton = screen.getByRole('button', {
+                name: 'Continue',
+            })
+            const targetEl = screen.getByTestId('file-input-droptarget')
+
+            // upload one file
+            dragAndDrop(targetEl, [TEST_PDF_FILE])
+            const imageElFile1 = screen.getByTestId('file-input-preview-image')
+            expect(imageElFile1).toHaveClass('is-loading')
+            await waitFor(() =>
+                expect(imageElFile1).not.toHaveClass('is-loading')
+            )
+
+            // upload second file
+            dragAndDrop(targetEl, [TEST_DOC_FILE])
+
+            const imageElFile2 = screen.getAllByTestId(
+                'file-input-preview-image'
+            )[1]
+            expect(imageElFile2).toHaveClass('is-loading')
+            fireEvent.click(continueButton)
+            expect(continueButton).toHaveAttribute('aria-disabled', 'true')
+
+            expect(
+                screen.getAllByText(
+                    'You must wait for all documents to finish uploading before continuing'
+                )
+            ).toHaveLength(2)
+        })
+    })

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -5,7 +5,7 @@ import {
     FormGroup,
     ButtonGroup,
 } from '@trussworks/react-uswds'
-import styles from '../../StateSubmission/StateSubmissionForm.module.scss'
+import styles from './UploadQuestions.module.scss'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useS3 } from '../../../contexts/S3Context'
 import {

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -46,7 +46,7 @@ export const UploadQuestions = () => {
     } = useFileUpload(shouldValidate)
     const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
         useErrorSummary()
-    const showFileUploadError = shouldValidate && !hasValidFiles
+    const showFileUploadError = shouldValidate && (!hasValidFiles || hasNoFiles)
     const fileUploadErrorFocusKey = hasNoFiles
         ? 'questions-upload'
         : '#file-items-list'
@@ -54,7 +54,7 @@ export const UploadQuestions = () => {
     const handleFormSubmit = async () => {
         // Currently documents validation happens (outside of the yup schema, which only handles the formik form data)
         // if there are any errors present in the documents list and we are in a validation state (relevant for Save as Draft) force user to clear validations to continue
-        if (!hasValidFiles) {
+        if (!hasValidFiles || hasNoFiles) {
             setShouldValidate(true)
             setFocusErrorSummaryHeading(true)
             return

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -1,14 +1,77 @@
-import React, { FormEvent } from 'react'
-import { GridContainer, Form as UswdsForm } from '@trussworks/react-uswds'
+import React, { FormEvent, useEffect, useState } from 'react'
+import { GridContainer, Form as UswdsForm, FormGroup, Link } from '@trussworks/react-uswds'
 import styles from '../../StateSubmission/StateSubmissionForm.module.scss'
 import { useParams } from 'react-router-dom'
+import { useS3 } from '../../../contexts/S3Context'
+import { ErrorSummary, FileItemT, FileUpload } from '../../../components'
+import { useFileUpload } from '../../../hooks/useFileUpload'
+import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
+import { PageActions } from '../../StateSubmission/PageActions'
 
 export const UploadQuestions = () => {
     const { division } = useParams<{ division: string }>()
+    const [shouldValidate, setShouldValidate] = React.useState(false)
 
-    //Placeholder submit function
-    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-        console.info(e)
+    /* Documents state management */
+    const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
+    const {
+        hasValidFiles,
+        hasLoadingFiles,
+        onFileItemsUpdate,
+        fileItems,
+    } = useFileUpload()
+    const [isSubmitting, setIsSubmitting] = useState(false) // mock same behavior as formik isSubmitting
+     const showFileUploadError = shouldValidate && !hasValidFiles
+    const documentsErrorMessage =
+        showFileUploadError && hasLoadingFiles
+            ? 'You must wait for all documents to finish uploading before continuing'
+            : showFileUploadError && fileItems.length === 0
+            ? ' You must upload at least one document'
+            : showFileUploadError && !hasValidFiles
+            ? ' You must remove all documents with error messages before continuing'
+            : undefined
+    const documentsErrorKey =
+        fileItems.length === 0 ? 'documents' : '#file-items-list'
+
+
+
+    /* Error summary state management */
+    const errorSummaryHeadingRef = React.useRef<HTMLHeadingElement>(null)
+    const [focusErrorSummaryHeading, setFocusErrorSummaryHeading] =
+        React.useState(false)
+        useEffect(() => {
+            // Focus the error summary heading only if we are displaying
+            // validation errors and the heading element exists
+            if (focusErrorSummaryHeading && errorSummaryHeadingRef.current) {
+                errorSummaryHeadingRef.current.focus()
+            }
+            setFocusErrorSummaryHeading(false)
+        }, [focusErrorSummaryHeading])
+
+   const handleFormSubmit = async (
+        setSubmitting: (isSubmitting: boolean) => void, // formik setSubmitting
+        options: {
+            shouldValidateDocuments: boolean
+            redirectPath: string
+        }
+    ) => {
+        // Currently documents validation happens (outside of the yup schema, which only handles the formik form data)
+        // if there are any errors present in the documents list and we are in a validation state (relevant for Save as Draft) force user to clear validations to continue
+        if (options.shouldValidateDocuments) {
+            if (!hasValidFiles) {
+                setShouldValidate(true)
+                setFocusErrorSummaryHeading(true)
+                setSubmitting(false)
+                return
+            }
+        }
+
+
+        try {
+            setSubmitting(false)
+        } catch (serverError) {
+            setSubmitting(false)
+        }
     }
 
     return (
@@ -18,12 +81,57 @@ export const UploadQuestions = () => {
                 id="AddQuestionsForm"
                 aria-label="Add Questions Form"
                 aria-describedby="form-guidance"
-                onSubmit={(e) => handleSubmit(e)}
+                onSubmit={(e) => console.log('ah')}
             >
                 <fieldset className="usa-fieldset">
+                    <legend>Add questions</legend>
                     <h2>Add questions</h2>
                     <p>{`Questions from ${division?.toUpperCase()}`}</p>
+
+                    <FormGroup error={showFileUploadError}>
+                        <FileUpload
+                            id="documents"
+                            name="documents"
+                            label="Upload contract"
+                            renderMode="list"
+                            aria-required
+                            error={documentsErrorMessage}
+                            hint={
+                                <>
+                                    <Link
+                                        aria-label="Document definitions and requirements (opens in new window)"
+                                        href={'/help#key-documents'}
+                                        variant="external"
+                                        target="_blank"
+                                    >
+                                        Document definitions and requirements
+                                    </Link>
+                                    <span>
+                                        This input only accepts PDF, CSV, DOC,
+                                        DOCX, XLS, XLSX, XLSM files.
+                                    </span>
+                                </>
+                            }
+                            accept={ACCEPTED_SUBMISSION_FILE_TYPES}
+                            uploadFile={handleUploadFile}
+                            scanFile={handleScanFile}
+                            deleteFile={handleDeleteFile}
+                            onFileItemsUpdate={onFileItemsUpdate}
+                        />
+                    </FormGroup>
                 </fieldset>
+                <PageActions
+                    backOnClick={async () => {
+                        // do not need to validate or resubmit if no documents are uploaded
+                        // if (fileItems.length === 0) {
+                        //     navigate('../type')
+                        // } else {
+                            // await handleFormSubmit( )
+                        }
+                    }
+                    disableContinue={showFileUploadError}
+                    actionInProgress={isSubmitting}
+                />
             </UswdsForm>
         </GridContainer>
     )

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -41,12 +41,12 @@ export const UploadQuestions = () => {
         hasValidFiles,
         hasNoFiles,
         onFileItemsUpdate,
-        fileUploadErrorMessage,
+        fileUploadError,
         cleanFileItemsBeforeSave,
     } = useFileUpload(shouldValidate)
     const { setFocusErrorSummaryHeading, errorSummaryHeadingRef } =
         useErrorSummary()
-    const showFileUploadError = shouldValidate && (!hasValidFiles || hasNoFiles)
+    const showFileUploadError = Boolean(shouldValidate && fileUploadError)
     const fileUploadErrorFocusKey = hasNoFiles
         ? 'questions-upload'
         : '#file-items-list'
@@ -103,10 +103,10 @@ export const UploadQuestions = () => {
                     {shouldValidate && (
                         <ErrorSummary
                             errors={
-                                showFileUploadError && fileUploadErrorMessage
+                                showFileUploadError && fileUploadError
                                     ? {
                                           [fileUploadErrorFocusKey]:
-                                              fileUploadErrorMessage,
+                                              fileUploadError,
                                       }
                                     : {}
                             }
@@ -121,11 +121,7 @@ export const UploadQuestions = () => {
                             label="Upload questions"
                             renderMode="list"
                             aria-required
-                            error={
-                                showFileUploadError
-                                    ? fileUploadErrorMessage
-                                    : ''
-                            }
+                            error={showFileUploadError ? fileUploadError : ''}
                             hint={
                                 <span>
                                     This input only accepts PDF, CSV, DOC, DOCX,
@@ -171,8 +167,6 @@ export const UploadQuestions = () => {
                             disabled={showFileUploadError}
                             onClick={async (e) => {
                                 e.preventDefault()
-                                // return apiLoading || showFileUploadError
-                                //     ? undefined
                                 await handleFormSubmit()
                             }}
                             animationTimeout={1000}

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -133,9 +133,15 @@ export const UploadQuestions = () => {
                                 </span>
                             }
                             accept={ACCEPTED_SUBMISSION_FILE_TYPES}
-                            uploadFile={handleUploadFile}
-                            scanFile={handleScanFile}
-                            deleteFile={handleDeleteFile}
+                            uploadFile={(file) =>
+                                handleUploadFile(file, 'QUESTION_ANSWER_DOCS')
+                            }
+                            scanFile={(key) =>
+                                handleScanFile(key, 'QUESTION_ANSWER_DOCS')
+                            }
+                            deleteFile={(key) =>
+                                handleDeleteFile(key, 'QUESTION_ANSWER_DOCS')
+                            }
                             onFileItemsUpdate={onFileItemsUpdate}
                         />
                     </FormGroup>

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -29,10 +29,8 @@ export const UploadQuestions = () => {
     const navigate = useNavigate()
 
     // api
-    const [
-        createQuestion,
-        { data: apiResponseData, loading: apiLoading, error: apiError },
-    ] = useCreateQuestionMutation()
+    const [createQuestion, { loading: apiLoading, error: apiError }] =
+        useCreateQuestionMutation()
 
     // page level state
     const [shouldValidate, setShouldValidate] = React.useState(false)
@@ -76,10 +74,9 @@ export const UploadQuestions = () => {
                 documents: questionDocs,
             }
 
-            await createQuestion({ variables: { input } })
+            const createResult = await createQuestion({ variables: { input } })
 
-            if (apiResponseData) {
-                console.info('Upload success')
+            if (createResult) {
                 navigate(`/submissions/${id}/question-and-answers`)
             }
         } catch (serverError) {

--- a/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionsAnswers/UploadQuestions/UploadQuestions.tsx
@@ -29,8 +29,10 @@ export const UploadQuestions = () => {
     const navigate = useNavigate()
 
     // api
-    const [createQuestion, { loading: apiLoading, error: apiError }] =
-        useCreateQuestionMutation()
+    const [
+        createQuestion,
+        { data: apiResponseData, loading: apiLoading, error: apiError },
+    ] = useCreateQuestionMutation()
 
     // page level state
     const [shouldValidate, setShouldValidate] = React.useState(false)
@@ -74,11 +76,9 @@ export const UploadQuestions = () => {
                 documents: questionDocs,
             }
 
-            const update = await createQuestion({ variables: { input } })
+            await createQuestion({ variables: { input } })
 
-            if (update instanceof Error) {
-                console.info('Error creating question')
-            } else {
+            if (apiResponseData) {
                 console.info('Upload success')
                 navigate(`/submissions/${id}/question-and-answers`)
             }

--- a/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/ContractDetails/ContractDetails.tsx
@@ -187,7 +187,7 @@ export const ContractDetails = ({
             )
 
         if (!isSubmittedFile) {
-            const result = await deleteFile(key)
+            const result = await deleteFile(key, 'HEALTH_PLAN_DOCS')
             if (isS3Error(result)) {
                 throw new Error(`Error in S3 key: ${key}`)
             }
@@ -196,19 +196,19 @@ export const ContractDetails = ({
     }
 
     const handleUploadFile = async (file: File): Promise<S3FileData> => {
-        const s3Key = await uploadFile(file)
+        const s3Key = await uploadFile(file, 'HEALTH_PLAN_DOCS')
 
         if (isS3Error(s3Key)) {
             throw new Error(`Error in S3: ${file.name}`)
         }
 
-        const s3URL = await getS3URL(s3Key, file.name)
+        const s3URL = await getS3URL(s3Key, file.name, 'HEALTH_PLAN_DOCS')
         return { key: s3Key, s3URL: s3URL }
     }
 
     const handleScanFile = async (key: string): Promise<void | Error> => {
         try {
-            await scanFile(key)
+            await scanFile(key, 'HEALTH_PLAN_DOCS')
         } catch (e) {
             if (isS3Error(e)) {
                 throw new Error(`Error in S3: ${key}`)

--- a/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
+++ b/services/app-web/src/pages/StateSubmission/Documents/Documents.tsx
@@ -138,7 +138,7 @@ export const Documents = ({
             )
 
         if (!isSubmittedFile) {
-            const result = await deleteFile(key)
+            const result = await deleteFile(key, 'HEALTH_PLAN_DOCS')
             if (isS3Error(result)) {
                 throw new Error(`Error in S3 key: ${key}`)
             }
@@ -147,19 +147,19 @@ export const Documents = ({
     }
 
     const handleUploadFile = async (file: File): Promise<S3FileData> => {
-        const s3Key = await uploadFile(file)
+        const s3Key = await uploadFile(file, 'HEALTH_PLAN_DOCS')
 
         if (isS3Error(s3Key)) {
             throw new Error(`Error in S3: ${file.name}`)
         }
 
-        const s3URL = await getS3URL(s3Key, file.name)
+        const s3URL = await getS3URL(s3Key, file.name, 'HEALTH_PLAN_DOCS')
         return { key: s3Key, s3URL: s3URL }
     }
 
     const handleScanFile = async (key: string): Promise<void | Error> => {
         try {
-            await scanFile(key)
+            await scanFile(key, 'HEALTH_PLAN_DOCS')
         } catch (e) {
             if (isS3Error(e)) {
                 throw new Error(`Error in S3: ${key}`)

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.tsx
@@ -317,7 +317,7 @@ export const RateDetails = ({
             )
 
         if (!isSubmittedFile) {
-            const result = await deleteFile(key)
+            const result = await deleteFile(key, 'HEALTH_PLAN_DOCS')
             if (isS3Error(result)) {
                 throw new Error(`Error in S3 key: ${key}`)
             }
@@ -326,19 +326,19 @@ export const RateDetails = ({
     }
 
     const handleUploadFile = async (file: File): Promise<S3FileData> => {
-        const s3Key = await uploadFile(file)
+        const s3Key = await uploadFile(file, 'HEALTH_PLAN_DOCS')
 
         if (isS3Error(s3Key)) {
             throw new Error(`Error in S3: ${file.name}`)
         }
 
-        const s3URL = await getS3URL(s3Key, file.name)
+        const s3URL = await getS3URL(s3Key, file.name, 'HEALTH_PLAN_DOCS')
         return { key: s3Key, s3URL: s3URL }
     }
 
     const handleScanFile = async (key: string): Promise<void | Error> => {
         try {
-            await scanFile(key)
+            await scanFile(key, 'HEALTH_PLAN_DOCS')
         } catch (e) {
             if (isS3Error(e)) {
                 throw new Error(`Error in S3: ${key}`)

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -29,11 +29,7 @@ import {
 } from '../../../gen/gqlClient'
 import { PageActions } from '../PageActions'
 import styles from '../StateSubmissionForm.module.scss'
-import {
-    GenericApiErrorBanner,
-    ProgramSelect,
-    FieldPreserveScrollPosition,
-} from '../../../components'
+import { GenericApiErrorBanner, ProgramSelect } from '../../../components'
 import type { HealthPlanFormPageProps } from '../StateSubmissionForm'
 import { useStatePrograms } from '../../../hooks/useStatePrograms'
 import {
@@ -373,11 +369,6 @@ export const SubmissionType = ({
                             <FormGroup
                                 error={showFieldErrors(errors.contractType)}
                             >
-                                <FieldPreserveScrollPosition
-                                    fieldName={
-                                        'contractType' as keyof SubmissionTypeFormValues
-                                    }
-                                />
                                 <Fieldset
                                     role="radiogroup"
                                     aria-required

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -15,6 +15,12 @@ type s3PutResponse = {
     key: string
 }
 
+type BucketShortName = 'HEALTH_PLAN_DOCS' | 'QUESTION_ANSWER_DOCS'
+type S3BucketConfigType = {
+    [K in BucketShortName]: string
+}
+
+
 function assertIsS3PutResponse(val: unknown): asserts val is s3PutResponse {
     if (typeof val === 'object' && val && !('key' in val)) {
         throw new Error('We dont have a key in this response')
@@ -33,14 +39,15 @@ function assertIsS3PutError(val: unknown): asserts val is s3PutError {
 }
 
 // MAIN
-// TODO pass buckets object
 // TODO clarify what gets3URL versus getURL are doing
-// type Bucket = 'HEALTH_PLAN_DOCS' | 'QA'
-// type Buckets = { [K in Bucket]: string}
 
-function newAmplifyS3Client(bucketName: string): S3ClientT {
+
+function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
     return {
-        uploadFile: async (file: File): Promise<string | S3Error> => {
+        uploadFile: async (
+            file: File,
+            bucket: BucketShortName
+        ): Promise<string | S3Error> => {
             const uuid = uuidv4()
             const ext = file.name.split('.').pop()
             //encode file names and decoding done in bulk_downloads.ts
@@ -48,7 +55,7 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
 
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
-                    bucket: process.env.REACT_APP_S3_QA_BUCKET,
+                    bucket,
                     contentType: file.type,
                     contentDisposition: `attachment; filename=${fileName}`,
                 })
@@ -70,10 +77,13 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             }
         },
 
-        deleteFile: async (filename: string): Promise<void | S3Error> => {
+        deleteFile: async (
+            filename: string,
+            bucket: BucketShortName
+        ): Promise<void | S3Error> => {
             try {
                 await Storage.remove(filename, {
-                    bucket: process.env.REACT_APP_S3_QA_BUCKET,
+                    bucket: bucketConfig[bucket],
                 })
                 return
             } catch (err) {
@@ -96,12 +106,15 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
             - In total, each file could be up to 40 sec in a loading state (20s wait for scanning + 8s of retries + extra time for uploading and scanning api requests to resolve)
             - While the file is scanning, returns 403. When scanning is complete, the resource returns 200
         */
-        scanFile: async (filename: string): Promise<void | S3Error> => {
+        scanFile: async (
+            filename: string,
+            bucket: BucketShortName
+        ): Promise<void | S3Error> => {
             try {
                 await waitFor(20000)
                 await retryWithBackoff(async () => {
                     await Storage.get(filename, {
-                        bucket: process.env.REACT_APP_S3_QA_BUCKET,
+                        bucket: bucketConfig[bucket],
                         download: true,
                     })
                 })
@@ -117,16 +130,23 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
                 throw err
             }
         },
-        getS3URL: async (key: string, fileName: string): Promise<string> => {
-            return `s3://${process.env.REACT_APP_S3_QA_BUCKET}/${key}/${fileName}`
+        getS3URL: async (
+            key: string,
+            fileName: string,
+            bucket: BucketShortName
+        ): Promise<string> => {
+            return `s3://${bucketConfig[bucket]}/${key}/${fileName}`
         },
         getKey: (s3URL: string) => {
             const key = parseKey(s3URL)
             return key instanceof Error ? null : key
         },
-        getURL: async (key: string): Promise<string> => {
+        getURL: async (
+            key: string,
+            bucket: BucketShortName
+        ): Promise<string> => {
             const result = await Storage.get(key, {
-                bucket: process.env.REACT_APP_S3_QA_BUCKET,
+                bucket: bucketConfig[bucket],
             })
             if (typeof result === 'string') {
                 return result
@@ -138,14 +158,15 @@ function newAmplifyS3Client(bucketName: string): S3ClientT {
         },
         getBulkDlURL: async (
             keys: string[],
-            filename: string
+            filename: string,
+            bucket: BucketShortName
         ): Promise<string | Error> => {
             const prependedKeys = keys.map((key) => `allusers/${key}`)
             const prependedFilename = `allusers/${filename}`
 
             const zipRequestParams = {
                 keys: prependedKeys,
-                bucket: bucketName,
+                bucket: bucketConfig[bucket],
                 zipFileName: prependedFilename,
             }
 
@@ -195,3 +216,4 @@ const retryWithBackoff = async (
 }
 
 export { newAmplifyS3Client }
+export type { BucketShortName, S3BucketConfigType }

--- a/services/app-web/src/s3/s3Amplify.ts
+++ b/services/app-web/src/s3/s3Amplify.ts
@@ -55,7 +55,7 @@ function newAmplifyS3Client(bucketConfig: S3BucketConfigType): S3ClientT {
 
             try {
                 const stored = await Storage.put(`${uuid}.${ext}`, file, {
-                    bucket,
+                    bucket: bucketConfig[bucket],
                     contentType: file.type,
                     contentDisposition: `attachment; filename=${fileName}`,
                 })

--- a/services/app-web/src/s3/s3Client.d.ts
+++ b/services/app-web/src/s3/s3Client.d.ts
@@ -1,11 +1,26 @@
-import { S3Error } from './s3Error'
+import type { BucketShortName } from './s3Amplify'
+import type { S3Error } from './s3Error'
 
 export type S3ClientT = {
-    uploadFile: (file: File) => Promise<string | S3Error>
-    deleteFile: (key: string) => Promise<void | S3Error>
-    scanFile: (key: string) => Promise<void | S3Error>
+    uploadFile: (
+        file: File,
+        bucket: BucketShortName
+    ) => Promise<string | S3Error>
+    deleteFile: (
+        key: string,
+        bucket: BucketShortName
+    ) => Promise<void | S3Error>
+    scanFile: (key: string, bucket: BucketShortName) => Promise<void | S3Error>
     getKey: (S3URL: string) => string | null
-    getURL: (key: string) => Promise<string>
-    getS3URL: (key: string, filename: string) => Promise<string>
-    getBulkDlURL: (keys: string[], filename: string) => Promise<string | Error>
+    getURL: (key: string, bucket: BucketShortName) => Promise<string>
+    getS3URL: (
+        key: string,
+        filename: string,
+        bucket: BucketShortName
+    ) => Promise<string>
+    getBulkDlURL: (
+        keys: string[],
+        filename: string,
+        bucket: BucketShortName
+    ) => Promise<string | Error>
 }

--- a/services/app-web/src/testHelpers/apolloMocks/questionAnswerGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/questionAnswerGQLMock.ts
@@ -1,15 +1,56 @@
 import { MockedResponse } from '@apollo/client/testing'
 import {
     CreateQuestionDocument,
+    CreateQuestionInput,
     CreateQuestionMutation,
+    Question as QuestionType,
 } from '../../gen/gqlClient'
+import { mockValidCMSUser } from './userGQLMock'
 
-const createQuestionNetworkFailure =
-    (): MockedResponse<CreateQuestionMutation> => {
-        return {
-            request: { query: CreateQuestionDocument },
-            error: new Error('A network error occurred'),
-        }
+const createQuestionSuccess = (
+    question?: CreateQuestionInput | Partial<CreateQuestionInput>
+): MockedResponse<CreateQuestionMutation> => {
+    const defaultQuestionInput: CreateQuestionInput = {
+        dueDate: new Date('11-11-2100'),
+        pkgID: '123-abc',
+        documents: [
+            {
+                name: 'Test document',
+                s3URL: 's3://test-document.doc',
+            },
+        ],
     }
 
-export { createQuestionNetworkFailure }
+    const testInput = { ...defaultQuestionInput, ...question }
+
+    return {
+        request: {
+            query: CreateQuestionDocument,
+            variables: { input: testInput },
+        },
+        result: {
+            data: {
+                createQuestion: {
+                    question: {
+                        id: 'test123',
+                        pkgID: testInput.pkgID,
+                        createdAt: new Date(),
+                        addedBy: mockValidCMSUser(),
+                        documents: testInput.documents,
+                    },
+                },
+            },
+        },
+    }
+}
+
+const createQuestionNetworkFailure = (
+    question?: QuestionType | Partial<QuestionType>
+): MockedResponse<CreateQuestionMutation> => {
+    return {
+        request: { query: CreateQuestionDocument },
+        error: new Error('A network error occurred'),
+    }
+}
+
+export { createQuestionNetworkFailure, createQuestionSuccess }

--- a/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/userGQLMock.ts
@@ -1,5 +1,9 @@
 import { MockedResponse } from '@apollo/client/testing'
-import { FetchCurrentUserDocument, User as UserType } from '../../gen/gqlClient'
+import {
+    CmsUser,
+    FetchCurrentUserDocument,
+    User as UserType,
+} from '../../gen/gqlClient'
 
 import { mockMNState } from './stateMock'
 function mockValidUser(): UserType {
@@ -14,7 +18,7 @@ function mockValidUser(): UserType {
     }
 }
 
-function mockValidCMSUser(): UserType {
+function mockValidCMSUser(): CmsUser {
     return {
         __typename: 'CMSUser' as const,
         id: 'bar-id',

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -12,6 +12,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${aws:region}
   document_uploads_bucket_arn: ${cf:uploads-${sls:stage}.DocumentUploadsBucketArn}
+  qa_uploads_bucket_arn: ${cf:uploads-${sls:stage}.QAUploadsBucketName}
   api_gateway_rest_api_name: ${cf:infra-api-${sls:stage}.ApiGatewayRestApiId}
   application_endpoint_url: ${cf:ui-${sls:stage}.CloudFrontEndpointUrl}
   okta_metadata_url: ${ssm:/configuration/okta_metadata_url}
@@ -196,6 +197,7 @@ resources:
                   Resource:
                     # Must use Join here.  See: https://github.com/serverless/serverless/issues/3565
                     - ${self:custom.document_uploads_bucket_arn}/allusers/*
+                    - ${self:custom.qa_uploads_bucket_arn}/allusers/*
                     # This private bucket is used by any files stored "private" by Amplify
                     # https://docs.amplify.aws/lib/storage/configureaccess/q/platform/js/
                     - Fn::Join:

--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -12,7 +12,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${aws:region}
   document_uploads_bucket_arn: ${cf:uploads-${sls:stage}.DocumentUploadsBucketArn}
-  qa_uploads_bucket_arn: ${cf:uploads-${sls:stage}.QAUploadsBucketName}
+  qa_uploads_bucket_arn: ${cf:uploads-${sls:stage}.QAUploadsBucketArn}
   api_gateway_rest_api_name: ${cf:infra-api-${sls:stage}.ApiGatewayRestApiId}
   application_endpoint_url: ${cf:ui-${sls:stage}.CloudFrontEndpointUrl}
   okta_metadata_url: ${ssm:/configuration/okta_metadata_url}


### PR DESCRIPTION
## Summary
Add file upload to add questions page. 

Other refactors: 
-  new React hooks -  `useFileUpload` and `useErrorSummary`. 
- edited `useS3` to include handling for bucket name and also hold S3 utility functions

#### Related issues
https://qmacbis.atlassian.net/browse/MR-2886 
Also fixed this viewport scroll position bug https://qmacbis.atlassian.net/browse/MR-2997 

#### Screenshots
![Screenshot 2023-02-23 at 11 33 56 AM](https://user-images.githubusercontent.com/10750442/220985196-7ceb4e98-a947-4f11-bbe3-db347fb40aa7.png)

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->
JEST:
- file upload accepts multiple pdf, word, excel documents
- displays form validation error if attempting to add question with zero files
- displays file upload alert if attempting to add question with all invalid files
- displays api error if createQuestion fails

CYPRESS:
- none yet, will address this as part of https://qmacbis.atlassian.net/browse/MR-2887 so we just add one full test for Q&A.


## QA guidance
See ticket AC and also
- Make sure file uploads, downloads, bulk downloads still working (since I changed how s3 works slightly to handle different buckets for different use cases)

<!---These are developer instructions on how to test or validate the work -->
