### PR TITLE
MR-3116: Email errors should not block submit, unlock and resubmit to complete. 

### DIFF
--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -32,6 +32,7 @@ import { toDomain } from '../../../../app-web/src/common-code/proto/healthPlanFo
 import { EmailParameterStore } from '../../parameterStore'
 import { LDService } from '../../launchDarkly/launchDarkly'
 import { FlagValueTypes } from 'app-web/src/common-code/featureFlags'
+import { GraphQLError } from 'graphql'
 
 export const SubmissionErrorCodes = ['INCOMPLETE', 'INVALID'] as const
 type SubmissionErrorCode = typeof SubmissionErrorCodes[number] // iterable union type
@@ -343,7 +344,11 @@ export function submitHealthPlanPackageResolver(
                 cmsPackageEmailResult
             )
             setErrorAttributesOnActiveSpan('CMS email failed', span)
-            throw cmsPackageEmailResult
+            throw new GraphQLError(cmsPackageEmailResult.message, {
+                extensions: {
+                    code: 'EMAIL_ERROR',
+                },
+            })
         }
 
         if (statePackageEmailResult instanceof Error) {
@@ -352,7 +357,11 @@ export function submitHealthPlanPackageResolver(
                 statePackageEmailResult
             )
             setErrorAttributesOnActiveSpan('state email failed', span)
-            throw statePackageEmailResult
+            throw new GraphQLError(statePackageEmailResult.message, {
+                extensions: {
+                    code: 'EMAIL_ERROR',
+                },
+            })
         }
 
         logSuccess('submitHealthPlanPackage')

--- a/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/unlockHealthPlanPackage.ts
@@ -21,6 +21,7 @@ import {
     setSuccessAttributesOnActiveSpan,
 } from '../attributeHelper'
 import { EmailParameterStore } from '../../parameterStore'
+import { GraphQLError } from 'graphql'
 
 // unlock is a state machine transforming a LockedFormData and turning it into UnlockedFormData
 // Since Unlocked is a strict subset of Locked, this can't error today.
@@ -176,7 +177,11 @@ export function unlockHealthPlanPackageResolver(
                 'unlockPackageCMSEmail - CMS email failed',
                 unlockPackageCMSEmailResult
             )
-            throw unlockPackageCMSEmailResult
+            throw new GraphQLError(unlockPackageCMSEmailResult.message, {
+                extensions: {
+                    code: 'EMAIL_ERROR',
+                },
+            })
         }
 
         if (unlockPackageStateEmailResult instanceof Error) {
@@ -184,7 +189,11 @@ export function unlockHealthPlanPackageResolver(
                 'unlockPackageCMSEmail - CMS email failed',
                 unlockPackageStateEmailResult
             )
-            throw unlockPackageStateEmailResult
+            throw new GraphQLError(unlockPackageStateEmailResult.message, {
+                extensions: {
+                    code: 'EMAIL_ERROR',
+                },
+            })
         }
 
         logSuccess('unlockHealthPlanPackage')

--- a/services/app-web/src/components/Modal/UnlockSubmitModal.test.tsx
+++ b/services/app-web/src/components/Modal/UnlockSubmitModal.test.tsx
@@ -92,6 +92,52 @@ describe('UnlockSubmitModal', () => {
                 )
             )
         })
