### PR TITLE
Fix: add_question_response migration 

### DIFF
--- a/services/app-api/prisma/migrations/20230228215104_add_question_response/migration.sql
+++ b/services/app-api/prisma/migrations/20230228215104_add_question_response/migration.sql
@@ -1,15 +1,8 @@
-/*
-  Warnings:
-
-  - Added the required column `updatedAt` to the `Question` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `updatedAt` to the `QuestionDocument` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- AlterTable
-ALTER TABLE "Question" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "Question" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
 -- AlterTable
-ALTER TABLE "QuestionDocument" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "QuestionDocument" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
 -- CreateTable
 CREATE TABLE "QuestionResponseDocument" (

--- a/services/app-api/prisma/schema.prisma
+++ b/services/app-api/prisma/schema.prisma
@@ -57,7 +57,7 @@ model User {
 model Question {
   id            String                 @id
   createdAt     DateTime               @default(now())
-  updatedAt     DateTime               @updatedAt
+  updatedAt     DateTime               @updatedAt  @default(now())
   pkgID         String
   pkg           HealthPlanPackageTable @relation(fields: [pkgID], references: [id])
   addedBy       User                   @relation(fields: [addedByUserID], references: [id])
@@ -69,7 +69,7 @@ model Question {
 model QuestionDocument {
   id         String   @id
   createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  updatedAt  DateTime @updatedAt  @default(now())
   name       String
   s3URL      String
   questionID String


### PR DESCRIPTION
## Summary
Fix failed deploy of #1524 . This was due to not setting default values for `updatedAt`, which was added to new tables but also on existing question tables. 

Addressed the issue by editing initial migration to allow this to deploy in dev.

