### PR TITLE
MR-3055 Delete CMS dashboard and No Rate Cert feature flags and code. 

### DIFF
--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.test.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.test.ts
@@ -23,7 +23,6 @@ import {
     getTestStateAnalystsEmails,
 } from '../../testHelpers/parameterStoreHelpers'
 import { UserType } from '../../domain-models'
-import { testLDService } from '../../testHelpers/launchDarklyHelpers'
 
 describe('submitHealthPlanPackage', () => {
     const testUserCMS: UserType = {
@@ -741,12 +740,9 @@ describe('submitHealthPlanPackage', () => {
     })
 })
 
-describe('submitHealthPlanPackage with feature flags', () => {
-    it('errors when risk based question is undefined and rate-cert-assurance feature flag is on', async () => {
-        const mockLDService = testLDService({ 'rate-cert-assurance': true })
-        const server = await constructTestPostgresServer({
-            ldService: mockLDService,
-        })
+describe('submitHealthPlanPackage risk based question tests', () => {
+    it('errors when risk based question is undefined', async () => {
+        const server = await constructTestPostgresServer()
 
         // setup
         const initialPkg = await createAndUpdateTestHealthPlanPackage(server, {
@@ -771,78 +767,5 @@ describe('submitHealthPlanPackage with feature flags', () => {
         expect(submitResult.errors?.[0].extensions?.message).toBe(
             'formData is missing required contract fields'
         )
-    }, 20000)
-
-    it('does not error when risk based question is undefined and rate-cert-assurance feature flag is off', async () => {
-        const mockLDService = testLDService({ 'rate-cert-assurance': false })
-        const server = await constructTestPostgresServer({
-            ldService: mockLDService,
-        })
-
-        // setup
-        const initialPkg = await createAndUpdateTestHealthPlanPackage(server, {
-            riskBasedContract: undefined,
-        })
-        const draft = latestFormData(initialPkg)
-        const draftID = draft.id
-
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-
-        // submit
-        const submitResult = await server.executeOperation({
-            query: SUBMIT_HEALTH_PLAN_PACKAGE,
-            variables: {
-                input: {
-                    pkgID: draftID,
-                },
-            },
-        })
-
-        expect(submitResult.errors).toBeUndefined()
-        const createdID = submitResult?.data?.submitHealthPlanPackage.pkg.id
-
-        // test result
-        const pkg = await fetchTestHealthPlanPackageById(server, createdID)
-
-        const resultDraft = latestFormData(pkg)
-
-        // The submission fields should still be set
-        expect(resultDraft.id).toEqual(createdID)
-        expect(resultDraft.submissionType).toBe('CONTRACT_AND_RATES')
-        expect(resultDraft.programIDs).toEqual([defaultFloridaProgram().id])
-        // check that the stateNumber is being returned the same
-        expect(resultDraft.stateNumber).toEqual(draft.stateNumber)
-        expect(resultDraft.submissionDescription).toBe('An updated submission')
-        expect(resultDraft.documents).toEqual(draft.documents)
-
-        // Contract details fields should still be set
-        expect(resultDraft.contractType).toEqual(draft.contractType)
-        expect(resultDraft.contractExecutionStatus).toEqual(
-            draft.contractExecutionStatus
-        )
-        expect(resultDraft.contractDateStart).toEqual(draft.contractDateStart)
-        expect(resultDraft.contractDateEnd).toEqual(draft.contractDateEnd)
-        expect(resultDraft.managedCareEntities).toEqual(
-            draft.managedCareEntities
-        )
-        expect(resultDraft.contractDocuments).toEqual(draft.contractDocuments)
-
-        expect(resultDraft.federalAuthorities).toEqual(draft.federalAuthorities)
-
-        if (resultDraft.status == 'DRAFT') {
-            throw new Error('Not a locked submission')
-        }
-
-        // submittedAt should be set to today's date
-        const today = new Date()
-        const expectedDate = today.toISOString().split('T')[0]
-        expect(pkg.initiallySubmittedAt).toEqual(expectedDate)
-
-        // UpdatedAt should be after the former updatedAt
-        const resultUpdated = new Date(resultDraft.updatedAt)
-        const createdUpdated = new Date(draft.updatedAt)
-        expect(
-            resultUpdated.getTime() - createdUpdated.getTime()
-        ).toBeGreaterThan(0)
     }, 20000)
 })

--- a/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
+++ b/services/app-api/src/resolvers/healthPlanPackage/submitHealthPlanPackage.ts
@@ -31,7 +31,6 @@ import {
 import { toDomain } from '../../../../app-web/src/common-code/proto/healthPlanFormDataProto'
 import { EmailParameterStore } from '../../parameterStore'
 import { LDService } from '../../launchDarkly/launchDarkly'
-import { FlagValueTypes } from 'app-web/src/common-code/featureFlags'
 import { GraphQLError } from 'graphql'
 
 export const SubmissionErrorCodes = ['INCOMPLETE', 'INVALID'] as const
@@ -66,8 +65,7 @@ export function isSubmissionError(err: unknown): err is SubmissionError {
 // This strategy (returning a different type from validation) is taken from the
 // "parse, don't validate" article: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
 function submit(
-    draft: UnlockedHealthPlanFormDataType,
-    rateCertAssuranceFlag: FlagValueTypes
+    draft: UnlockedHealthPlanFormDataType
 ): LockedHealthPlanFormDataType | SubmissionError {
     const maybeStateSubmission: Record<string, unknown> = {
         ...draft,
@@ -75,14 +73,9 @@ function submit(
         submittedAt: new Date(),
     }
 
-    // Valid rate cert assurance questions always true if feature flag is off so to not block submissions. Otherwise
-    // hasValidRateCertAssurance will validate submission on rate cert assurance questions.
-    const validRateCertAssurance = rateCertAssuranceFlag
-        ? hasValidRateCertAssurance(
-              maybeStateSubmission as LockedHealthPlanFormDataType
-          )
-        : true
-
+    const validRateCertAssurance = hasValidRateCertAssurance(
+        maybeStateSubmission as LockedHealthPlanFormDataType
+    )
     if (
         isLockedHealthPlanFormData(maybeStateSubmission) &&
         validRateCertAssurance
@@ -144,11 +137,6 @@ export function submitHealthPlanPackageResolver(
         const { submittedReason, pkgID } = input
         setResolverDetailsOnActiveSpan('submitHealthPlanPackage', user, span)
         span?.setAttribute('mcreview.package_id', pkgID)
-
-        const rateCertAssuranceFlag = await launchDarkly.getFeatureFlag(
-            context,
-            'rate-cert-assurance'
-        )
 
         // This resolver is only callable by state users
         if (!isStateUser(user)) {
@@ -253,7 +241,7 @@ export function submitHealthPlanPackageResolver(
         }
 
         // attempt to parse into a StateSubmission
-        const submissionResult = submit(draftResult, rateCertAssuranceFlag)
+        const submissionResult = submit(draftResult)
 
         if (isSubmissionError(submissionResult)) {
             const errMessage = submissionResult.message

--- a/services/app-web/src/common-code/featureFlags/flags.ts
+++ b/services/app-web/src/common-code/featureFlags/flags.ts
@@ -43,20 +43,6 @@ export const featureFlags = {
         defaultValue: 2,
     },
     /**
-     * Enables filter on CMS dashboard
-     */
-    CMS_DASHBOARD_FILTER: {
-        flag: 'cms-dashboard-filter',
-        defaultValue: false,
-    },
-    /**
-     * Enables rate cert assurance workflow
-     */
-    RATE_CERT_ASSURANCE: {
-        flag: 'rate-cert-assurance',
-        defaultValue: false,
-    },
-    /**
      * Enables state and CMS Q&A features
      */
     CMS_QUESTIONS: {

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.test.tsx
@@ -1,8 +1,5 @@
 import { screen } from '@testing-library/react'
-import {
-    renderWithProviders,
-    ldUseClientSpy,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { SubmissionTypeSummarySection } from './SubmissionTypeSummarySection'
 import {
     mockContractAndRatesDraft,
@@ -69,9 +66,6 @@ describe('SubmissionTypeSummarySection', () => {
     })
 
     it('renders expected fields for draft package on review and submit', () => {
-        ldUseClientSpy({
-            'rate-cert-assurance': true,
-        })
         renderWithProviders(
             <SubmissionTypeSummarySection
                 submission={draftSubmission}
@@ -101,9 +95,6 @@ describe('SubmissionTypeSummarySection', () => {
     })
 
     it('renders missing field message for risk based contract when expected', () => {
-        ldUseClientSpy({
-            'rate-cert-assurance': true,
-        })
         renderWithProviders(
             <SubmissionTypeSummarySection
                 submission={

--- a/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
+++ b/services/app-web/src/components/SubmissionSummarySection/SubmissionTypeSummarySection/SubmissionTypeSummarySection.tsx
@@ -12,8 +12,6 @@ import { Program } from '../../../gen/gqlClient'
 import { usePreviousSubmission } from '../../../hooks/usePreviousSubmission'
 import { booleanAsYesNoUserValue } from '../../../components/Form/FieldYesNo/FieldYesNo'
 import styles from '../SubmissionSummarySection.module.scss'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../../common-code/featureFlags'
 
 export type SubmissionTypeSummarySectionProps = {
     submission: HealthPlanFormDataType
@@ -37,13 +35,6 @@ export const SubmissionTypeSummarySection = ({
         .filter((p) => submission.programIDs.includes(p.id))
         .map((p) => p.name)
     const isSubmitted = submission.status === 'SUBMITTED'
-
-    // Launch Darkly
-    const ldClient = useLDClient()
-    const showRateCertAssurance = ldClient?.variation(
-        featureFlags.RATE_CERT_ASSURANCE.flag,
-        featureFlags.RATE_CERT_ASSURANCE.defaultValue
-    )
 
     return (
         <section id="submissionTypeSection" className={styles.summarySection}>
@@ -97,16 +88,14 @@ export const SubmissionTypeSummarySection = ({
                                 : ''
                         }
                     />
-                    {showRateCertAssurance && (
-                        <DataDetail
-                            id="riskBasedContract"
-                            label="Is this a risk based contract"
-                            explainMissingData={!isSubmitted}
-                            children={booleanAsYesNoUserValue(
-                                submission.riskBasedContract
-                            )}
-                        />
-                    )}
+                    <DataDetail
+                        id="riskBasedContract"
+                        label="Is this a risk based contract"
+                        explainMissingData={!isSubmitted}
+                        children={booleanAsYesNoUserValue(
+                            submission.riskBasedContract
+                        )}
+                    />
                 </DoubleColumnGrid>
 
                 <Grid row gap className={styles.reviewDataRow}>

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.test.tsx
@@ -7,10 +7,7 @@ import {
     mockSubmittedHealthPlanPackage,
     mockUnlockedHealthPlanPackage,
 } from '../../testHelpers/apolloMocks'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
 import { CMSDashboard } from './CMSDashboard'
 import { User } from '../../gen/gqlClient'
 
@@ -169,8 +166,7 @@ describe('CMSDashboard', () => {
         expect(lastUpdated).toHaveTextContent('01/22/2100')
     })
 
-    it('should display filters on cms dashboard page when feature flag is on', async () => {
-        ldUseClientSpy({ 'cms-dashboard-filter': true })
+    it('should display filters on cms dashboard', async () => {
         const unlocked = mockUnlockedHealthPlanPackage()
         const submitted = mockSubmittedHealthPlanPackage()
         submitted.id = 'test-abc-submitted'

--- a/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
+++ b/services/app-web/src/pages/CMSDashboard/CMSDashboard.tsx
@@ -19,8 +19,6 @@ import {
     HealthPlanPackageTable,
     PackageInDashboardType,
 } from '../../components'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
-import { featureFlags } from '../../common-code/featureFlags'
 
 /**
  * We only pull a subset of data out of the submission and revisions for display in Dashboard
@@ -29,15 +27,10 @@ import { featureFlags } from '../../common-code/featureFlags'
 
 export const CMSDashboard = (): React.ReactElement => {
     const { loginStatus, loggedInUser } = useAuth()
-    const ldClient = useLDClient()
     const { loading, data, error } = useIndexHealthPlanPackagesQuery({
         fetchPolicy: 'network-only',
     })
     const isAuthenticated = loginStatus === 'LOGGED_IN'
-    const showDashboardFilter = ldClient?.variation(
-        featureFlags.CMS_DASHBOARD_FILTER.flag,
-        featureFlags.CMS_DASHBOARD_FILTER.defaultValue
-    )
 
     if (error) {
         handleApolloError(error, isAuthenticated)
@@ -180,7 +173,7 @@ export const CMSDashboard = (): React.ReactElement => {
                         <HealthPlanPackageTable
                             tableData={submissionRows}
                             user={loggedInUser}
-                            showFilters={showDashboardFilter}
+                            showFilters
                         />
                     </section>
                 </GridContainer>

--- a/services/app-web/src/pages/StateDashboard/StateDashboard.test.tsx
+++ b/services/app-web/src/pages/StateDashboard/StateDashboard.test.tsx
@@ -8,10 +8,7 @@ import {
     mockSubmittedHealthPlanPackage,
     mockUnlockedHealthPlanPackage,
 } from '../../testHelpers/apolloMocks'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../testHelpers/jestHelpers'
 
 describe('StateDashboard', () => {
     it('display submission heading', async () => {
@@ -128,7 +125,6 @@ describe('StateDashboard', () => {
         expect(link3).toHaveAttribute('href', '/submissions/test-abc-submitted')
     })
     it('should not display filters on state dashboard page', async () => {
-        ldUseClientSpy({ 'cms-dashboard-filter': true })
         renderWithProviders(<StateDashboard />, {
             apolloProvider: {
                 mocks: [

--- a/services/app-web/src/pages/StateSubmission/New/NewStateSubmissionForm.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/New/NewStateSubmissionForm.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 
 import {
     fetchCurrentUserMock,
@@ -53,6 +53,16 @@ describe('NewStateSubmissionForm', () => {
 
         const contractType = await screen.findByText('Base contract')
         await userEvent.click(contractType)
+
+        const riskBasedContractFieldSet = screen.getByText(
+            /Is this a risk-based contract/
+        ).parentElement
+        expect(riskBasedContractFieldSet).toBeDefined()
+
+        await userEvent.click(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            within(riskBasedContractFieldSet!).getByLabelText('No')
+        )
 
         const textarea = await screen.findByRole('textbox', {
             name: 'Submission description',

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.test.tsx
@@ -3,10 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { screen, waitFor, within } from '@testing-library/react'
 import selectEvent from 'react-select-event'
 import { fetchCurrentUserMock } from '../../../testHelpers/apolloMocks'
-import {
-    ldUseClientSpy,
-    renderWithProviders,
-} from '../../../testHelpers/jestHelpers'
+import { renderWithProviders } from '../../../testHelpers/jestHelpers'
 import { SubmissionType, SubmissionTypeFormValues } from './'
 import { Formik } from 'formik'
 import { contractOnly } from '../../../common-code/healthPlanFormDataMocks'
@@ -227,9 +224,6 @@ describe('SubmissionType', () => {
     })
 
     it('displays risk-based contract radio buttons and validation message', async () => {
-        ldUseClientSpy({
-            'rate-cert-assurance': true,
-        })
         renderWithProviders(
             <Formik
                 initialValues={SubmissionTypeInitialValues}

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionType.tsx
@@ -38,8 +38,6 @@ import {
     booleanAsYesNoFormValue,
     yesNoFormValueAsBoolean,
 } from '../../../components/Form/FieldYesNo/FieldYesNo'
-import { featureFlags } from '../../../common-code/featureFlags'
-import { useLDClient } from 'launchdarkly-react-client-sdk'
 import { SubmissionTypeFormSchema } from './SubmissionTypeSchema'
 
 export interface SubmissionTypeFormValues {
@@ -74,13 +72,6 @@ export const SubmissionType = ({
     const isNewSubmission = location.pathname === '/submissions/new'
 
     const statePrograms = useStatePrograms()
-
-    // Launch Darkly
-    const ldClient = useLDClient()
-    const showRateCertAssurance = ldClient?.variation(
-        featureFlags.RATE_CERT_ASSURANCE.flag,
-        featureFlags.RATE_CERT_ASSURANCE.defaultValue
-    )
 
     const [createHealthPlanPackage, { error }] =
         useCreateHealthPlanPackageMutation({
@@ -186,9 +177,9 @@ export const SubmissionType = ({
                 const input: CreateHealthPlanPackageInput = {
                     programIDs: values.programIDs,
                     submissionType: values.submissionType,
-                    riskBasedContract: showRateCertAssurance
-                        ? yesNoFormValueAsBoolean(values.riskBasedContract)
-                        : undefined,
+                    riskBasedContract: yesNoFormValueAsBoolean(
+                        values.riskBasedContract
+                    ),
                     submissionDescription: values.submissionDescription,
                     contractType: values.contractType,
                 }
@@ -226,9 +217,9 @@ export const SubmissionType = ({
             draftSubmission.programIDs = values.programIDs
             draftSubmission.submissionType =
                 values.submissionType as SubmissionTypeT
-            draftSubmission.riskBasedContract = showRateCertAssurance
-                ? yesNoFormValueAsBoolean(values.riskBasedContract)
-                : undefined
+            draftSubmission.riskBasedContract = yesNoFormValueAsBoolean(
+                values.riskBasedContract
+            )
             draftSubmission.submissionDescription = values.submissionDescription
             draftSubmission.contractType = values.contractType as ContractType
 
@@ -265,9 +256,7 @@ export const SubmissionType = ({
         <Formik
             initialValues={submissionTypeInitialValues}
             onSubmit={handleFormSubmit}
-            validationSchema={SubmissionTypeFormSchema({
-                'rate-cert-assurance': showRateCertAssurance,
-            })}
+            validationSchema={SubmissionTypeFormSchema}
         >
             {({
                 values,
@@ -409,17 +398,15 @@ export const SubmissionType = ({
                                     errors.riskBasedContract
                                 )}
                             >
-                                {showRateCertAssurance && (
-                                    <FieldYesNo
-                                        id="riskBasedContract"
-                                        name="riskBasedContract"
-                                        label="Is this a risk-based contract?"
-                                        hint="See 42 CFR § 438.2"
-                                        showError={showFieldErrors(
-                                            errors.riskBasedContract
-                                        )}
-                                    />
-                                )}
+                                <FieldYesNo
+                                    id="riskBasedContract"
+                                    name="riskBasedContract"
+                                    label="Is this a risk-based contract?"
+                                    hint="See 42 CFR § 438.2"
+                                    showError={showFieldErrors(
+                                        errors.riskBasedContract
+                                    )}
+                                />
                             </FormGroup>
                             <FieldTextarea
                                 label="Submission description"

--- a/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionTypeSchema.ts
+++ b/services/app-web/src/pages/StateSubmission/SubmissionType/SubmissionTypeSchema.ts
@@ -15,9 +15,7 @@ const SubmissionTypeFormSchema = (flags: FeatureFlagsForYup = {}) =>
             'You must choose a submission type'
         ),
         contractType: Yup.string().required('You must choose a contract type'),
-        riskBasedContract: flags['rate-cert-assurance']
-            ? Yup.string().required('You must select yes or no')
-            : Yup.string().optional(),
+        riskBasedContract: Yup.string().required('You must select yes or no'),
         submissionDescription: Yup.string().required(
             'You must provide a description of any major changes or updates'
         ),

--- a/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/unlockResubmit.spec.ts
@@ -5,7 +5,6 @@ describe('CMS user', () => {
         cy.stubFeatureFlags()
     })
     it('can unlock and resubmit', () => {
-        cy.interceptFeatureFlags({ 'rate-cert-assurance': true })
         cy.logInAsStateUser()
 
         // fill out an entire submission

--- a/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
+++ b/tests/cypress/integration/cmsWorkflow/viewSubmission.spec.ts
@@ -3,7 +3,6 @@ describe('CMS user can view submission', () => {
         cy.stubFeatureFlags()
     })
     it('in the CMS dashboard', () => {
-        cy.interceptFeatureFlags({ 'rate-cert-assurance': true })
         // state user adds a new package
         cy.logInAsStateUser()
         cy.startNewContractAndRatesSubmission()

--- a/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/dashboard/dashboard.spec.ts
@@ -22,7 +22,6 @@ describe('dashboard', () => {
     })
 
     it('can see submission summary', () => {
-        cy.interceptFeatureFlags({ 'rate-cert-assurance': true })
         cy.logInAsStateUser()
 
         // add a draft submission

--- a/tests/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/questionResponse/questionResponse.spec.ts
@@ -11,7 +11,6 @@ describe('Q&A', () => {
 
     it('can add questions and responses', () => {
         cy.interceptFeatureFlags({
-            'rate-cert-assurance': true,
             'cms-questions': true
         })
         cy.logInAsStateUser()

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/reviewAndSubmit.spec.ts
@@ -30,7 +30,6 @@ describe('review and submit', () => {
     })
 
     it('can not submit an incomplete submission', () => {
-        cy.interceptFeatureFlags({ 'rate-cert-assurance': true })
         cy.logInAsStateUser()
         cy.startNewContractAndRatesSubmission()
 

--- a/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
+++ b/tests/cypress/integration/stateWorkflow/stateSubmissionForm/submissionType.spec.ts
@@ -82,7 +82,6 @@ describe('submission type', () => {
     })
 
     it('can save submission edits using Save as draft button', () => {
-        cy.interceptFeatureFlags({ 'rate-cert-assurance': true })
         cy.logInAsStateUser()
         cy.startNewContractOnlySubmissionWithBaseContract()
 

--- a/tests/cypress/support/stateSubmissionFormCommands.ts
+++ b/tests/cypress/support/stateSubmissionFormCommands.ts
@@ -48,11 +48,7 @@ Cypress.Commands.add('fillOutContractActionOnlyWithBaseContract', () => {
     cy.findByText('Base contract').click()
 
     //rate-cert-assurance
-    cy.getFeatureFlagStore(['rate-cert-assurance']).then((store) => {
-        if (store['rate-cert-assurance']) {
-            cy.get('label[for="riskBasedContractNo"]').click()
-        }
-    })
+    cy.get('label[for="riskBasedContractNo"]').click()
 
     cy.findByRole('textbox', { name: 'Submission description' }).type(
         'description of contract only submission'
@@ -71,11 +67,7 @@ Cypress.Commands.add('fillOutContractActionOnlyWithAmendment', () => {
     cy.findByText('Contract action only').click()
 
     //rate-cert-assurance
-    cy.getFeatureFlagStore(['rate-cert-assurance']).then((store) => {
-        if (store['rate-cert-assurance']) {
-            cy.get('label[for="riskBasedContractNo"]').click()
-        }
-    })
+    cy.get('label[for="riskBasedContractNo"]').click()
 
     cy.findByText('Amendment to base contract').click()
     cy.findByRole('textbox', { name: 'Submission description' }).type(
@@ -95,11 +87,7 @@ Cypress.Commands.add('fillOutContractActionAndRateCertification', () => {
     cy.findByText('Contract action and rate certification').click()
 
     //rate-cert-assurance
-    cy.getFeatureFlagStore(['rate-cert-assurance']).then((store) => {
-        if (store['rate-cert-assurance']) {
-            cy.get('label[for="riskBasedContractNo"]').click()
-        }
-    })
+    cy.get('label[for="riskBasedContractNo"]').click()
 
     cy.findByText('Base contract').click()
     cy.findByRole('textbox', { name: 'Submission description' }).type(


### PR DESCRIPTION
## Summary

[MR-3055](https://qmacbis.atlassian.net/browse/MR-3055)

Removed `CMS_DASHBOARD_FILTER` an `RATE_CERT_ASSURANCE` from feature flags in `flag.ts`

**Note**: `RATE_CERT_ASSURANCE` is a unique flag, it was used both in front end and the api. 

#### Related issues

#### Screenshots

#### Test cases covered

<!---These are the tests written in this PR and the cases they cover -->

## QA guidance

<!---These are developer instructions on how to test or validate the work -->
