### PR TITLE
Aurora updates for security hub findings

### DIFF
--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -150,6 +150,11 @@ resources:
         Engine: aurora-postgresql
         DBInstanceClass: db.serverless
         DBClusterIdentifier: !Ref PostgresAuroraV2
+        AutoMinorVersionUpgrade: true
+        BackupRetentionPeriod: 7
+        CopyTagsToSnapshot: true
+        EnableCloudwatchLogsExports:
+          - postgresql
 
     PostgresSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -150,10 +150,6 @@ resources:
         DBInstanceClass: db.serverless
         DBClusterIdentifier: !Ref PostgresAuroraV2
         AutoMinorVersionUpgrade: true
-        BackupRetentionPeriod: 7
-        CopyTagsToSnapshot: true
-        EnableCloudwatchLogsExports:
-          - postgresql
 
     PostgresSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -136,7 +136,6 @@ resources:
         VpcSecurityGroupIds: ['${self:custom.sgId}']
         CopyTagsToSnapshot: true
         BackupRetentionPeriod: 7
-        AutoMinorVersionUpgrade: true
         EnableCloudwatchLogsExports:
           - postgresql
         ServerlessV2ScalingConfiguration:

--- a/services/postgres/serverless.yml
+++ b/services/postgres/serverless.yml
@@ -134,6 +134,11 @@ resources:
         MasterUserPassword: !Sub '{{resolve:secretsmanager:${PostgresSecret}::password}}'
         DBSubnetGroupName: !Ref PostgresSubnetGroup
         VpcSecurityGroupIds: ['${self:custom.sgId}']
+        CopyTagsToSnapshot: true
+        BackupRetentionPeriod: 7
+        AutoMinorVersionUpgrade: true
+        EnableCloudwatchLogsExports:
+          - postgresql
         ServerlessV2ScalingConfiguration:
           MinCapacity: 1
           MaxCapacity: 32


### PR DESCRIPTION
## Summary

Since the new aurora v2 upgrade last night, there have been some security hub recommendations that have come through to keep things in line with CMS requirements. This turns those things on.

The one that should be highlighted is the automatic minor version upgrades during the nightly maintenance window. This will apply minor upgrades to Aurora v2 postgres at night, which means the DB will be unavailable during the upgrade and the site will be down. Not sure how I feel about that to be honest, but it's what security hub says they want.

#### Related issues
https://jiraent.cms.gov/browse/CLDSPT-43654
