### PR TITLE
Make updatedAt tags used for testing uploads service be valid

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -98,7 +98,8 @@ functions:
     handler: src/lambdas/index.avScan
     name: ${self:service}-${sls:stage}-avScan
     timeout: 300 # 300 seconds = 5 minutes. Average scan is 25 seconds.
-    memorySize: 3008
+    memorySize: 4096
+    ephemeralStorageSize: 1024
     layers:
       - !Ref ClamDefsLambdaLayer
       - arn:aws:lambda:us-east-1:901920570463:layer:aws-otel-nodejs-amd64-ver-1-9-1:1

--- a/services/uploads/src/deps/clamAV/clamAV.ts
+++ b/services/uploads/src/deps/clamAV/clamAV.ts
@@ -179,7 +179,6 @@ function scanForInfectedFiles(
         const avResult = spawnSync(config.pathToClamav, [
             '--stdout',
             '-v',
-            '--statistics',
             '-d',
             config.pathToDefintions,
             pathToScan,

--- a/services/uploads/src/deps/clamAV/clamAV.ts
+++ b/services/uploads/src/deps/clamAV/clamAV.ts
@@ -178,6 +178,8 @@ function scanForInfectedFiles(
         console.info('Executing clamav')
         const avResult = spawnSync(config.pathToClamav, [
             '--stdout',
+            '-v',
+            '--statistics',
             '-d',
             config.pathToDefintions,
             pathToScan,

--- a/services/uploads/src/deps/clamAV/clamAV.ts
+++ b/services/uploads/src/deps/clamAV/clamAV.ts
@@ -3,6 +3,7 @@ import { spawnSync } from 'child_process'
 import { readdir } from 'fs/promises'
 
 import { S3UploadsClient } from '../s3'
+import { generateUploadedAtTagSet } from '../../lib/tags'
 
 interface ClamAV {
     downloadAVDefinitions: () => Promise<undefined | Error>
@@ -99,14 +100,7 @@ async function uploadAVDefinitions(
         return s3Client
             .uploadObject(key, config.bucketName, filepath)
             .then(() => {
-                const tags = {
-                    TagSet: [
-                        {
-                            Key: 'uploadedAt',
-                            Value: new Date().toString(),
-                        },
-                    ],
-                }
+                const tags = generateUploadedAtTagSet()
 
                 return s3Client.tagObject(key, config.bucketName, tags)
             })

--- a/services/uploads/src/lib/tags.ts
+++ b/services/uploads/src/lib/tags.ts
@@ -53,7 +53,18 @@ function virusScanStatus(tags: Tag[]): ScanStatus | Error | undefined {
     return undefined
 }
 
-function uploadedAt(tags: Tag[]): Date | Error | undefined {
+function generateUploadedAtTagSet() {
+    return {
+        TagSet: [
+            {
+                Key: 'uploadedAt',
+                Value: new Date().toISOString(),
+            },
+        ],
+    }
+}
+
+function parseUploadedAtFromTags(tags: Tag[]): Date | Error | undefined {
     for (const tag of tags) {
         if (tag.Key === 'uploadedAt') {
             if (!tag.Value) {
@@ -67,6 +78,12 @@ function uploadedAt(tags: Tag[]): Date | Error | undefined {
     return undefined
 }
 
-export { generateVirusScanTagSet, virusScanStatus, uploadedAt, isScanStatus }
+export {
+    generateVirusScanTagSet,
+    virusScanStatus,
+    parseUploadedAtFromTags as uploadedAt,
+    generateUploadedAtTagSet,
+    isScanStatus,
+}
 
 export type { ScanStatus }


### PR DESCRIPTION
## Summary

I added updatedAt tags for the av definition files to make the test run smoothly. Those tags were invalid S3 tags (they had parens in them) so this fixes that and has a little test to make sure. 

#### Test cases covered

Tested the tag value. I should have been doing ISO string anyway. 

## QA guidance

Do you see errors in the avUploadDefinitions service