### PR TITLE
Fix broken app-api unlock test and refactor flakey app-web rate details test

### DIFF
--- a/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.test.ts
@@ -106,7 +106,7 @@ test('to addresses list does not include duplicate state receiver emails on subm
     expect(template.toAddresses).toEqual([
         'test1@example.com',
         ...defaultSubmitters,
-        ...testEmailConfig.cmsReviewSharedEmails,
+        ...testEmailConfig.devReviewTeamEmails,
     ])
 })
 

--- a/services/app-api/src/emailer/emails/newPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/newPackageStateEmail.ts
@@ -26,7 +26,7 @@ export const newPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
-        ...config.cmsReviewSharedEmails,
+        ...config.devReviewTeamEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.

--- a/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/resubmitPackageStateEmail.ts
@@ -28,7 +28,7 @@ export const resubmitPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
-        ...config.cmsReviewSharedEmails,
+        ...config.devReviewTeamEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.

--- a/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
+++ b/services/app-api/src/emailer/emails/unlockPackageStateEmail.ts
@@ -27,7 +27,7 @@ export const unlockPackageStateEmail = async (
     const receiverEmails = pruneDuplicateEmails([
         ...stateContactEmails,
         ...submitterEmails,
-        ...config.cmsReviewSharedEmails,
+        ...config.devReviewTeamEmails,
     ])
 
     //This checks to make sure all programs contained in submission exists for the state.

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -26,7 +26,6 @@ import {
     TEST_PNG_FILE,
     dragAndDrop,
     updateDateRange,
-    prettyDebug,
 } from '../../../testHelpers'
 import { RateDetails } from './RateDetails'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
@@ -546,14 +545,14 @@ describe('RateDetails', () => {
                 const rateCertsAfterAddAnother = rateCertifications(screen)
                 expect(rateCertsAfterAddAnother).toHaveLength(3)
             })
-            prettyDebug()
+
             await clickRemoveIndexRate(screen, 1)
 
             await waitFor(() => {
                 const rateCertsAfterRemove = rateCertifications(screen)
                 expect(rateCertsAfterRemove).toHaveLength(2)
             })
-        }, 13000)
+        }, 10000)
 
         it('accepts documents on second rate', async () => {
             renderWithProviders(

--- a/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/RateDetails/RateDetails.test.tsx
@@ -26,6 +26,7 @@ import {
     TEST_PNG_FILE,
     dragAndDrop,
     updateDateRange,
+    prettyDebug,
 } from '../../../testHelpers'
 import { RateDetails } from './RateDetails'
 import { ACCEPTED_SUBMISSION_FILE_TYPES } from '../../../components/FileUpload'
@@ -34,6 +35,11 @@ import * as useStatePrograms from '../../../hooks/useStatePrograms'
 import { unlockedWithALittleBitOfEverything } from '../../../common-code/healthPlanFormDataMocks'
 
 describe('RateDetails', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+        jest.spyOn(useStatePrograms, 'useStatePrograms').mockRestore()
+    })
+
     const emptyRateDetailsDraft = {
         ...mockDraft(),
         rateInfos: [],
@@ -43,195 +49,6 @@ describe('RateDetails', () => {
         rateDateCertified: undefined,
         actuaryContacts: [],
     }
-
-    afterEach(() => {
-        jest.clearAllMocks()
-        jest.spyOn(useStatePrograms, 'useStatePrograms').mockRestore()
-    })
-
-    const fillOutIndexRate = async (screen: Screen, index: number) => {
-        const targetRateCert = rateCertifications(screen)[index]
-        expect(targetRateCert).toBeDefined()
-        const withinTargetRateCert = within(targetRateCert)
-
-        // assert proper initial fields are present
-        expect(
-            withinTargetRateCert.getByText('Upload rate certification')
-        ).toBeInTheDocument()
-        expect(
-            withinTargetRateCert.getByText(
-                'Programs this rate certification covers'
-            )
-        ).toBeInTheDocument()
-        expect(
-            withinTargetRateCert.getByText('Rate certification type')
-        ).toBeInTheDocument()
-        expect(
-            withinTargetRateCert.getByText(
-                'Does the actuary certify capitation rates specific to each rate cell or a rate range?'
-            )
-        ).toBeInTheDocument()
-
-        //Rates across submission
-        const sharedRates = withinTargetRateCert.queryByText(
-            /Was this rate certification uploaded to any other submissions/
-        )
-        //if rates across submission UI exists then fill out section
-        if (sharedRates) {
-            expect(sharedRates).toBeInTheDocument()
-            withinTargetRateCert.getByLabelText('No').click()
-        }
-
-        // add 1 doc
-        const input = withinTargetRateCert.getByLabelText(
-            'Upload rate certification'
-        )
-        await userEvent.upload(input, [TEST_DOC_FILE])
-
-        // add programs
-        const combobox = await withinTargetRateCert.findByRole('combobox')
-        await selectEvent.openMenu(combobox)
-        await selectEvent.select(combobox, 'SNBC')
-        await selectEvent.openMenu(combobox)
-        await selectEvent.select(combobox, 'PMAP')
-        expect(
-            withinTargetRateCert.getByLabelText('Remove SNBC')
-        ).toBeInTheDocument()
-        expect(
-            withinTargetRateCert.getByLabelText('Remove PMAP')
-        ).toBeInTheDocument()
-
-        //  add types and answer captitation rates question
-        withinTargetRateCert.getByLabelText('New rate certification').click()
-
-        withinTargetRateCert
-            .getByLabelText(
-                'Certification of capitation rates specific to each rate cell'
-            )
-            .click()
-
-        // check that now we can see dates, since that is triggered after selecting type
-        await waitFor(() => {
-            expect(
-                withinTargetRateCert.queryByText('Start date')
-            ).toBeInTheDocument()
-            expect(
-                withinTargetRateCert.queryByText('End date')
-            ).toBeInTheDocument()
-            expect(
-                withinTargetRateCert.queryByText('Date certified')
-            ).toBeInTheDocument()
-            expect(withinTargetRateCert.queryByText('Name')).toBeInTheDocument()
-            expect(
-                withinTargetRateCert.queryByText('Title/Role')
-            ).toBeInTheDocument()
-            expect(
-                withinTargetRateCert.queryByText('Email')
-            ).toBeInTheDocument()
-        })
-
-        const startDateInputs =
-            withinTargetRateCert.getAllByLabelText('Start date')
-        const endDateInputs = withinTargetRateCert.getAllByLabelText('End date')
-        await updateDateRange({
-            start: { elements: startDateInputs, date: '01/01/2022' },
-            end: { elements: endDateInputs, date: '12/31/2022' },
-        })
-
-        withinTargetRateCert.getAllByLabelText('Date certified')[0].focus()
-        await userEvent.paste('12/01/2021')
-
-        // fill out actuary contact
-        withinTargetRateCert.getByLabelText('Name').focus()
-        await userEvent.paste(`Actuary Contact Person ${index}`)
-
-        withinTargetRateCert.getByLabelText('Title/Role').focus()
-        await userEvent.paste(`Actuary Contact Title ${index}`)
-
-        withinTargetRateCert.getByLabelText('Email').focus()
-        await userEvent.paste(`actuarycontact${index}@test.com`)
-
-        await userEvent.click(withinTargetRateCert.getByLabelText('Mercer'))
-    }
-
-    const fillOutFirstRate = async (screen: Screen) => {
-        // trigger errors (used later to confirm we filled out every field)
-        fireEvent.click(
-            screen.getByRole('button', {
-                name: 'Continue',
-            })
-        )
-
-        await fillOutIndexRate(screen, 0)
-        // wait for all errors to clear
-        await waitForElementToBeRemoved(() =>
-            screen.queryAllByTestId('errorMessage')
-        )
-    }
-
-    const clickAddNewRate = async (screen: Screen) => {
-        const rateCertsBeforeAddingNewRate = rateCertifications(screen)
-
-        const addAnotherButton = screen.getByRole('button', {
-            name: /Add another rate/,
-        })
-
-        expect(addAnotherButton).toBeInTheDocument()
-        fireEvent.click(addAnotherButton)
-        return await waitFor(() =>
-            expect(rateCertifications(screen)).toHaveLength(
-                rateCertsBeforeAddingNewRate.length + 1
-            )
-        )
-    }
-
-    const clickRemoveIndexRate = async (
-        screen: Screen,
-        indexOfRateCertToRemove: number
-    ) => {
-        // Remember, user cannot never remove the first rate certification -- MR-2231
-        const rateCertsBeforeRemoving = rateCertifications(screen)
-        // Confirm there is a rate to remove
-        expect(rateCertsBeforeRemoving.length).toBeGreaterThanOrEqual(2)
-
-        // Confirm there is one less rate removal button than rate certs
-        const removeRateButtonsBeforeClick = screen.getAllByRole('button', {
-            name: /Remove rate certification/,
-        })
-        expect(removeRateButtonsBeforeClick.length).toBeGreaterThanOrEqual(1)
-        expect(removeRateButtonsBeforeClick).toHaveLength(
-            rateCertsBeforeRemoving.length - 1
-        )
-
-        // Remove rate cert
-        const removeRateButton =
-            removeRateButtonsBeforeClick[indexOfRateCertToRemove - 1]
-
-        expect(removeRateButton).toBeInTheDocument()
-        fireEvent.click(removeRateButton)
-
-        await waitFor(() => {
-            // Confirm that there is one less rate certification on the page
-            expect(rateCertifications(screen)).toHaveLength(
-                rateCertsBeforeRemoving.length - 1
-            )
-            // Confirm that there is one less rate removal button (might even be zero buttons on page if all additional rates removed)
-            expect(
-                screen.getAllByRole('button', {
-                    name: /Remove rate certification/,
-                })
-            ).toHaveLength(removeRateButtonsBeforeClick.length - 1)
-        })
-    }
-
-    const rateCertifications = (screen: Screen) => {
-        return screen.getAllByTestId('rate-certification-form')
-    }
-
-    const lastRateCertificationFromList = (screen: Screen) => {
-        return rateCertifications(screen).pop()
-    }
-
     describe('handles a single rate', () => {
         afterEach(() => {
             jest.clearAllMocks()
@@ -723,24 +540,20 @@ describe('RateDetails', () => {
             const rateCertsOnLoad = rateCertifications(screen)
             expect(rateCertsOnLoad).toHaveLength(1)
 
-            await fillOutFirstRate(screen)
             await clickAddNewRate(screen)
-            await fillOutIndexRate(screen, 1)
             await clickAddNewRate(screen)
-            await fillOutIndexRate(screen, 2)
-
             await waitFor(() => {
                 const rateCertsAfterAddAnother = rateCertifications(screen)
                 expect(rateCertsAfterAddAnother).toHaveLength(3)
             })
-
+            prettyDebug()
             await clickRemoveIndexRate(screen, 1)
 
             await waitFor(() => {
                 const rateCertsAfterRemove = rateCertifications(screen)
                 expect(rateCertsAfterRemove).toHaveLength(2)
             })
-        }, 10000)
+        }, 13000)
 
         it('accepts documents on second rate', async () => {
             renderWithProviders(
@@ -1874,3 +1687,183 @@ describe('RateDetails', () => {
         })
     })
 })
+
+// Helper functions
+
+const fillOutIndexRate = async (screen: Screen, index: number) => {
+    const targetRateCert = rateCertifications(screen)[index]
+    expect(targetRateCert).toBeDefined()
+    const withinTargetRateCert = within(targetRateCert)
+
+    // assert proper initial fields are present
+    expect(
+        withinTargetRateCert.getByText('Upload rate certification')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText(
+            'Programs this rate certification covers'
+        )
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText('Rate certification type')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByText(
+            'Does the actuary certify capitation rates specific to each rate cell or a rate range?'
+        )
+    ).toBeInTheDocument()
+
+    //Rates across submission
+    const sharedRates = withinTargetRateCert.queryByText(
+        /Was this rate certification uploaded to any other submissions/
+    )
+    //if rates across submission UI exists then fill out section
+    if (sharedRates) {
+        expect(sharedRates).toBeInTheDocument()
+        withinTargetRateCert.getByLabelText('No').click()
+    }
+
+    // add 1 doc
+    const input = withinTargetRateCert.getByLabelText(
+        'Upload rate certification'
+    )
+    await userEvent.upload(input, [TEST_DOC_FILE])
+
+    // add programs
+    const combobox = await withinTargetRateCert.findByRole('combobox')
+    await selectEvent.openMenu(combobox)
+    await selectEvent.select(combobox, 'SNBC')
+    await selectEvent.openMenu(combobox)
+    await selectEvent.select(combobox, 'PMAP')
+    expect(
+        withinTargetRateCert.getByLabelText('Remove SNBC')
+    ).toBeInTheDocument()
+    expect(
+        withinTargetRateCert.getByLabelText('Remove PMAP')
+    ).toBeInTheDocument()
+
+    //  add types and answer captitation rates question
+    withinTargetRateCert.getByLabelText('New rate certification').click()
+
+    withinTargetRateCert
+        .getByLabelText(
+            'Certification of capitation rates specific to each rate cell'
+        )
+        .click()
+
+    // check that now we can see dates, since that is triggered after selecting type
+    await waitFor(() => {
+        expect(
+            withinTargetRateCert.queryByText('Start date')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('End date')).toBeInTheDocument()
+        expect(
+            withinTargetRateCert.queryByText('Date certified')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('Name')).toBeInTheDocument()
+        expect(
+            withinTargetRateCert.queryByText('Title/Role')
+        ).toBeInTheDocument()
+        expect(withinTargetRateCert.queryByText('Email')).toBeInTheDocument()
+    })
+
+    const startDateInputs = withinTargetRateCert.getAllByLabelText('Start date')
+    const endDateInputs = withinTargetRateCert.getAllByLabelText('End date')
+    await updateDateRange({
+        start: { elements: startDateInputs, date: '01/01/2022' },
+        end: { elements: endDateInputs, date: '12/31/2022' },
+    })
+
+    withinTargetRateCert.getAllByLabelText('Date certified')[0].focus()
+    await userEvent.paste('12/01/2021')
+
+    // fill out actuary contact
+    withinTargetRateCert.getByLabelText('Name').focus()
+    await userEvent.paste(`Actuary Contact Person ${index}`)
+
+    withinTargetRateCert.getByLabelText('Title/Role').focus()
+    await userEvent.paste(`Actuary Contact Title ${index}`)
+
+    withinTargetRateCert.getByLabelText('Email').focus()
+    await userEvent.paste(`actuarycontact${index}@test.com`)
+
+    await userEvent.click(withinTargetRateCert.getByLabelText('Mercer'))
+}
+
+const fillOutFirstRate = async (screen: Screen) => {
+    // trigger errors (used later to confirm we filled out every field)
+    fireEvent.click(
+        screen.getByRole('button', {
+            name: 'Continue',
+        })
+    )
+
+    await fillOutIndexRate(screen, 0)
+    // wait for all errors to clear
+    await waitForElementToBeRemoved(() =>
+        screen.queryAllByTestId('errorMessage')
+    )
+}
+
+const clickAddNewRate = async (screen: Screen) => {
+    const rateCertsBeforeAddingNewRate = rateCertifications(screen)
+
+    const addAnotherButton = screen.getByRole('button', {
+        name: /Add another rate/,
+    })
+
+    expect(addAnotherButton).toBeInTheDocument()
+    fireEvent.click(addAnotherButton)
+    return await waitFor(() =>
+        expect(rateCertifications(screen)).toHaveLength(
+            rateCertsBeforeAddingNewRate.length + 1
+        )
+    )
+}
+
+const clickRemoveIndexRate = async (
+    screen: Screen,
+    indexOfRateCertToRemove: number
+) => {
+    // Remember, user cannot never remove the first rate certification -- MR-2231
+    const rateCertsBeforeRemoving = rateCertifications(screen)
+    // Confirm there is a rate to remove
+    expect(rateCertsBeforeRemoving.length).toBeGreaterThanOrEqual(2)
+
+    // Confirm there is one less rate removal button than rate certs
+    const removeRateButtonsBeforeClick = screen.getAllByRole('button', {
+        name: /Remove rate certification/,
+    })
+    expect(removeRateButtonsBeforeClick.length).toBeGreaterThanOrEqual(1)
+    expect(removeRateButtonsBeforeClick).toHaveLength(
+        rateCertsBeforeRemoving.length - 1
+    )
+
+    // Remove rate cert
+    const removeRateButton =
+        removeRateButtonsBeforeClick[indexOfRateCertToRemove - 1]
+
+    expect(removeRateButton).toBeInTheDocument()
+    fireEvent.click(removeRateButton)
+
+    await waitFor(() => {
+        // Confirm that there is one less rate certification on the page
+        expect(rateCertifications(screen)).toHaveLength(
+            rateCertsBeforeRemoving.length - 1
+        )
+        // Confirm that there is one less rate removal button (might even be zero buttons on page if all additional rates removed)
+        expect(
+            screen.getAllByRole('button', {
+                name: /Remove rate certification/,
+            })
+        ).toHaveLength(removeRateButtonsBeforeClick.length - 1)
+    })
+}
+
+const rateCertifications = (screen: Screen) => {
+    return screen.getAllByTestId('rate-certification-form')
+}
+
+const lastRateCertificationFromList = (screen: Screen) => {
+    return rateCertifications(screen).pop()
+}


### PR DESCRIPTION
## Summary
We have two failed promotes due to issues with unit tests today. This is a quick fix to try and address.
1. Remove invalid variable
2. Remove filling out the rate certs for remove button tests
