### PR TITLE
Fix bootstrapping logic

### DIFF
--- a/services/github-oidc/README.md
+++ b/services/github-oidc/README.md
@@ -23,11 +23,9 @@ The `val` and `prod` environments each have a single OIDC role that is promoted 
 
 ## Usage
 ### Bootstrapping
-The OIDC resources for each environment need to be manually bootstrapped for two reasons:
-- this service uses OIDC for permissions to deploy itself (chicken and egg problem)
-- the fact that only one AWS IdP for GitHub can exist per environment makes it tricky to manage multiple stages in the dev environment. CloudFormation isn't great at checking if resources exist before trying to create them and trying to create a duplicate IdP for each feature branch in dev will fail.
+The OIDC resources for each environment need to be manually bootstrapped because this service uses OIDC for permissions to deploy itself (chicken and egg problem)
 
-The service is configured to be bootstrapped by running `serverless deploy` locally once for the 'official' stage for each environment (see step 4 below). This will create both the AWS OIDC IdP and the IAM role for that stage and environment.  Subsequent automated deploys of the service will update the IAM role, but won't touch the IdP.  Configuration changes for the IdP should be infrequent, but if they occur they will need to be applied manually following the steps below.
+The service is configured to be bootstrapped by running `serverless deploy` locally once for the 'official' stage for each environment (see step 4 below).
 
 Steps:
 1. Set AWS creds from CloudTamer/Kion for the target environment (dev, val, prod), then confirm the correct target
@@ -42,12 +40,12 @@ aws sts get-caller-identity
 ```bash
 cd services/github-oidc
 ```
-3. Deploy the service, passing the bootstrap flag and the stage name that corresponds to the 'official' stage for the target environment:
+3. Deploy the service with the stage name that corresponds to the 'official' stage for the target environment:
     - `main` for dev
     - `val` for val
     - `prod` for prod
 ```bash
-serverless deploy --stage ${stage_name} --param='bootstrap=true'
+serverless deploy --stage ${stage_name}
 ```
 
 ## Examples

--- a/services/github-oidc/serverless.yml
+++ b/services/github-oidc/serverless.yml
@@ -22,9 +22,6 @@ params:
     # catchall for feature stages and the main stage
     subjectClaim: "repo:CMSgov/managed-care-review:environment:dev"
 
-    # this param should be overridden with a value of 'true' via the CLI when bootstrapping an environment. see https://www.serverless.com/framework/docs/guides/parameters#inheritance-and-overriding
-    bootstrap: 'false'
-
     # list of valid server thumbprints for tokens sent by the GitHub OIDC provider
     # value comes from https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
     githubActionsThumbprint: [6938fd4d98bab03faadb97b34396831e3780aea1]
@@ -63,9 +60,17 @@ provider:
 
 resources:
   Conditions:
-    CreateGitHubIdentityProvider: !Equals
-      - ${param:bootstrap}
-      - 'true'
+    # only one IdP is allowed per AWS account, so only create the IdP if the stage is one of the three official environments [main, val, prod]
+    CreateGitHubIdentityProvider: !Or
+      - !Equals
+        - ${sls:stage}
+        - main
+      - !Equals
+        - ${sls:stage}
+        - val
+      - !Equals
+        - ${sls:stage}
+        - prod
     CreateGitHubActionsPermissionsPolicy: !Not
       - !Equals
         - ""


### PR DESCRIPTION
## Summary

I made a mistake with the bootstrapping logic that caused some CI failures with this error: `Error: No OpenIDConnect provider found in your account for https://token.actions.githubusercontent.com/`.  Here's what happened:

I set up bootstrapping so that each 'official' stage `[main, val, prod]` would be manually deployed once with a `bootstrap=true` flag that would tell the CloudFormation to go ahead and create the GitHub OICD IdP. The flag is tied to a CloudFormation conditional that tells the template to either create the IdP or not.
There can only be one of these IdPs pointing to GitHub per environment (attempts to create a duplicate will fail) and so I thought this would solve the problem of keeping each feature branch in dev from trying to deploy its own copy of the IdP and failing. 

This worked fine for feature branches. 

What I didn't understand about CloudFormation is that if the conditional resolves to false, CF will delete the IdP resource if it exists!  So when `promote` deployed the OIDC service to the `[main, val, prod]` stage with no bootstrap flag, it blew away the IdP, causing the error above. 

The reason this didn't surface sooner is that I initially forgot to add `github-oidc` to the list of changed services used by `promote`, so we saw a handful of successful promotes using OIDC.  This is because the OIDC service was always skipped, and the logic that would have deleted the OIDC IdP never ran.   The problem cropped up after I merged https://github.com/CMSgov/managed-care-review/pull/1535.

The fix is simple:  just add a conditional check in the CF to see if the stage is one of `[main, val, prod]`.  If it is, then it's ok to manage the IdP with this stage, since there will only ever be one of these stages created in a given AWS account.

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

Manual testing: 

I manually deployed the OIDC service for both the `main` stage, and a feature stage `bharveytest` and confirmed that the first deploy created the GitHub OIDC IdP, while the second did not.

