### PR TITLE
OIDC for higher environments

### DIFF
--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -46,12 +46,12 @@ jobs:
           # if the environment isn't one of [dev, val, prod], fail the job
           run: |
             echo "stage-name=$(
-              if [[ "${{ github.event.inputs.environment }}" == "val" || "${{ github.event.inputs.environment }}" == "prod" ]]; then
-                echo "${{ github.event.inputs.environment }}";
-              elif [[ ${{ github.event.inputs.environment }} == "dev" ]]; then
+              if [[ "${{ inputs.environment }}" == "val" || "${{ inputs.environment }}" == "prod" ]]; then
+                echo "${{ inputs.environment }}";
+              elif [[ ${{ inputs.environment }} == "dev" ]]; then
                 echo "main";
               else
-                echo "Invalid environment: ${{ github.event.inputs.environment }}" >&2;
+                echo "Invalid environment: ${{ inputs.environment }}" >&2;
                 kill -HUP $$
               fi
             )" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -39,13 +39,30 @@ jobs:
           run: |
             lerna run build:ci-scripts
 
+        - name: Set the correct stage name for the bootstrapped OIDC role based on the environment
+          id: set-oidc-stage-name
+          shell: bash
+          # the dev environment uses 'main' as the stage name; otherwise the stage name is same as the environment name
+          # if the environment isn't one of [dev, val, prod], fail the job
+          run: |
+            echo "stage-name=$(
+              if [[ "${{ github.event.inputs.environment }}" == "val" || "${{ github.event.inputs.environment }}" == "prod" ]]; then
+                echo "${{ github.event.inputs.environment }}";
+              elif [[ ${{ github.event.inputs.environment }} == "dev" ]]; then
+                echo "main";
+              else
+                echo "Invalid environment: ${{ github.event.inputs.environment }}" >&2;
+                kill -HUP $$
+              fi
+            )" >> $GITHUB_OUTPUT
+
         - name: Get AWS credentials
           uses: ./.github/actions/get_aws_credentials
           with:
             region: ${{ secrets.aws_default_region }}
             account-id: ${{ secrets.aws_account_id }}
             # use the manually bootstrapped OIDC role to solve the chicken-and-egg problem of deploying the OIDC service via OIDC
-            stage-name: main
+            stage-name: ${{ steps.set-oidc-stage-name.outputs.stage-name }}
 
         - name: deploy github-oidc
           id: deploy-github-oidc

--- a/.github/workflows/deploy-infra-to-env.yml
+++ b/.github/workflows/deploy-infra-to-env.yml
@@ -49,8 +49,6 @@ jobs:
 
         - name: deploy github-oidc
           id: deploy-github-oidc