+        it('redirects if submission succeeds, but failed sending emails', async () => {
+            let testLocation: Location
+            const modalRef = createRef<ModalRef>()
+            const handleOpen = () =>
+                modalRef.current?.toggleModal(undefined, true)
+            renderWithProviders(
+                <UnlockSubmitModal
+                    healthPlanPackage={mockCompleteDraft()}
+                    submissionName="Test-Submission"
+                    modalType="SUBMIT"
+                    modalRef={modalRef}
+                    setIsSubmitting={mockSetIsSubmitting}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            submitHealthPlanPackageMockError({
+                                id: mockCompleteDraft().id,
+                                errorCode: 'EMAIL_ERROR',
+                            }),
+                        ],
+                    },
+                    routerProvider: {
+                        route: `draftSubmission/${
+                            mockCompleteDraft().id
+                        }/review-and-submit`,
+                    },
+                    location: (location) => (testLocation = location),
+                }
+            )
+
+            await waitFor(() => handleOpen())
+            const dialog = screen.getByRole('dialog')
+            await waitFor(() => expect(dialog).toHaveClass('is-visible'))
+
+            await userEvent.click(screen.getByTestId('submit-modal-submit'))
+
+            await waitFor(() =>
+                expect(testLocation.pathname).toBe(`/dashboard`)
+            )
+            await waitFor(() =>
+                expect(testLocation.search).toBe(
+                    `?justSubmitted=Test-Submission`
+                )
+            )
+        })
         it('displays modal alert banner error if submit api request fails', async () => {
             const modalRef = createRef<ModalRef>()
             const handleOpen = () =>
@@ -312,6 +358,52 @@ describe('UnlockSubmitModal', () => {
                 expect(errorHeading).toBeInTheDocument()
                 expect(errorMessage).toBeInTheDocument()
             })
+        })
+        it('does not display modal alert banner error if unlock succeeds, but fails sending emails', async () => {
+            const modalRef = createRef<ModalRef>()
+            const handleOpen = () =>
+                modalRef.current?.toggleModal(undefined, true)
+            renderWithProviders(
+                <UnlockSubmitModal
+                    modalRef={modalRef}
+                    modalType="UNLOCK"
+                    healthPlanPackage={mockSubmittedHealthPlanPackage()}
+                />,
+                {
+                    apolloProvider: {
+                        mocks: [
+                            unlockHealthPlanPackageMockError({
+                                id: mockUnlockedHealthPlanPackage().id,
+                                reason: 'Test unlock summary',
+                                errorCode: 'EMAIL_ERROR',
+                            }),
+                        ],
+                    },
+                }
+            )
+            await waitFor(() => handleOpen())
+            const dialog = screen.getByRole('dialog')
+            await waitFor(() => expect(dialog).toHaveClass('is-visible'))
+
+            await userEvent.type(
+                screen.getByTestId('unlockSubmitModalInput'),
+                'Test unlock summary'
+            )
+
+            await userEvent.click(screen.getByTestId('unlock-modal-submit'))
+
+            await waitFor(() => {
+                const errorHeading = screen.queryByRole('heading', {
+                    name: 'Unlock error',
+                })
+                const errorMessage = screen.queryByText(
+                    'Error attempting to unlock.'
+                )
+                expect(errorHeading).not.toBeInTheDocument()
+                expect(errorMessage).not.toBeInTheDocument()
+            })
+
+            await waitFor(() => expect(dialog).toHaveClass('is-hidden'))
         })
     })
 

--- a/services/app-web/src/constants/errors.ts
+++ b/services/app-web/src/constants/errors.ts
@@ -2,6 +2,7 @@
     This file contains lang constants related to user facing error messages across the application. 
     - Use caution editing this file, you could be changing content used across multiple pages
 */
