### PR TITLE
Use ID instead of ARN in postgres migrate snapshot

### DIFF
--- a/services/app-api/src/handlers/configuration.ts
+++ b/services/app-api/src/handlers/configuration.ts
@@ -78,11 +78,7 @@ async function getDBClusterID(secretName: string): Promise<string | Error> {
         )
         return secretsResult
     }
-    console.info(
-        `returned from secrets manager ${secretsResult.dbClusterIdentifier}`
-    )
     const dbID = secretsResult.dbClusterIdentifier.split(':').slice(-1)[0]
-    console.info(`parsed DB ID ${dbID}`)
     return dbID
 }
 

--- a/services/app-api/src/handlers/configuration.ts
+++ b/services/app-api/src/handlers/configuration.ts
@@ -78,7 +78,12 @@ async function getDBClusterID(secretName: string): Promise<string | Error> {
         )
         return secretsResult
     }
-    return secretsResult.dbClusterIdentifier
+    console.info(
+        `returned from secrets manager ${secretsResult.dbClusterIdentifier}`
+    )
+    const dbID = secretsResult.dbClusterIdentifier.split(':').slice(-1)[0]
+    console.info(`parsed DB ID ${dbID}`)
+    return dbID
 }
 
 export { configurePostgres, getPostgresURL, getDBClusterID }

--- a/services/app-api/src/handlers/postgres_migrate.ts
+++ b/services/app-api/src/handlers/postgres_migrate.ts
@@ -59,7 +59,7 @@ export const main: APIGatewayProxyHandler = async () => {
 
     // take a snapshot of the DB before running data migration.
     // don't take a snapshot if we're in a PR branch
-    if (['dev', 'val', 'prod', 'main'].includes(stage)) {
+    if (['dev', 'val', 'prod', 'main', 'mtuseidpgsm'].includes(stage)) {
         const dbClusterId = await getDBClusterID(secretsManagerSecret)
         if (dbClusterId instanceof Error) {
             console.error(

--- a/services/app-api/src/handlers/postgres_migrate.ts
+++ b/services/app-api/src/handlers/postgres_migrate.ts
@@ -59,7 +59,7 @@ export const main: APIGatewayProxyHandler = async () => {
 
     // take a snapshot of the DB before running data migration.
     // don't take a snapshot if we're in a PR branch
-    if (['dev', 'val', 'prod', 'main', 'mtuseidpgsm'].includes(stage)) {
+    if (['dev', 'val', 'prod', 'main'].includes(stage)) {
         const dbClusterId = await getDBClusterID(secretsManagerSecret)
         if (dbClusterId instanceof Error) {
             console.error(


### PR DESCRIPTION
## Summary

We ran into an issue where our restored Postgres DB in dev was unable to have a snapshot taken, which would fail the migrate. It looks like passing in an ARN for the DB as a cluster identifier is not working for the snapshots AWS SDK all of a sudden (this has been working fine). 

This change parses out the ID from the ARN and passes it to the snapshot call in the migrate handler.
