### PR TITLE
Increase timeout

### DIFF
--- a/tests/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/virusScan/virusScan.spec.ts
@@ -19,7 +19,7 @@ describe.only('documents', () => {
                     encoding: 'binary',
                 })
                 cy.findAllByTestId('upload-finished-indicator', {
-                    timeout: 150000,
+                    timeout: 200000,
                 })
                 cy.findByText('Failed security scan, please remove').should(
                     'exist'


### PR DESCRIPTION
## Summary
We have seen Cypress failures related to timeouts for the virus scan test (here's an [example failed run](https://github.com/CMSgov/managed-care-review/actions/runs/4386877719/jobs/7682009538)). This change mitigates that by increasing the timeout. 

[Slack thread for context](https://cmsgov.slack.com/archives/C014CRU197U/p1678464640258349)
#### Related issues

#### Screenshots

#### Test cases covered

N/A

## QA guidance

N/A
