### PR TITLE
Add github-oidc to changed services for promote

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,7 +21,8 @@ jobs:
         'uploads',
         'run-migrations',
         'prisma-layer',
-        'infra-api'
+        'infra-api',
+        'github-oidc'
         ]"
     services:
       postgres:


### PR DESCRIPTION
## Summary

In https://github.com/CMSgov/managed-care-review/pull/1531, I neglected to add `github-oidc` to the list of changed-services that is used by `promote`.  This fixes that!

#### Related issues

#### Screenshots

#### Test cases covered



## QA guidance