-          env:
-            GITHUB_TOKEN: ${{ secrets.personal_access_token }}
           run: |
             pushd services/github-oidc && npx serverless deploy --stage ${{ inputs.stage_name }}
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -118,81 +118,75 @@ jobs:
 
   promote-infra-dev:
     needs: [build-prisma-client-lambda-layer, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
+      environment: dev
       stage_name: main
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
 
   promote-app-dev:
     needs: [promote-infra-dev, build-prisma-client-lambda-layer, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
+      environment: dev
       stage_name: main
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-infra-val:
     needs: [promote-app-dev, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
+      environment: val
       stage_name: val
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.VAL_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.VAL_AWS_SECRET_ACCESS_KEY }}
+      aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   promote-app-val:
     needs: [promote-app-dev, promote-infra-val, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
+      environment: val
       stage_name: val
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.VAL_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.VAL_AWS_SECRET_ACCESS_KEY }}
+      aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-infra-prod:
     needs: [promote-app-val, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
+      environment: prod
       stage_name: prod
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+      aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
   promote-app-prod:
     needs: [promote-app-val, promote-infra-prod, unit-tests]
-    # TODO update inputs/secrets and pin back to main after verifying OIDC in dev
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@59cf176903e73516371a247258abf4991c5dc99a
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-app-to-env.yml@main
     with:
+      environment: prod
       stage_name: prod
       app_version: ${{ needs.unit-tests.outputs.app-version }}
       changed_services: ${{ needs.unit-tests.outputs.changed-services}}
     secrets:
-      aws_access_key_id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+      aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
       react_app_auth_mode: IDM
       nr_license_key: ${{ secrets.NR_LICENSE_KEY }}

--- a/services/github-oidc/README.md
+++ b/services/github-oidc/README.md
@@ -27,7 +27,7 @@ The OIDC resources for each environment need to be manually bootstrapped for two
 - this service uses OIDC for permissions to deploy itself (chicken and egg problem)
 - the fact that only one AWS IdP for GitHub can exist per environment makes it tricky to manage multiple stages in the dev environment. CloudFormation isn't great at checking if resources exist before trying to create them and trying to create a duplicate IdP for each feature branch in dev will fail.
 
-The service is configured to be bootstrapped by running `serverless deploy` locally once for each environment (see step 4 below). This will create both the AWS OIDC IdP and the IAM role for that stage and environment.  Subsequent automated deploys of the service will update the IAM role, but won't touch the IdP.  Configuration changes for the IdP should be infrequent, but if they occur they will need to be applied manually following the steps below.
+The service is configured to be bootstrapped by running `serverless deploy` locally once for the 'official' stage for each environment (see step 4 below). This will create both the AWS OIDC IdP and the IAM role for that stage and environment.  Subsequent automated deploys of the service will update the IAM role, but won't touch the IdP.  Configuration changes for the IdP should be infrequent, but if they occur they will need to be applied manually following the steps below.
 
 Steps:
 1. Set AWS creds from CloudTamer/Kion for the target environment (dev, val, prod), then confirm the correct target
@@ -42,9 +42,12 @@ aws sts get-caller-identity
 ```bash
 cd services/github-oidc
 ```
-3. Deploy the service, passing `main` as the stage name and the bootstrap flag:
+3. Deploy the service, passing the bootstrap flag and the stage name that corresponds to the 'official' stage for the target environment:
+    - `main` for dev
+    - `val` for val
+    - `prod` for prod
 ```bash
-serverless deploy --stage main --param='bootstrap=true'
+serverless deploy --stage ${stage_name} --param='bootstrap=true'
 ```
 
 ## Examples

--- a/services/github-oidc/README.md
+++ b/services/github-oidc/README.md
@@ -27,7 +27,7 @@ The OIDC resources for each environment need to be manually bootstrapped for two
 - this service uses OIDC for permissions to deploy itself (chicken and egg problem)
 - the fact that only one AWS IdP for GitHub can exist per environment makes it tricky to manage multiple stages in the dev environment. CloudFormation isn't great at checking if resources exist before trying to create them and trying to create a duplicate IdP for each feature branch in dev will fail.
 
-The service is configured to be bootstrapped by running `serverless deploy` locally once for the 'official' stage for each environment (see step 4 below). This will create both the AWS OIDC IdP and the IAM role for that stage and environment.  Subsequent automated deploys of the service will update the IAM role, but won't touch the IdP.  Configuration changes for the IdP should be infrequent, but if they occur they will need to be applied manually following the steps below.
+The service is configured to be bootstrapped by running `serverless deploy` locally once for each environment (see step 4 below). This will create both the AWS OIDC IdP and the IAM role for that stage and environment.  Subsequent automated deploys of the service will update the IAM role, but won't touch the IdP.  Configuration changes for the IdP should be infrequent, but if they occur they will need to be applied manually following the steps below.
 
 Steps:
 1. Set AWS creds from CloudTamer/Kion for the target environment (dev, val, prod), then confirm the correct target
@@ -42,12 +42,9 @@ aws sts get-caller-identity
 ```bash
 cd services/github-oidc
 ```
-3. Deploy the service, passing the bootstrap flag and the stage name that corresponds to the 'official' stage for the target environment:
-    - `main` for dev
-    - `val` for val
-    - `prod` for prod
+3. Deploy the service, passing `main` as the stage name and the bootstrap flag:
 ```bash
-serverless deploy --stage ${stage_name} --param='bootstrap=true'
+serverless deploy --stage main --param='bootstrap=true'
 ```
 
 ## Examples


### PR DESCRIPTION
## Summary

This change enables GitHub OIDC for `val` and `prod` by:
- removing the pin so that `promote` now uses the updated versions of the `deploy-*-to-env` reusable workflows, and updating the inputs and secrets for those workflows
- adding some logic to choose the correct bootstrapped OIDC stage name based on the environment when the `github-oidc` service is deployed.  This is necessary because the `dev` environment uses the stage name `main` (for `val` and `prod` the stage name and environment name match)

Note:  I manually bootstrapped the `val` and `prod` OIDC roles following the instructions in the README 

#### Screenshots

#### Test cases covered

## QA guidance

This is a tricky one to test manually. Most of our QA comes from the fact that OIDC is working smoothly in `dev`.
 I did test the changes to `deploy-infra-to-env` locally to ensure that the script for setting the OIDC stage name based on the environment worked correctly. 
