### PR TITLE
Sync SecHub findings with Jira issues

### DIFF
--- a/.github/actions/get_aws_credentials/action.yml
+++ b/.github/actions/get_aws_credentials/action.yml
@@ -34,7 +34,7 @@ runs:
       id: set-oidc-stage-name
       shell: bash
       run: |
-        echo "stage-name=${{ (contains('main, val, prod', inputs.stage-name) || contains(inputs.changed-services, 'github-oidc')) && inputs.stage-name || 'main' }}" >> $GITHUB_OUTPUT
+        echo "stage-name=${{ (contains('main, val, prod', inputs.stage-name) || inputs.changed-services == '' || contains(inputs.changed-services, 'github-oidc')) && inputs.stage-name || 'main' }}" >> $GITHUB_OUTPUT
 
     - name: Format OIDC role ARN
       shell: bash

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -1,0 +1,54 @@
+name: Sync Security Hub findings and Jira issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '25 1 * * *' # daily at 6:25 am EST
+
+permissions:
+  id-token: write
+
+jobs:
+  sync:
+    name: Run sync
+    environment: prod
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Get AWS credentials
+        uses: ./.github/actions/get_aws_credentials
+        with:
+          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          account-id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
+          stage-name: prod
+
+      - name: Sync Security Hub and Jira
+        uses: Enterprise-CMCS/security-hub-visibility@v1.0.1
+        with:
+          jira-token: ${{ secrets.JIRA_TOKEN }}
+          jira-username: ${{ secrets.JIRA_USERNAME }}
+          jira-host: qmacbis.atlassian.net
+          jira-project-key: MR # add issues to the 'MC-Review' project
+          jira-epic-key: MR-3092 # add issues to the '[Tech Maintenance] Security Hub' epic
+          jira-custom-fields: '{ "customfield_10006": 925 }' # add issues to the 'Tech Maintenance' sprint
+          jira-ignore-statuses: Done
+          aws-region: us-east-1
+          aws-severities: CRITICAL, HIGH, MEDIUM
+
+  slack:
+    name: Slack notification on failure
+    runs-on: ubuntu-20.04
+    if: failure()
+    steps:
+      - name: Alert Slack On Failure
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: Deploy Alerts
+          SLACK_ICON_EMOJI: ':bell:'
+          SLACK_COLOR: failure
+          SLACK_FOOTER: ''
+          SLACK_MESSAGE: 'Syncing Security Hub findings with Jira issues failed'
+          MSG_MINIMAL: actions url

--- a/.github/workflows/sechub-jira-sync.yml
+++ b/.github/workflows/sechub-jira-sync.yml
@@ -1,7 +1,7 @@
 name: Sync Security Hub findings and Jira issues
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # for testing and manual runs
   schedule:
     - cron: '25 1 * * *' # daily at 6:25 am EST
 
@@ -37,18 +37,16 @@ jobs:
           aws-region: us-east-1
           aws-severities: CRITICAL, HIGH, MEDIUM
 
-  slack:
-    name: Slack notification on failure
-    runs-on: ubuntu-20.04
-    if: failure()
-    steps:
       - name: Alert Slack On Failure
         uses: rtCamp/action-slack-notify@v2
+        if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_USERNAME: Deploy Alerts
           SLACK_ICON_EMOJI: ':bell:'
           SLACK_COLOR: failure
           SLACK_FOOTER: ''
-          SLACK_MESSAGE: 'Syncing Security Hub findings with Jira issues failed'
+          SLACK_MESSAGE: 'Failure syncing Security Hub findings and Jira issues'
           MSG_MINIMAL: actions url
+
+

--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -57,6 +57,7 @@ params:
       - "ssm:*"
       - "s3:*"
       - "wafv2:*"
+      - "securityhub:*"
 
 provider:
   name: aws


### PR DESCRIPTION
## Summary

This change adds a workflow that runs on a cron and syncs Security Hub findings from the prod environment with Jira issues. See the inputs to the syncing action for details on the Jira configuration.  For more on the behavior of the syncing action, see https://github.com/Enterprise-CMCS/security-hub-visibility

There's also a small change to the composite action for getting AWS creds so that it can be called by workflows that don't pass a `changed-services` input.

### Authentication
- AWS
  - uses OIDC to get prod credentials.  To support this, `securityhub` is added to the list of allowed AWS actions for the OIDC role
- Jira
   - uses credentials for a Jira service user stored as Actions secrets to perform Jira actions


#### Related issues

#### Screenshots

#### Test cases covered

## QA guidance
Manual testing: using static credentials (`PROD_AWS_SECRET_ACCESS_KEY`, etc), I ran the workflow manually and confirmed that issues are created and added to the correct Jira project, epic, and sprint.  I manually closed an issue without resolving the underlying finding and saw that the issue was reopened by automation. 

Targeting a MAC-FC test environment (because I didn't want to mess with prod findings), I manually resolved a finding and saw that the corresponding issue was automatically closed. 

