### PR TITLE
Fix pruneDuplicateEmails

### DIFF
--- a/services/app-api/.eslintrc
+++ b/services/app-api/.eslintrc
@@ -17,6 +17,7 @@
     },
     "ignorePatterns": ["gen/*", "webpack.config.js"],
     "rules": {
+        "array-callback-return": "error",
         "prefer-promise-reject-errors": "error",
         "no-throw-literal": "error",
         "jest/no-focused-tests": "error",

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.test.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.test.ts
@@ -99,9 +99,15 @@ describe('pruneDuplicateEmails', () => {
             ['"Foo Bar 1" foo@bar.com', '"Foo Bar 2" <foo@bar.com>'],
             ['"Foo Bar 1" foo@bar.com', '"Foo Bar 2" <foo@bar.com>'],
         ],
+        // simple email addresses that are duplicates due to casing are pruned and lowercase preferred
         [
-            ['foo@bar.com', 'foo@nothing.com', 'bar@foo.com', 'bar@foo.com'],
-            ['foo@bar.com', 'foo@nothing.com', 'bar@foo.com'],
+            ['Foo@bar.com', 'Fo.b-r@bar.com', 'fo.b-r@bar.com', 'foo@bar.com'],
+            ['fo.b-r@bar.com', 'foo@bar.com'],
+        ],
+        // simple email addresses that are not duplicates remain the same
+        [
+            ['Foo@bar.com', 'Fo.b-r@bar.com', 'foo@nothing.com'],
+            ['Foo@bar.com', 'Fo.b-r@bar.com', 'foo@nothing.com'],
         ],
     ]
 

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.test.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.test.ts
@@ -102,7 +102,7 @@ describe('pruneDuplicateEmails', () => {
         // simple email addresses that are duplicates due to casing are pruned and lowercase preferred
         [
             ['Foo@bar.com', 'Fo.b-r@bar.com', 'fo.b-r@bar.com', 'foo@bar.com'],
-            ['fo.b-r@bar.com', 'foo@bar.com'],
+            ['Foo@bar.com', 'Fo.b-r@bar.com'],
         ],
         // simple email addresses that are not duplicates remain the same
         [

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
@@ -41,10 +41,11 @@ const pruneDuplicateEmails = (emails: string[]): string[] => {
     emails.forEach((currentEmail: string) => {
         const rawEmail = formatEmailAddresses(currentEmail).toLowerCase()
         const emailInObject = uniqueEmails[rawEmail]
-        /* ['Jane Johnson <jane@example.com>', 'jane@example.com', 'Bill Smith <BILL@example.com>']
+        /* ['Jane Johnson <jane@example.com>', 'jane@example.com', 'ROGER@example.com' 'Bill Smith <BILL@example.com>']
         becomes
         {
             jane@example.com: 'Jane Johnson <jane@example.com>',
+            roger@example.com: 'ROGER@example.com',
             bill@example.com: 'Bill Smith <BILL@example.com>'
         }
         */

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
@@ -35,22 +35,28 @@ const formatEmailAddresses = (str: string) => {
     e.g. if "Foo Bar" <foobar@example> and foobar@example.com are both in the list, only foobar@example.com will remain after prune
     e.g. if "Foo Bar" <foobar@example> and "The best Foo Bar" <foobar@example> are both in the list, both remain after prune
 */
-const pruneDuplicateEmails = (emails: string[]): string[] =>
-    emails.filter((email, index) => {
+const pruneDuplicateEmails = (emails: string[]): string[] => {
+    /* we'll use all-lowercase to compare, but return the original case
+    when one address appears with mixed casing, we'll return the first one we find */
+    const lowercasedEmails = emails.map((email) => email.toLowerCase())
+    return emails.filter((email, index) => {
         const aliasedEmail = !isEmailAddress(email)
         const rawEmailAddress = formatEmailAddresses(email)
-
-        if (aliasedEmail && emails.indexOf(rawEmailAddress) !== -1) {
+        if (
+            aliasedEmail &&
+            lowercasedEmails.indexOf(rawEmailAddress.toLowerCase()) !== -1
+        ) {
             // aliased email address is also included elsewhere on list as a raw email, remove it
-            emails.indexOf(rawEmailAddress) === index
+            lowercasedEmails.indexOf(rawEmailAddress.toLowerCase()) === index
         } else if (aliasedEmail) {
             // return unique aliased email address
-            return emails.indexOf(email) === index
+            return lowercasedEmails.indexOf(email.toLowerCase()) === index
         } else {
-            // return unique email address, prefer lowercased if duplicates exist
-            return emails.indexOf(email.toLowerCase()) === index
+            // return unique email address
+            return lowercasedEmails.indexOf(email.toLowerCase()) === index
         }
     })
+}
 
 export {
     isEmailAddress,

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
@@ -45,7 +45,7 @@ const pruneDuplicateEmails = (emails: string[]): string[] => {
         becomes
         {
             jane@example.com: 'Jane Johnson <jane@example.com>',
-            bill@example.com: 'Bill Smith <bill@example.com>'
+            bill@example.com: 'Bill Smith <BILL@example.com>'
         }
         */
         if (

--- a/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
+++ b/services/app-api/src/emailer/formatters/formatEmailAddresses.ts
@@ -11,7 +11,7 @@ const includesEmailAddress = (str: string) => {
 const emailAddressOnlyRegex =
     /^[a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+$/
 const matchExactEmail = (str: string) => str.match(emailAddressOnlyRegex)
-const isEmailAddress = (str: string) => Boolean(matchExactEmail(str))
+const hasAlias = (str: string) => !matchExactEmail(str)
 
 /*
    Change parameter store string into a raw email address for user display
@@ -30,36 +30,38 @@ const formatEmailAddresses = (str: string) => {
     Remove duplicate emails from email string array
 
     This function will remove duplicate emails, including aliased emails that duplicate the same raw email string used elsewhere as a standalone entry
-    However, multiple aliased email addresses that do not replicate a raw email string elsewhere in list are allowed as duplicates because there is not way to determine which to prefer
-    e.g. if FooBar@example.com and foobar@example.com are both in list, only foobar@example.com will remain after prune
-    e.g. if "Foo Bar" <foobar@example> and foobar@example.com are both in the list, only foobar@example.com will remain after prune
-    e.g. if "Foo Bar" <foobar@example> and "The best Foo Bar" <foobar@example> are both in the list, both remain after prune
+    If there are multiple aliased emails that duplicate the same raw email string, we'll keep only the first aliased email
+    We prefer aliased emails over standalone emails because they make it easier to catch potential errors in our lower environments
+    e.g. if FooBar@example.com and foobar@example.com are both in list, only one will remain
+    e.g. if "Foo Bar" <foobar@example> and foobar@example.com are both in the list, only "Foo Bar" <foobar@example> will remain
+    e.g. if "Foo Bar" <foobar@example> and "The best Foo Bar" <foobar@example> are both in the list, "Foo Bar" <foobar@example> will remain
 */
 const pruneDuplicateEmails = (emails: string[]): string[] => {
-    /* we'll use all-lowercase to compare, but return the original case
-    when one address appears with mixed casing, we'll return the first one we find */
-    const lowercasedEmails = emails.map((email) => email.toLowerCase())
-    return emails.filter((email, index) => {
-        const aliasedEmail = !isEmailAddress(email)
-        const rawEmailAddress = formatEmailAddresses(email)
+    const uniqueEmails: { [key: string]: string } = {}
+    emails.forEach((currentEmail: string) => {
+        const rawEmail = formatEmailAddresses(currentEmail).toLowerCase()
+        const emailInObject = uniqueEmails[rawEmail]
+        /* ['Jane Johnson <jane@example.com>', 'jane@example.com', 'Bill Smith <BILL@example.com>']
+        becomes
+        {
+            jane@example.com: 'Jane Johnson <jane@example.com>',
+            bill@example.com: 'Bill Smith <bill@example.com>'
+        }
+        */
         if (
-            aliasedEmail &&
-            lowercasedEmails.indexOf(rawEmailAddress.toLowerCase()) !== -1
+            emailInObject === undefined ||
+            /* we prefer the aliased email */
+            (!hasAlias(emailInObject) && hasAlias(currentEmail))
         ) {
-            // aliased email address is also included elsewhere on list as a raw email, remove it
-            lowercasedEmails.indexOf(rawEmailAddress.toLowerCase()) === index
-        } else if (aliasedEmail) {
-            // return unique aliased email address
-            return lowercasedEmails.indexOf(email.toLowerCase()) === index
-        } else {
-            // return unique email address
-            return lowercasedEmails.indexOf(email.toLowerCase()) === index
+            uniqueEmails[rawEmail] = currentEmail
         }
     })
+
+    return Object.values(uniqueEmails)
 }
 
 export {
-    isEmailAddress,
+    hasAlias,
     includesEmailAddress,
     formatEmailAddresses,
     pruneDuplicateEmails,

--- a/services/app-api/src/emailer/formatters/index.ts
+++ b/services/app-api/src/emailer/formatters/index.ts
@@ -1,5 +1,5 @@
 export {
-    isEmailAddress,
+    hasAlias,
     includesEmailAddress,
     formatEmailAddresses,
     pruneDuplicateEmails,

--- a/services/app-web/.eslintrc
+++ b/services/app-web/.eslintrc
@@ -19,6 +19,7 @@
     },
     "ignorePatterns": ["src/gen/*", "*.config.ts"],
     "rules": {
+        "array-callback-return": "error",
         "prefer-promise-reject-errors": "error",
         "no-throw-literal": "error",
         "jest/no-focused-tests": "error",


### PR DESCRIPTION
## Summary

@rswerve putting up a failing test for now. I will try to push a commit to fix but in case I don't get there before meetings start wanted to have visibility.

The cases the function needs to handle:

- prune duplicate emails due to alias 
- prune duplicate emails due to casing
- maintain aliased emails that are unique
- maintain raw emails that are unique even if they have uppercase (this is what was broken I believe - I think #1489 and caused divisions to be removed only in prod)

**Maz (@rswerve ) adds**: You were right.  Uppercasing was breaking pruneDupes....  I'm now comparing everything as lowercase, and returning whichever casing we see first in the array (so I tweaked your test to account for that).  All tests are passing.