### PR TITLE
Add a few console logs to our email sending flow

### DIFF
--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -75,8 +75,6 @@ async function sendSESEmail(
         return await ses.send(command)
     } catch (err) {
         console.error(JSON.stringify(err))
-        const { requestId, cfId, extendedRequestId } = err.$$metadata
-        console.info({ requestId, cfId, extendedRequestId })
         return err
     }
 }

--- a/services/app-api/src/emailer/awsSES.ts
+++ b/services/app-api/src/emailer/awsSES.ts
@@ -69,7 +69,9 @@ async function sendSESEmail(
     params: SendEmailRequest
 ): Promise<SendEmailResponse | SESServiceException> {
     try {
+        console.info('SendEmailCommand params: ', params)
         const command = new SendEmailCommand(params)
+        console.info('SendEmailCommand: ', command)
         return await ses.send(command)
     } catch (err) {
         console.error(JSON.stringify(err))

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
@@ -105,9 +105,8 @@ test('to addresses list does not include duplicate state receiver emails on subm
 
     expect(template.toAddresses).toEqual([
         'test1@example.com',
-        'cmsreview1@example.com',
-        'cmsreview2@example.com',
         ...defaultSubmitters,
+        ...testEmailConfig.cmsReviewSharedEmails,
     ])
 })
 

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
@@ -105,6 +105,8 @@ test('to addresses list does not include duplicate state receiver emails on subm
 
     expect(template.toAddresses).toEqual([
         'test1@example.com',
+        'cmsreview1@example.com',
+        'cmsreview2@example.com',
         ...defaultSubmitters,
     ])
 })

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.ts
@@ -26,6 +26,7 @@ export const newPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
+        ...config.cmsReviewSharedEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.

--- a/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
@@ -28,6 +28,7 @@ export const resubmitPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
+        ...config.cmsReviewSharedEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.

--- a/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
@@ -27,6 +27,7 @@ export const unlockPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
+        ...config.cmsReviewSharedEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.


### PR DESCRIPTION
## Summary

In trying to diagnose whether emails were sent, we ran into some gaps in our logging.  This PR adds a couple of lines, and also adds the team's email address to the recipients, so we can have another signal about whether a send happened.