+
 const ERROR_MESSAGES = {
     generic_error: "We're having trouble loading this page.",
     submit_error_heading: 'Submission error',
@@ -17,8 +18,17 @@ const ERROR_MESSAGES = {
     question_missing_field: 'Your question is missing information.',
     question_error_generic: 'Error attempting to add question.',
     response_error_generic: 'Error attempting to add response.',
+    email_error_generic: 'Error attempting to send email.',
 }
 
 const MAIL_TO_SUPPORT = 'mc-review@cms.hhs.gov'
 
-export { MAIL_TO_SUPPORT, ERROR_MESSAGES }
+const GRAPHQL_ERROR_MESSAGES = {
+    EMAIL_ERROR: 'Error attempting to send emails.',
+    BAD_USER_INPUT: 'Your submission is missing information.',
+    FORBIDDEN: 'User not authorized to fetch state data.',
+}
+
+export type GraphQLErrorTypes = keyof typeof GRAPHQL_ERROR_MESSAGES
+
+export { MAIL_TO_SUPPORT, ERROR_MESSAGES, GRAPHQL_ERROR_MESSAGES }

--- a/services/app-web/src/constants/errors.ts
+++ b/services/app-web/src/constants/errors.ts
@@ -23,12 +23,4 @@ const ERROR_MESSAGES = {
 
 const MAIL_TO_SUPPORT = 'mc-review@cms.hhs.gov'
 
-const GRAPHQL_ERROR_MESSAGES = {
-    EMAIL_ERROR: 'Error attempting to send emails.',
-    BAD_USER_INPUT: 'Your submission is missing information.',
-    FORBIDDEN: 'User not authorized to fetch state data.',
-}
-
-export type GraphQLErrorTypes = keyof typeof GRAPHQL_ERROR_MESSAGES
-
-export { MAIL_TO_SUPPORT, ERROR_MESSAGES, GRAPHQL_ERROR_MESSAGES }
+export { MAIL_TO_SUPPORT, ERROR_MESSAGES }

--- a/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
+++ b/services/app-web/src/pages/SubmissionSummary/SubmissionSummary.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useRef, useState } from 'react'
 import { NavLink, useOutletContext } from 'react-router-dom'
 import sprite from 'uswds/src/img/sprite.svg'
 import { packageName } from '../../common-code/healthPlanFormDataType'
-import { Loading } from '../../components/Loading'
 import {
     ContactsSummarySection,
     ContractDetailsSummarySection,
@@ -70,17 +69,8 @@ export const SubmissionSummary = (): React.ReactElement => {
         featureFlags.CMS_QUESTIONS.defaultValue
     )
 
-    const outletContext = useOutletContext<SideNavOutletContextType>()
-    if (!outletContext) {
-        return (
-            <GridContainer>
-                <Loading />
-            </GridContainer>
-        )
-    }
-
     const { pkg, currentRevision, packageData, user, documentDates } =
-        outletContext
+        useOutletContext<SideNavOutletContextType>()
 
     const isCMSUser = user?.role === 'CMS_USER'
     const submissionStatus = pkg.status

--- a/services/app-web/src/testHelpers/apolloMocks/apolloErrorCodeMocks.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/apolloErrorCodeMocks.ts
@@ -1,0 +1,7 @@
+export const GRAPHQL_ERROR_MOCK_MESSAGES = {
+    EMAIL_ERROR: 'Error attempting to send emails.',
+    BAD_USER_INPUT: 'An error occurred due to bad user input.',
+    FORBIDDEN: "You don't have permission to access the requested resource.",
+}
+
+export type GraphQLErrorMockCodeType = keyof typeof GRAPHQL_ERROR_MOCK_MESSAGES

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
@@ -28,9 +28,9 @@ import {
 } from './healthPlanFormDataMock'
 import { ApolloError } from '@apollo/client'
 import {
-    GRAPHQL_ERROR_MESSAGES,
-    GraphQLErrorTypes,
-} from '../../constants/errors'
+    GRAPHQL_ERROR_MOCK_MESSAGES,
+    GraphQLErrorMockCodeType,
+} from './apolloErrorCodeMocks'
 
 type fetchHealthPlanPackageMockProps = {
     submission?: HealthPlanPackage
@@ -424,11 +424,11 @@ const submitHealthPlanPackageMockError = ({
     errorCode,
 }: {
     id: string
-    errorCode?: GraphQLErrorTypes
+    errorCode?: GraphQLErrorMockCodeType
 }): MockedResponse<SubmitHealthPlanPackageMutation | ApolloError> => {
     const graphQLError = new GraphQLError(
         errorCode
-            ? GRAPHQL_ERROR_MESSAGES[errorCode]
+            ? GRAPHQL_ERROR_MOCK_MESSAGES[errorCode]
             : 'Error attempting to submit.',
         {
             extensions: {
@@ -479,11 +479,11 @@ const unlockHealthPlanPackageMockError = ({
 }: {
     id: string
     reason: string
-    errorCode?: GraphQLErrorTypes
+    errorCode?: GraphQLErrorMockCodeType
 }): MockedResponse<UnlockHealthPlanPackageMutation> => {
     const graphQLError = new GraphQLError(
         errorCode
-            ? GRAPHQL_ERROR_MESSAGES[errorCode]
+            ? GRAPHQL_ERROR_MOCK_MESSAGES[errorCode]
             : 'Error attempting to unlock.',
         {
             extensions: {

--- a/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
+++ b/services/app-web/src/testHelpers/apolloMocks/healthPlanPackageGQLMock.ts
@@ -26,6 +26,11 @@ import {
     mockUnlockedHealthPlanPackageWithDocuments,
     mockUnlockedHealthPlanPackage,
 } from './healthPlanFormDataMock'
+import { ApolloError } from '@apollo/client'
+import {
+    GRAPHQL_ERROR_MESSAGES,
+    GraphQLErrorTypes,
+} from '../../constants/errors'
 
 type fetchHealthPlanPackageMockProps = {
     submission?: HealthPlanPackage
@@ -416,21 +421,33 @@ const submitHealthPlanPackageMockSuccess = ({
 
 const submitHealthPlanPackageMockError = ({
     id,
+    errorCode,
 }: {
     id: string
-}): MockedResponse<SubmitHealthPlanPackageMutation> => {
+    errorCode?: GraphQLErrorTypes
+}): MockedResponse<SubmitHealthPlanPackageMutation | ApolloError> => {
+    const graphQLError = new GraphQLError(
+        errorCode
+            ? GRAPHQL_ERROR_MESSAGES[errorCode]
+            : 'Error attempting to submit.',
+        {
+            extensions: {
+                code: errorCode,
+            },
+        }
+    )
+
     return {
         request: {
             query: SubmitHealthPlanPackageDocument,
-            variables: { input: { submissionID: id } },
+            variables: { input: { pkgID: id } },
         },
+        error: new ApolloError({
+            graphQLErrors: [graphQLError],
+        }),
         result: {
-            errors: [
-                new GraphQLError(
-                    'Incomplete submission cannot be submitted',
-                    {}
-                ),
-            ],
+            data: null,
+            errors: [graphQLError],
         },
     }
 }
@@ -458,22 +475,34 @@ const unlockHealthPlanPackageMockSuccess = ({
 const unlockHealthPlanPackageMockError = ({
     id,
     reason,
+    errorCode,
 }: {
     id: string
     reason: string
+    errorCode?: GraphQLErrorTypes
 }): MockedResponse<UnlockHealthPlanPackageMutation> => {
+    const graphQLError = new GraphQLError(
+        errorCode
+            ? GRAPHQL_ERROR_MESSAGES[errorCode]
+            : 'Error attempting to unlock.',
+        {
+            extensions: {
+                code: errorCode,
+            },
+        }
+    )
+
     return {
         request: {
             query: UnlockHealthPlanPackageDocument,
             variables: { input: { pkgID: id, unlockedReason: reason } },
         },
+        error: new ApolloError({
+            graphQLErrors: [graphQLError],
+        }),
         result: {
-            errors: [
-                new GraphQLError(
-                    'Incomplete submission cannot be submitted',
-                    {}
-                ),
-            ],
+            data: null,
+            errors: [graphQLError],
         },
     }
 }


### PR DESCRIPTION
## Summary
[MR-3116](https://qmacbis.atlassian.net/browse/MR-3116)

`submitHealthPlanPackage.ts` and `unlockHealthPlanPackage.ts` resolvers now throw `GraphQL` errors when sending emails fails.

On the front-end, users will no longer be shown errors when submitting, unlocking, or resubmitting fails due to a failure in sending emails.

Extras:
- `useCreateHealthPlanPackageMutation` in  `SubmissionType.tsx` is now updating the cache more consistent with the Q&A mutations.
- Adding some hard coded graphQL error codes in `errors.ts`. Follows the same style we used in `flags.ts` so we have a central place where we can store error codes. I'm using this for making the unlock and submit mock mutations more consistent with errors from the server. I think @mojotalantikite was talking about having something like this when working on this [spike ticket](https://qmacbis.atlassian.net/browse/MR-3182).

Notes:
- I did not tackle refactoring a lot of the error handling around `mutiationWrappersForUserFriendlyErrors.ts` and other places in this ticket. I was thinking the [spike ticket](https://qmacbis.atlassian.net/browse/MR-3182) should be done first and tickets to refactor error handling will be sprung from it.

#### Related issues

#### Screenshots

#### Test cases covered

Unit tests
- `unlockSubmitModal.test.tsx`
   - `'redirects if submission succeeds, but failed sending emails'`
   - `'does not display modal alert banner error if unlock succeeds, but fails sending emails'`

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
