### PR TITLE
MR-2906 MR-2901 Add breadcrumbs to upload pages and success banners

### DIFF
--- a/services/app-web/.storybook/storybook.scss
+++ b/services/app-web/.storybook/storybook.scss
@@ -1,7 +1,7 @@
 .sb-show-main {
     #root {
-        // add so that the top of stories isn't hidden by the iframe
-        padding-top: 5px;
+        // pad stories, ensure top also isn't hidden by the iframe
+        padding: 5px;
         height: 100vh;
     }
 }

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.stories.tsx
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Story } from '@storybook/react'
+import { QuestionResponseSubmitBanner } from './QuestionResponseSubmitBanner'
+import type { QuestionResponseSubmitBannerProps } from './QuestionResponseSubmitBanner'
+
+export default {
+    title: 'Components/Banner/QuestionResponseBanner',
+    component: QuestionResponseSubmitBanner,
+}
+
+const Template: Story<QuestionResponseSubmitBannerProps> = (args) => (
+    <QuestionResponseSubmitBanner {...args} />
+)
+
+export const QuestionResponseSubmitBannerCMSUser = Template.bind({})
+QuestionResponseSubmitBannerCMSUser.args = {
+    submitType: 'question',
+}
+
+export const QuestionResponseSubmitBannerStateUser = Template.bind({})
+QuestionResponseSubmitBannerStateUser.args = {
+    submitType: 'response',
+}

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.test.tsx
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { QuestionResponseSubmitBanner } from './QuestionResponseSubmitBanner'
+
+describe('QuestionResponseSubmitBanner', () => {
+    it('renders without errors and correct text for a CMS question submit', () => {
+        render(<QuestionResponseSubmitBanner submitType="question" />)
+        expect(screen.getByTestId('alert')).toHaveClass('usa-alert--success')
+        expect(screen.getByText('Questions sent')).toBeInTheDocument()
+    })
+
+    it('renders without errors and correct text for a state response', () => {
+        render(<QuestionResponseSubmitBanner submitType="response" />)
+        expect(screen.getByTestId('alert')).toHaveClass('usa-alert--success')
+        expect(screen.getByText('Response sent')).toBeInTheDocument()
+    })
+
+    it('renders nothing if invalid submitType passed in URL params', () => {
+        render(
+            <div data-testid="test1">
+                <QuestionResponseSubmitBanner submitType="errorweird" />
+            </div>
+        )
+        expect(screen.getByTestId('test1')).toBeEmptyDOMElement()
+    })
+})

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
@@ -1,0 +1,30 @@
+import { Alert } from '@trussworks/react-uswds'
+import styles from '../Banner.module.scss'
+
+type SubmitType = 'question' | 'response'
+export type QuestionResponseSubmitBannerProps = {
+    submitType?: string | null
+}
+function isSubmitType(type: SubmitType | string): type is SubmitType {
+    return type === 'question' || type === 'response'
+}
+
+const QuestionResponseSubmitBanner = ({
+    submitType,
+}: QuestionResponseSubmitBannerProps) => {
+    if (!submitType || !isSubmitType(submitType)) return null
+    const cmsQuestion = submitType === 'question'
+    const heading = cmsQuestion ? 'Questions sent' : 'Response sent'
+    const message = cmsQuestion
+        ? 'Your questions were sent to the state.'
+        : 'Your response was submitted to CMS.'
+    return (
+        <div className={styles.bannerBodyText}>
+            <Alert type="success" headingLevel="h4" heading={heading}>
+                {message}
+            </Alert>
+        </div>
+    )
+}
+
+export { QuestionResponseSubmitBanner }

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner.tsx
@@ -3,7 +3,7 @@ import styles from '../Banner.module.scss'
 
 type SubmitType = 'question' | 'response'
 export type QuestionResponseSubmitBannerProps = {
-    submitType?: string | null
+    submitType: string
 }
 function isSubmitType(type: SubmitType | string): type is SubmitType {
     return type === 'question' || type === 'response'
@@ -12,7 +12,7 @@ function isSubmitType(type: SubmitType | string): type is SubmitType {
 const QuestionResponseSubmitBanner = ({
     submitType,
 }: QuestionResponseSubmitBannerProps) => {
-    if (!submitType || !isSubmitType(submitType)) return null
+    if (!isSubmitType(submitType)) return null
     const cmsQuestion = submitType === 'question'
     const heading = cmsQuestion ? 'Questions sent' : 'Response sent'
     const message = cmsQuestion

--- a/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/index.ts
+++ b/services/app-web/src/components/Banner/QuestionResponseSubmitBanner/index.ts
@@ -1,0 +1,1 @@
+export { QuestionResponseSubmitBanner } from './QuestionResponseSubmitBanner'

--- a/services/app-web/src/components/Banner/index.ts
+++ b/services/app-web/src/components/Banner/index.ts
@@ -2,3 +2,4 @@ export { SubmissionUnlockedBanner } from './SubmissionUnlockedBanner/SubmissionU
 export { PreviousSubmissionBanner } from './PreviousSubmissionBanner/PreviousSubmissionBanner'
 export { SubmissionUpdatedBanner } from './SubmissionUpdatedBanner/SubmissionUpdatedBanner'
 export { GenericApiErrorBanner } from './GenericApiErrorBanner/GenericApiErrorBanner'
+export { QuestionResponseSubmitBanner } from './QuestionResponseSubmitBanner'

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../testHelpers'
 import { Breadcrumbs } from './Breadcrumbs'
 
 describe('Breadcrumbs', () => {
@@ -7,7 +8,7 @@ describe('Breadcrumbs', () => {
             { text: 'First link', link: '/firstlink' },
             { text: 'Second link', link: '/secondlink' },
         ]
-        render(<Breadcrumbs items={items} />)
+        renderWithProviders(<Breadcrumbs items={items} />)
         expect(screen.getByText('First link')).toBeInTheDocument()
         expect(screen.getByText('Second link')).toBeInTheDocument()
     })
@@ -18,13 +19,13 @@ describe('Breadcrumbs', () => {
             { text: 'Second link', link: '/secondlink' },
             { text: 'Active link, no href needed' },
         ]
-        render(<Breadcrumbs items={items} />)
+        renderWithProviders(<Breadcrumbs items={items} />)
         expect(screen.getAllByRole('listitem')).toHaveLength(items.length)
         expect(screen.getAllByRole('link')).toHaveLength(items.length - 1)
     })
 
     it('renders nothing if no items passed in', () => {
-        render(
+        renderWithProviders(
             <div data-testid="test1">
                 <Breadcrumbs items={[]} />
             </div>

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumb.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { Breadcrumbs } from './Breadcrumbs'
+
+describe('Breadcrumbs', () => {
+    it('renders without errors', () => {
+        const items = [
+            { text: 'First link', link: '/firstlink' },
+            { text: 'Second link', link: '/secondlink' },
+        ]
+        render(<Breadcrumbs items={items} />)
+        expect(screen.getByText('First link')).toBeInTheDocument()
+        expect(screen.getByText('Second link')).toBeInTheDocument()
+    })
+
+    it('renders items with links when expected', () => {
+        const items = [
+            { text: 'First link', link: '/firstlink' },
+            { text: 'Second link', link: '/secondlink' },
+            { text: 'Active link, no href needed' },
+        ]
+        render(<Breadcrumbs items={items} />)
+        expect(screen.getAllByRole('listitem')).toHaveLength(items.length)
+        expect(screen.getAllByRole('link')).toHaveLength(items.length - 1)
+    })
+
+    it('renders nothing if no items passed in', () => {
+        render(
+            <div data-testid="test1">
+                <Breadcrumbs items={[]} />
+            </div>
+        )
+        expect(screen.getByTestId('test1')).toBeEmptyDOMElement()
+    })
+})

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,0 +1,5 @@
+.crumbContainer {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    background: none;
+}

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Story } from '@storybook/react'
 import { Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs'
+import ProvidersDecorator from '../../../.storybook/providersDecorator'
 
 export default {
     title: 'Components/Breadcrumbs',
@@ -14,6 +15,7 @@ export default {
 const Template: Story<BreadcrumbsProps> = (args) => <Breadcrumbs {...args} />
 
 export const Default = Template.bind({})
+Default.decorators = [(Story) => ProvidersDecorator(Story, {})]
 Default.args = {
     items: [
         { text: 'First link', link: '/firstlink' },

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Story } from '@storybook/react'
+import { Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs'
+
+export default {
+    title: 'Components/Breadcrumbs',
+    component: Breadcrumbs,
+    parameters: {
+        componentSubtitle:
+            'Breadcrumbs provide secondary navigation to help users understand where they are in a website.',
+    },
+}
+
+const Template: Story<BreadcrumbsProps> = (args) => <Breadcrumbs {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+    items: [
+        { text: 'First link', link: '/firstlink' },
+        { text: 'Second link', link: '/secondlink' },
+        { text: 'Active link, no href needed' },
+    ],
+}

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,8 +1,5 @@
-import {
-    BreadcrumbBar,
-    Breadcrumb,
-    BreadcrumbLink,
-} from '@trussworks/react-uswds'
+import { BreadcrumbBar, Breadcrumb, Link } from '@trussworks/react-uswds'
+import { NavLink } from 'react-router-dom'
 import styles from './Breadcrumbs.module.scss'
 
 type BreadcrumbItem = {
@@ -18,9 +15,9 @@ const Crumb = (crumb: BreadcrumbItem) => {
     if (link) {
         return (
             <Breadcrumb>
-                <BreadcrumbLink href={link}>
+                <Link asCustom={NavLink} to={link}>
                     <span>{text}</span>
-                </BreadcrumbLink>
+                </Link>
             </Breadcrumb>
         )
     } else {

--- a/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/services/app-web/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,46 @@
+import {
+    BreadcrumbBar,
+    Breadcrumb,
+    BreadcrumbLink,
+} from '@trussworks/react-uswds'
+import styles from './Breadcrumbs.module.scss'
+
+type BreadcrumbItem = {
+    text: string
+    link?: string
+}
+export type BreadcrumbsProps = {
+    items: BreadcrumbItem[]
+}
+
+const Crumb = (crumb: BreadcrumbItem) => {
+    const { link, text } = crumb
+    if (link) {
+        return (
+            <Breadcrumb>
+                <BreadcrumbLink href={link}>
+                    <span>{text}</span>
+                </BreadcrumbLink>
+            </Breadcrumb>
+        )
+    } else {
+        return (
+            <Breadcrumb>
+                <span>{text}</span>
+            </Breadcrumb>
+        )
+    }
+}
+
+const Breadcrumbs = ({ items }: BreadcrumbsProps) => {
+    if (items.length === 0) return null
+    return (
+        <BreadcrumbBar className={styles.crumbContainer}>
+            {items.map((item, index) => (
+                <Crumb key={index} {...item} />
+            ))}
+        </BreadcrumbBar>
+    )
+}
+
+export { Breadcrumbs }

--- a/services/app-web/src/components/Breadcrumbs/index.ts
+++ b/services/app-web/src/components/Breadcrumbs/index.ts
@@ -1,0 +1,1 @@
+export { Breadcrumbs } from './Breadcrumbs'

--- a/services/app-web/src/components/index.ts
+++ b/services/app-web/src/components/index.ts
@@ -53,6 +53,7 @@ export {
     PreviousSubmissionBanner,
     SubmissionUpdatedBanner,
     GenericApiErrorBanner,
+    QuestionResponseSubmitBanner,
 } from './Banner'
 
 export { Modal } from './Modal'
@@ -80,3 +81,4 @@ export { FilterAccordion } from './FilterAccordion'
 export type { FilterAccordionPropType } from './FilterAccordion'
 
 export { ActionButton } from './ActionButton'
+export { Breadcrumbs } from './Breadcrumbs'

--- a/services/app-web/src/constants/routes.ts
+++ b/services/app-web/src/constants/routes.ts
@@ -72,6 +72,11 @@ const STATE_SUBMISSION_SUMMARY_ROUTES: RouteTWithUnknown[] = [
     'SUBMISSIONS_REVISION',
 ]
 
+const QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES: RouteTWithUnknown[] = [
+    'SUBMISSIONS_QUESTIONS_AND_ANSWERS',
+    'SUBMISSIONS_SUMMARY',
+]
+
 /*
     Page headings used in the <header> when user logged in.
     Dynamic headings, when necessary, are set in page specific parent component.
@@ -124,6 +129,7 @@ export {
     ROUTES,
     STATE_SUBMISSION_FORM_ROUTES,
     STATE_SUBMISSION_SUMMARY_ROUTES,
+    QUESTION_RESPONSE_SHOW_SIDEBAR_ROUTES,
 }
 
 export type { RouteT, RouteTWithUnknown }

--- a/services/app-web/src/pages/App/AppRoutes.tsx
+++ b/services/app-web/src/pages/App/AppRoutes.tsx
@@ -80,24 +80,24 @@ const StateUserRoutes = ({
                 />
                 <Route element={<SubmissionSideNav />}>
                     {showQuestionResponse && (
-                        <Route
-                            path={
-                                RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS
-                            }
-                            element={<QuestionResponse />}
-                        />
+                        <>
+                            <Route
+                                path={
+                                    RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS
+                                }
+                                element={<QuestionResponse />}
+                            />
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                                element={<UploadResponse />}
+                            />
+                        </>
                     )}
                     <Route
                         path={RoutesRecord.SUBMISSIONS_SUMMARY}
                         element={<SubmissionSummary />}
                     />
                 </Route>
-                {showQuestionResponse && (
-                    <Route
-                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                        element={<UploadResponse />}
-                    />
-                )}
                 <Route
                     path={RoutesRecord.SUBMISSIONS_REVISION}
                     element={<SubmissionRevisionSummary />}
@@ -139,12 +139,18 @@ const CMSUserRoutes = ({
                 />
                 <Route element={<SubmissionSideNav />}>
                     {showQuestionResponse && (
-                        <Route
-                            path={
-                                RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS
-                            }
-                            element={<QuestionResponse />}
-                        />
+                        <>
+                            <Route
+                                path={
+                                    RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS
+                                }
+                                element={<QuestionResponse />}
+                            />
+                            <Route
+                                path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
+                                element={<UploadQuestions />}
+                            />
+                        </>
                     )}
                     <Route
                         path={RoutesRecord.SUBMISSIONS_SUMMARY}
@@ -152,18 +158,6 @@ const CMSUserRoutes = ({
                     />
                 </Route>
 
-                {showQuestionResponse && (
-                    <>
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_UPLOAD_QUESTION}
-                            element={<UploadQuestions />}
-                        />
-                        <Route
-                            path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                            element={<UploadResponse />}
-                        />
-                    </>
-                )}
                 <Route
                     path={RoutesRecord.SUBMISSIONS_REVISION}
                     element={<SubmissionRevisionSummary />}

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.module.scss
@@ -29,8 +29,11 @@
   }
 }
 
+.breadcrumbs {
+  background: none;
+  margin: units(2) auto;
+}
 .formContainer {
-        padding-top: 5rem;
     > [class^='usa-fieldset'] {
         padding: units(4);
         margin-bottom: units(2);

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
@@ -1,10 +1,11 @@
+import React from 'react'
 import { screen, waitFor, within } from '@testing-library/react'
 import { Route, Routes } from 'react-router-dom'
 import { SubmissionSideNav } from '../SubmissionSideNav'
 import { QuestionResponse } from './QuestionResponse'
 import { ldUseClientSpy, renderWithProviders } from '../../testHelpers'
 import { RoutesRecord } from '../../constants/routes'
-import React from 'react'
+
 import {
     fetchCurrentUserMock,
     mockValidCMSUser,

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.test.tsx
@@ -11,6 +11,7 @@ import {
     mockValidCMSUser,
     fetchStateHealthPlanPackageWithQuestionsMockSuccess,
     mockQuestionsPayload,
+    mockValidUser,
 } from '../../testHelpers/apolloMocks'
 
 describe('QuestionResponse', () => {
@@ -175,6 +176,79 @@ describe('QuestionResponse', () => {
                 'This division has not submitted questions yet.'
             )
         ).toBeInTheDocument()
+
+        // no submit banner
+        expect(screen.queryByTestId('alert')).toBeNull()
+    })
+
+    it('renders with question submit banner after question submitted', async () => {
+        const mockQuestions = mockQuestionsPayload('15')
+        renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS}
+                        element={<QuestionResponse />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                            questions: mockQuestions,
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/question-and-answers?submit=question',
+                },
+            }
+        )
+
+        await screen.findByTestId('sidenav')
+        expect(screen.getByTestId('alert')).toHaveClass('usa-alert--success')
+        expect(screen.getByText('Questions sent')).toBeInTheDocument()
+    })
+
+    it('renders with response submit banner after response submitted', async () => {
+        const mockQuestions = mockQuestionsPayload('15')
+        renderWithProviders(
+            <Routes>
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_QUESTIONS_AND_ANSWERS}
+                        element={<QuestionResponse />}
+                    />
+                </Route>
+            </Routes>,
+            {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                            questions: mockQuestions,
+                        }),
+                    ],
+                },
+                routerProvider: {
+                    route: '/submissions/15/question-and-answers?submit=response',
+                },
+            }
+        )
+
+        await screen.findByTestId('sidenav')
+        expect(screen.getByTestId('alert')).toHaveClass('usa-alert--success')
+        expect(screen.getByText('Response sent')).toBeInTheDocument()
     })
     it('CMS users see add questions link on Q&A page', async () => {
         renderWithProviders(

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
@@ -1,32 +1,36 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { GridContainer, Link } from '@trussworks/react-uswds'
 import styles from './QuestionResponse.module.scss'
-import { SectionHeader } from '../../components'
-import { NavLink, useOutletContext } from 'react-router-dom'
-import { packageName } from '../../common-code/healthPlanFormDataType'
+
+import { Loading, SectionHeader } from '../../components'
+import { NavLink, useLocation, useOutletContext } from 'react-router-dom'
 import { usePage } from '../../contexts/PageContext'
 import { SideNavOutletContextType } from '../SubmissionSideNav/SubmissionSideNav'
+import { QuestionResponseSubmitBanner } from '../../components/Banner/QuestionResponseSubmitBanner/QuestionResponseSubmitBanner'
 import { QATable, QuestionData, Division } from './QATable/QATable'
 
 export const QuestionResponse = () => {
-    const outletContext = useOutletContext<SideNavOutletContextType>()
+    // router context
+    const location = useLocation()
+    const submitType = new URLSearchParams(location.search).get('submit')
+
+    // page context
     const { updateHeading } = usePage()
-    const [pkgName, setPkgName] = useState<string | undefined>(undefined)
-    const questions = outletContext.parsedQuestions
+    const { user, packageData, packageName, parsedQuestions } =
+        useOutletContext<SideNavOutletContextType>()
+    const questions = parsedQuestions
+    const isCMSUser = user?.role === 'CMS_USER'
 
     useEffect(() => {
-        updateHeading({ customHeading: `${pkgName} Upload questions` })
-    }, [pkgName, updateHeading])
+        updateHeading({ customHeading: packageName })
+    }, [packageName, updateHeading])
 
-    const isCMSUser = outletContext.user.role === 'CMS_USER'
-
-    // set the page heading
-    const name = packageName(
-        outletContext.packageData,
-        outletContext.pkg.state.programs
-    )
-    if (pkgName !== name) {
-        setPkgName(name)
+    if (!packageData || !user) {
+        return (
+            <GridContainer>
+                <Loading />
+            </GridContainer>
+        )
     }
 
     const mapQuestionTable = (
@@ -39,7 +43,7 @@ export const QuestionResponse = () => {
                     key={question.id}
                     question={question}
                     division={division}
-                    user={outletContext.user}
+                    user={user}
                 />
             ))
         ) : (
@@ -52,6 +56,7 @@ export const QuestionResponse = () => {
     return (
         <div className={styles.background}>
             <GridContainer className={styles.container}>
+                <QuestionResponseSubmitBanner submitType={submitType} />
                 <section>
                     <SectionHeader header="Q&A" hideBorder>
                         {isCMSUser && (

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
@@ -56,7 +56,9 @@ export const QuestionResponse = () => {
     return (
         <div className={styles.background}>
             <GridContainer className={styles.container}>
-                <QuestionResponseSubmitBanner submitType={submitType} />
+                {submitType && (
+                    <QuestionResponseSubmitBanner submitType={submitType} />
+                )}
                 <section>
                     <SectionHeader header="Q&A" hideBorder>
                         {isCMSUser && (

--- a/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/QuestionResponse.tsx
@@ -13,11 +13,11 @@ export const QuestionResponse = () => {
     // router context
     const location = useLocation()
     const submitType = new URLSearchParams(location.search).get('submit')
+    const { user, packageData, packageName, parsedQuestions } =
+        useOutletContext<SideNavOutletContextType>()
 
     // page context
     const { updateHeading } = usePage()
-    const { user, packageData, packageName, parsedQuestions } =
-        useOutletContext<SideNavOutletContextType>()
     const questions = parsedQuestions
     const isCMSUser = user?.role === 'CMS_USER'
 

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.test.tsx
@@ -12,8 +12,14 @@ import {
 } from '../../../testHelpers'
 import { RoutesRecord } from '../../../constants/routes'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
-import { fetchCurrentUserMock } from '../../../testHelpers/apolloMocks'
-import { createQuestionNetworkFailure } from '../../../testHelpers/apolloMocks/questionResponseGQLMock'
+import {
+    fetchCurrentUserMock,
+    mockValidCMSUser,
+} from '../../../testHelpers/apolloMocks'
+import {
+    createQuestionNetworkFailure,
+    fetchStateHealthPlanPackageWithQuestionsMockSuccess,
+} from '../../../testHelpers/apolloMocks/questionResponseGQLMock'
 
 describe('UploadQuestions', () => {
     it('displays file upload for correct cms division', async () => {
@@ -58,6 +64,17 @@ describe('UploadQuestions', () => {
                 />
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/upload-questions`,
                 },
@@ -92,7 +109,15 @@ describe('UploadQuestions', () => {
                     route: `/submissions/15/question-and-answers/dmco/upload-questions`,
                 },
                 apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidCMSUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
                 },
             }
         )

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -129,7 +129,7 @@ export const UploadQuestions = () => {
                         text: 'Dashboard',
                     },
                     { link: `/submissions/${id}`, text: packageName },
-                    { text: 'Upload questions' },
+                    { text: 'Add questions' },
                 ]}
             />
 

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
     GridContainer,
     Form as UswdsForm,
@@ -6,7 +6,7 @@ import {
     ButtonGroup,
 } from '@trussworks/react-uswds'
 import styles from '../QuestionResponse.module.scss'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useOutletContext, useParams } from 'react-router-dom'
 import { useS3 } from '../../../contexts/S3Context'
 import {
     ActionButton,
@@ -24,11 +24,14 @@ import {
     FetchHealthPlanPackageWithQuestionsDocument,
     FetchHealthPlanPackageWithQuestionsQuery,
 } from '../../../gen/gqlClient'
-
+import { SideNavOutletContextType } from '../../SubmissionSideNav/SubmissionSideNav'
+import { usePage } from '../../../contexts/PageContext'
+import { Breadcrumbs } from '../../../components/Breadcrumbs/Breadcrumbs'
 export const UploadQuestions = () => {
-    // third party
+    // router context
     const { division, id } = useParams<{ division: string; id: string }>()
     const navigate = useNavigate()
+    const { packageName } = useOutletContext<SideNavOutletContextType>()
 
     // api
     const [createQuestion, { loading: apiLoading, error: apiError }] =
@@ -36,6 +39,10 @@ export const UploadQuestions = () => {
 
     // page level state
     const [shouldValidate, setShouldValidate] = React.useState(false)
+    const { updateHeading } = usePage()
+    useEffect(() => {
+        updateHeading({ customHeading: packageName })
+    }, [packageName, updateHeading])
 
     // component specific support
     const { handleDeleteFile, handleUploadFile, handleScanFile } = useS3()
@@ -104,7 +111,9 @@ export const UploadQuestions = () => {
             })
 
             if (createResult) {
-                navigate(`/submissions/${id}/question-and-answers`)
+                navigate(
+                    `/submissions/${id}/question-and-answers?submit=question`
+                )
             }
         } catch (serverError) {
             console.info(serverError)
@@ -113,6 +122,17 @@ export const UploadQuestions = () => {
 
     return (
         <GridContainer>
+            <Breadcrumbs
+                items={[
+                    {
+                        link: `/dashboard`,
+                        text: 'Dashboard',
+                    },
+                    { link: `/submissions/${id}`, text: packageName },
+                    { text: 'Upload questions' },
+                ]}
+            />
+
             <UswdsForm
                 className={styles.formContainer}
                 id="AddQuestionsForm"

--- a/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadQuestions/UploadQuestions.tsx
@@ -41,7 +41,7 @@ export const UploadQuestions = () => {
     const [shouldValidate, setShouldValidate] = React.useState(false)
     const { updateHeading } = usePage()
     useEffect(() => {
-        updateHeading({ customHeading: packageName })
+        updateHeading({ customHeading: `${packageName} Add questions` })
     }, [packageName, updateHeading])
 
     // component specific support

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
@@ -196,7 +196,7 @@ describe('UploadResponse', () => {
         ).toHaveLength(2)
     })
 
-    it('displays api error if createQuestion fails', async () => {
+    it('displays api error if createQuestionResponse fails', async () => {
         renderWithProviders(
             <Routes>
                 <Route

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.test.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router-dom'
 import { UploadResponse } from './UploadResponse'
 import {
     dragAndDrop,
+    ldUseClientSpy,
     renderWithProviders,
     TEST_DOC_FILE,
     TEST_PDF_FILE,
@@ -12,40 +13,61 @@ import {
 } from '../../../testHelpers'
 import { RoutesRecord } from '../../../constants/routes'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
-import { fetchCurrentUserMock } from '../../../testHelpers/apolloMocks'
-import { createQuestionNetworkFailure } from '../../../testHelpers/apolloMocks/questionResponseGQLMock'
+import {
+    fetchCurrentUserMock,
+    mockValidUser,
+} from '../../../testHelpers/apolloMocks'
+import {
+    createQuestionResponseNetworkFailure,
+    fetchStateHealthPlanPackageWithQuestionsMockSuccess,
+} from '../../../testHelpers/apolloMocks/questionResponseGQLMock'
+import { SubmissionSideNav } from '../../SubmissionSideNav'
 
 describe('UploadResponse', () => {
+    beforeEach(() => {
+        ldUseClientSpy({ 'cms-questions': true })
+    })
+    afterEach(() => {
+        jest.resetAllMocks()
+    })
+
     const division = 'testDivision'
     const questionID = 'testQuestion'
 
     it('displays file upload for correct cms division', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/${division}/${questionID}/upload-response`,
                 },
             }
         )
 
-        // Expect text to display correct division from url parameters.
-        await waitFor(() => {
-            expect(
-                screen.queryByRole('heading', {
-                    name: /New response/,
-                    level: 2,
-                })
-            ).toBeInTheDocument()
-            expect(
-                screen.queryByText(`Questions from ${division.toUpperCase()}`)
-            ).toBeInTheDocument()
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
         })
+        // Expect text to display correct division from url parameters.
+        await screen.queryByText(`Questions from ${division.toUpperCase()}`)
         // Expect file upload input on page
         expect(await screen.findByTestId('file-input')).toBeInTheDocument()
         expect(screen.getByLabelText('Upload response')).toBeInTheDocument()
@@ -54,18 +76,35 @@ describe('UploadResponse', () => {
     it('file upload accepts multiple pdf, word, excel documents', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
                 },
             }
         )
 
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
+        })
         const input = screen.getByLabelText('Upload response')
         expect(input).toBeInTheDocument()
         expect(input).toHaveAttribute('accept', ACCEPTED_SUBMISSION_FILE_TYPES)
@@ -84,21 +123,35 @@ describe('UploadResponse', () => {
     it('displays form validation error if attempting to add question with zero files', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
-                },
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
                 },
             }
         )
 
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
+        })
         const continueButton = screen.getByRole('button', {
             name: 'Send response',
         })
@@ -116,20 +169,34 @@ describe('UploadResponse', () => {
     it('displays file upload alert if attempting to add question with all invalid files', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
                 },
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
             }
         )
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
+        })
         const continueButton = screen.getByRole('button', {
             name: 'Send response',
         })
@@ -152,20 +219,34 @@ describe('UploadResponse', () => {
     it('displays file upload error alert if attempting to add question while a file is still uploading', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
                 },
-                apolloProvider: {
-                    mocks: [fetchCurrentUserMock({ statusCode: 200 })],
-                },
             }
         )
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
+        })
         const continueButton = screen.getByRole('button', {
             name: 'Send response',
         })
@@ -199,24 +280,35 @@ describe('UploadResponse', () => {
     it('displays api error if createQuestionResponse fails', async () => {
         renderWithProviders(
             <Routes>
-                <Route
-                    path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
-                    element={<UploadResponse />}
-                />
+                <Route element={<SubmissionSideNav />}>
+                    <Route
+                        path={RoutesRecord.SUBMISSIONS_UPLOAD_RESPONSE}
+                        element={<UploadResponse />}
+                    />
+                </Route>
             </Routes>,
             {
+                apolloProvider: {
+                    mocks: [
+                        fetchCurrentUserMock({
+                            user: mockValidUser(),
+                            statusCode: 200,
+                        }),
+                        fetchStateHealthPlanPackageWithQuestionsMockSuccess({
+                            id: '15',
+                        }),
+                        createQuestionResponseNetworkFailure(),
+                    ],
+                },
                 routerProvider: {
                     route: `/submissions/15/question-and-answers/dmco/${questionID}/upload-response`,
                 },
-                apolloProvider: {
-                    mocks: [
-                        fetchCurrentUserMock({ statusCode: 200 }),
-                        createQuestionNetworkFailure(),
-                    ],
-                },
             }
         )
-
+        await screen.findByRole('heading', {
+            name: /New response/,
+            level: 2,
+        })
         const createQuestionButton = screen.getByRole('button', {
             name: 'Send response',
         })

--- a/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
+++ b/services/app-web/src/pages/QuestionResponse/UploadResponse/UploadResponse.tsx
@@ -130,7 +130,7 @@ export const UploadResponse = () => {
                 items={[
                     { link: `/dashboard`, text: 'Dashboard' },
                     { link: `/submissions/${id}`, text: packageName },
-                    { text: 'Upload response' },
+                    { text: 'Add response' },
                 ]}
             />
 

--- a/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.module.scss
+++ b/services/app-web/src/pages/SubmissionSideNav/SubmissionSideNav.module.scss
@@ -1,10 +1,14 @@
 @import '../../styles/uswdsImports.scss';
 @import '../../styles/custom.scss';
 
-.background {
+.backgroundSidebar {
   background-color: $cms-color-white;
   width: 100%;
 }
+.backgroundForm {
+  width: 100%;
+}
+
 
 .container {
   @include grid-container;

--- a/services/app-web/src/testHelpers/apolloMocks/questionResponseGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/questionResponseGQLMock.ts
@@ -1,9 +1,11 @@
 import { MockedResponse } from '@apollo/client/testing'
 import {
     CreateQuestionDocument,
+    CreateQuestionResponseDocument,
     CreateQuestionInput,
     CreateQuestionMutation,
     Question as QuestionType,
+    QuestionResponse as QuestionResponseType,
     FetchHealthPlanPackageWithQuestionsDocument,
     FetchHealthPlanPackageWithQuestionsQuery,
     HealthPlanPackage,
@@ -63,6 +65,14 @@ const createQuestionNetworkFailure = (
         error: new Error('A network error occurred'),
     }
 }
+const createQuestionResponseNetworkFailure = (
+    question?: QuestionResponseType | Partial<QuestionResponseType>
+): MockedResponse<CreateQuestionMutation> => {
+    return {
+        request: { query: CreateQuestionResponseDocument },
+        error: new Error('A network error occurred'),
+    }
+}
 
 const fetchStateHealthPlanPackageWithQuestionsMockSuccess = ({
     stateSubmission = mockSubmittedHealthPlanPackage(),
@@ -115,6 +125,7 @@ const fetchStateHealthPlanPackageWithQuestionsMockNotFound = ({
 
 export {
     createQuestionNetworkFailure,
+    createQuestionResponseNetworkFailure,
     createQuestionSuccess,
     fetchStateHealthPlanPackageWithQuestionsMockSuccess,
     fetchStateHealthPlanPackageWithQuestionsMockNotFound,

--- a/tests/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
@@ -66,11 +66,14 @@ describe('Q&A', () => {
 
             // Find QA Link and click
             cy.findByRole('link', { name: /Q&A/ }).click()
-            cy.url({ timeout: 10_000 }).should('contain', `${submissionId}/question-and-answers`)
+            cy.url({ timeout: 10_000 }).should(
+                'contain',
+                `${submissionId}/question-and-answers`
+            )
 
-            // Make sure Heading is correct with 'Upload questions' in addition to submission name
+            // Heading is correct for Q&A main page
             cy.findByRole('heading', {
-                name: `Minnesota ${submissionName} Upload questions`,
+                name: `Minnesota ${submissionName}`,
             }).should('exist')
 
             // Log out and log back in as cms user, visiting submission summary page,
@@ -78,35 +81,41 @@ describe('Q&A', () => {
             cy.findByText(
                 'Medicaid and CHIP Managed Care Reporting and Review System'
             )
-            cy.logInAsCMSUser({ initialURL: `/submissions/${submissionId}/question-and-answers` })
+            cy.logInAsCMSUser({
+                initialURL: `/submissions/${submissionId}/question-and-answers`,
+            })
 
             cy.wait(2000)
 
-            cy.findByRole('heading', {
-                name: `CMS ${submissionName} Upload questions`,
-            }).should('exist')
-
             // Add second question
             cy.addQuestion({
-                documentPath: 'documents/trussel-guide.pdf'
+                documentPath: 'documents/trussel-guide.pdf',
             })
 
             // Newly uploaded questions document should exist within DMCO section
-            cy.findByTestId('dmco-qa-section').should('exist').within(() => {
-                // Add timeout to findByText to allow time for generating document urls
-                cy.findByText('trussel-guide.pdf',  { timeout: 5000 }).should('exist')
-            })
+            cy.findByTestId('dmco-qa-section')
+                .should('exist')
+                .within(() => {
+                    // Add timeout to findByText to allow time for generating document urls
+                    cy.findByText('trussel-guide.pdf', {
+                        timeout: 5000,
+                    }).should('exist')
+                })
 
             // Add a second question
             cy.addQuestion({
-                documentPath: 'documents/testing.csv'
+                documentPath: 'documents/testing.csv',
             })
 
             // Newly uploaded questions document should exist within DMCO section
-            cy.findByTestId('dmco-qa-section').should('exist').within(() => {
-                // Add timeout to findByText to allow time for generating document urls
-                cy.findByText('testing.csv',  { timeout: 5000 }).should('exist')
-            })
+            cy.findByTestId('dmco-qa-section')
+                .should('exist')
+                .within(() => {
+                    // Add timeout to findByText to allow time for generating document urls
+                    cy.findByText('testing.csv', { timeout: 5000 }).should(
+                        'exist'
+                    )
+                })
 
             // Find submission summary link and click
             cy.findByRole('link', { name: /Submission summary/ }).click()


### PR DESCRIPTION
## Summary
1. Display breadcrumbs  with links back to submissions root and dashboard. Move `UploadResponse` and `UploadQuestions` into the submissions Outlet to enable referencing package data on these pages. 
2.  Add success banners on submit that display on main Q&A page.


#### Related issues
https://qmacbis.atlassian.net/browse/MR-2901
https://qmacbis.atlassian.net/browse/MR-2906
#### Test cases covered
Updated tests to handle submissions context sharing via outlet


## QA guidance

- See ticket AC. 