### PR TITLE
Add NR_LICENSE_KEY to promote

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,7 +211,7 @@ jobs:
 
   deploy-infra:
     needs: [begin-deployment]
-    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@mt-instrument-uploads
+    uses: CMSgov/managed-care-review/.github/workflows/deploy-infra-to-env.yml@main
     with:
       environment: dev
       stage_name: ${{ needs.begin-deployment.outputs.stage-name}}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -127,6 +127,7 @@ jobs:
     secrets:
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
       aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
+      nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-app-dev:
     needs: [promote-infra-dev, build-prisma-client-lambda-layer, unit-tests]
@@ -152,6 +153,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.VAL_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-app-val:
     needs: [promote-app-dev, promote-infra-val, unit-tests]
@@ -177,6 +179,7 @@ jobs:
     secrets:
       aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
       aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+      nr_license_key: ${{ secrets.NR_LICENSE_KEY }}
 
   promote-app-prod:
     needs: [promote-app-val, promote-infra-prod, unit-tests]


### PR DESCRIPTION
## Summary

PR #1527 had a missing env var in the promote script. This also puts the sha for the deploy action back to the `main` branch.
