### PR TITLE
Add github-oidc to destroy action

### DIFF
--- a/scripts/destroy_stage.ts
+++ b/scripts/destroy_stage.ts
@@ -27,6 +27,7 @@ const stackPrefixes = [
     'ui',
     'database',
     'stream-functions',
+    'github-oidc',
 ]
 
 const protectedStages = [


### PR DESCRIPTION
## Summary

We aren't cleaning up resources in PR branches related to `github-oidc` in the `destroy` action. This adds it to that script.

#### Related issues
https://qmacbis.atlassian.net/browse/MR-3191

